### PR TITLE
Add YAML issue templates for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -5,7 +5,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        > **Security vulnerabilities**: If you believe you have found a security vulnerability, please do **not** report it here. See [SECURITY.md](https://github.com/agent-receipts/dashboard/blob/main/SECURITY.md) for private vulnerability reporting instructions.
+        > **Security vulnerabilities**: If you believe you have found a security vulnerability, please do **not** report it here. Report via [GitHub Security Advisories](https://github.com/agent-receipts/dashboard/security/advisories/new).
 
   - type: dropdown
     id: component

--- a/.github/ISSUE_TEMPLATE/1-bug.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug.yml
@@ -1,0 +1,66 @@
+name: Bug report
+description: Report a bug in the dashboard
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        > **Security vulnerabilities**: If you believe you have found a security vulnerability, please do **not** report it here. See [SECURITY.md](https://github.com/agent-receipts/dashboard/blob/main/SECURITY.md) for private vulnerability reporting instructions.
+
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the dashboard is affected?
+      options:
+        - UI (HTML / htmx / Tailwind)
+        - API endpoints (server)
+        - SQLite reader (store)
+        - Chain verification (verify)
+        - CLI / startup
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Describe the bug
+      description: A clear description of what the bug is.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Steps to reproduce the behavior.
+      placeholder: |
+        1. ...
+        2. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened. Include error messages, logs, or screenshots if applicable.
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Runtime and version information.
+      placeholder: |
+        - OS:
+        - Go version:
+        - Browser:
+        - Database source (SDK, mcp-proxy, openclaw):

--- a/.github/ISSUE_TEMPLATE/2-feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/2-feature-request.yml
@@ -1,0 +1,39 @@
+name: Feature request
+description: Suggest a new feature or improvement
+labels: ["enhancement"]
+body:
+  - type: dropdown
+    id: component
+    attributes:
+      label: Component
+      description: Which part of the dashboard would this affect?
+      options:
+        - UI (HTML / htmx / Tailwind)
+        - API endpoints (server)
+        - SQLite reader (store)
+        - Chain verification (verify)
+        - CLI / startup
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: What problem does this solve? Why is it needed?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: Describe what you'd like to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Any alternative approaches you've thought about.


### PR DESCRIPTION
## Summary

- Adds structured GitHub issue forms (YAML) matching the ar and openclaw repos
- Bug template: component dropdown (UI/API/store/verify/CLI), repro steps, environment info, security advisory redirect
- Feature request template: component dropdown, motivation, proposed solution, alternatives

## Test plan

- [ ] Verify templates render correctly at github.com/agent-receipts/dashboard/issues/new/choose
- [ ] Verify bug template auto-applies `bug` label
- [ ] Verify feature template auto-applies `enhancement` label