### PR TITLE
ci: add Go module publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Vet
+        run: go vet ./...
+
       - name: Build
         run: go build ./cmd/dashboard
 
@@ -27,4 +30,17 @@ jobs:
 
       - name: Request pkg.go.dev indexing
         run: |
-          curl -fsS "https://proxy.golang.org/github.com/agent-receipts/dashboard/@v/${GITHUB_REF_NAME}.info" || true
+          URL="https://proxy.golang.org/github.com/agent-receipts/dashboard/@v/${GITHUB_REF_NAME}.info"
+          succeeded=false
+          for attempt in 1 2 3; do
+            if curl -fsS "$URL"; then
+              succeeded=true
+              break
+            fi
+            if [[ "$attempt" -lt 3 ]]; then
+              sleep 2
+            fi
+          done
+          if [[ "$succeeded" != "true" ]]; then
+            echo "::warning::Failed to request pkg.go.dev indexing for dashboard@${GITHUB_REF_NAME} after 3 attempts"
+          fi

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,30 @@
+name: Publish Go Module
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    if: startsWith(github.ref_name, 'v')
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Build
+        run: go build ./cmd/dashboard
+
+      - name: Test
+        run: go test ./...
+
+      - name: Request pkg.go.dev indexing
+        run: |
+          curl -fsS "https://proxy.golang.org/github.com/agent-receipts/dashboard/@v/${GITHUB_REF_NAME}.info" || true


### PR DESCRIPTION
## Summary
- Add `publish.yml` workflow triggered by GitHub Releases
- Builds, vets, tests, and requests pkg.go.dev indexing for the dashboard module
- Proxy indexing retries 3 times with warnings on failure
- Follows the same pattern as the ar monorepo publish workflows

## Release process
```bash
gh release create v0.1.0 --title "v0.1.0" --generate-notes
```

## Test plan
- [x] Publish a release with tag `v0.0.1-test` to confirm workflow triggers
- [x] Verify pkg.go.dev indexing after a real release