### PR TITLE
chore: add Conventional Commits enforcement via Lefthook and convco

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,7 @@ internal/verify/        # Hash linkage and chain verification
 - All web assets embedded via `//go:embed` — single binary distribution
 - The dashboard opens SQLite databases **read-only** — it must never write to receipt stores
 - Run `go vet` and `go test ./...` before committing
+- Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
 
 ## Dependencies
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,23 @@
+# Lefthook — pre-commit and commit-msg hooks
+# Install: brew install lefthook && lefthook install
+# Docs: https://lefthook.dev/configuration/
+
+pre-commit:
+  parallel: true
+  jobs:
+    - name: go-vet
+      glob: "*.{go,mod,sum}"
+      run: go vet ./...
+
+    - name: go-fmt
+      glob: "*.{go,mod,sum}"
+      run: test -z "$(gofmt -l .)" || (gofmt -d . && exit 1)
+
+    - name: go-test
+      glob: "*.{go,mod,sum}"
+      run: go test ./...
+
+commit-msg:
+  commands:
+    conventional-commit:
+      run: convco check --from-stdin < {1}

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,23 +1,26 @@
 # Lefthook — pre-commit and commit-msg hooks
 # Install: brew install lefthook && lefthook install
 # Docs: https://lefthook.dev/configuration/
+#
+# Glob patterns determine whether a job runs (based on staged files).
+# The run commands then check the entire module — not just staged files.
 
 pre-commit:
   parallel: true
   jobs:
     - name: go-vet
-      glob: "*.{go,mod,sum}"
+      glob: "**/*.{go,mod,sum}"
       run: go vet ./...
 
     - name: go-fmt
-      glob: "*.{go,mod,sum}"
+      glob: "**/*.{go,mod,sum}"
       run: test -z "$(gofmt -l .)" || (gofmt -d . && exit 1)
 
     - name: go-test
-      glob: "*.{go,mod,sum}"
+      glob: "**/*.{go,mod,sum}"
       run: go test ./...
 
 commit-msg:
   commands:
     conventional-commit:
-      run: convco check --from-stdin < {1}
+      run: convco check --from-stdin < "{1}"


### PR DESCRIPTION
## Summary

- Adds `lefthook.yml` with pre-commit hooks (go vet, go fmt, go test) and commit-msg hook
- Enforces Conventional Commits format via convco
- Updates AGENTS.md conventions to mention the requirement

Companion PRs: agent-receipts/ar#65, agent-receipts/openclaw#75

Note: CONTRIBUTING.md updates for this convention are in #16 — will add a follow-up commit there once this merges.

## Test plan

- [x] `brew install lefthook convco && lefthook install` sets up hooks
- [x] Valid messages pass: `echo "feat: test" | convco check --from-stdin`
- [x] Invalid messages fail: `echo "bad message" | convco check --from-stdin`
- [x] Pre-commit runs go vet, fmt, and test on staged Go files