### PR TITLE
chore: add release script

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -17,7 +17,10 @@ EOF
 fail() { echo "error: $1" >&2; exit 1; }
 
 # cd to repo root so the script works from any directory
+git rev-parse --is-inside-work-tree >/dev/null 2>&1 || fail "must be run from within the dashboard repo"
 cd "$(git rev-parse --show-toplevel)"
+
+REMOTE_NAME="${REMOTE:-origin}"
 
 # Preflight: ensure required tools are available
 command -v go >/dev/null 2>&1 || fail "go is not installed"
@@ -36,17 +39,18 @@ TAG="v${VERSION}"
 # Ensure we're on main and up to date
 BRANCH=$(git branch --show-current)
 [[ "$BRANCH" == "main" ]] || fail "must be on main branch (currently on $BRANCH)"
-git fetch origin main --quiet
+git remote get-url "$REMOTE_NAME" >/dev/null 2>&1 || fail "remote '$REMOTE_NAME' not found — set REMOTE=<name> if not using origin"
+git fetch "$REMOTE_NAME" main --quiet
 LOCAL=$(git rev-parse HEAD)
-REMOTE=$(git rev-parse origin/main)
-if [[ "$LOCAL" != "$REMOTE" ]]; then
-  read -r BEHIND AHEAD < <(git rev-list --left-right --count origin/main...HEAD)
+REMOTE_HEAD=$(git rev-parse "$REMOTE_NAME/main")
+if [[ "$LOCAL" != "$REMOTE_HEAD" ]]; then
+  read -r BEHIND AHEAD < <(git rev-list --left-right --count "$REMOTE_NAME/main"...HEAD)
   if [[ "$BEHIND" -gt 0 && "$AHEAD" -eq 0 ]]; then
-    fail "local main is behind origin/main by $BEHIND commit(s) — run git pull"
+    fail "local main is behind $REMOTE_NAME/main by $BEHIND commit(s) — run git pull"
   elif [[ "$BEHIND" -eq 0 && "$AHEAD" -gt 0 ]]; then
-    fail "local main is ahead of origin/main by $AHEAD commit(s) — push your commits or reset to origin/main"
+    fail "local main is ahead of $REMOTE_NAME/main by $AHEAD commit(s) — push your commits or reset to $REMOTE_NAME/main"
   else
-    fail "local main has diverged from origin/main ($BEHIND behind, $AHEAD ahead) — reconcile with pull/rebase or reset"
+    fail "local main has diverged from $REMOTE_NAME/main ($BEHIND behind, $AHEAD ahead) — reconcile with pull/rebase or reset"
   fi
 fi
 
@@ -54,9 +58,9 @@ fi
 [[ -z "$(git status --porcelain)" ]] || fail "working tree is not clean — commit or stash changes first"
 
 # Check tag doesn't already exist (locally or on remote)
-git fetch origin --tags --quiet
+git fetch "$REMOTE_NAME" --tags --quiet
 git tag -l "$TAG" | grep -q . && fail "tag $TAG already exists"
-git ls-remote --tags origin "refs/tags/$TAG" | grep -q . && fail "tag $TAG already exists on origin"
+git ls-remote --tags "$REMOTE_NAME" "refs/tags/$TAG" | grep -q . && fail "tag $TAG already exists on $REMOTE_NAME"
 
 echo "==> Releasing dashboard v$VERSION (tag: $TAG)"
 echo ""
@@ -65,6 +69,9 @@ echo "--- Running checks"
 go vet ./...
 go build ./cmd/dashboard
 go test ./... -count=1
+
+# Ensure checks did not modify tracked files (e.g. go.sum)
+[[ -z "$(git status --porcelain)" ]] || fail "working tree changed after running checks — review and commit or discard generated changes before releasing"
 
 echo ""
 echo "--- All checks passed"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,6 +16,11 @@ EOF
 
 fail() { echo "error: $1" >&2; exit 1; }
 
+# Preflight: ensure required tools are available
+command -v go >/dev/null 2>&1 || fail "go is not installed"
+command -v gh >/dev/null 2>&1 || fail "gh CLI is not installed — see https://cli.github.com"
+gh auth status >/dev/null 2>&1 || fail "gh is not authenticated — run gh auth login"
+
 [[ $# -eq 1 ]] || usage
 
 VERSION="$1"
@@ -31,7 +36,16 @@ BRANCH=$(git branch --show-current)
 git fetch origin main --quiet
 LOCAL=$(git rev-parse HEAD)
 REMOTE=$(git rev-parse origin/main)
-[[ "$LOCAL" == "$REMOTE" ]] || fail "local main is not up to date with origin — run git pull"
+if [[ "$LOCAL" != "$REMOTE" ]]; then
+  read -r BEHIND AHEAD < <(git rev-list --left-right --count origin/main...HEAD)
+  if [[ "$BEHIND" -gt 0 && "$AHEAD" -eq 0 ]]; then
+    fail "local main is behind origin/main by $BEHIND commit(s) — run git pull"
+  elif [[ "$BEHIND" -eq 0 && "$AHEAD" -gt 0 ]]; then
+    fail "local main is ahead of origin/main by $AHEAD commit(s) — push your commits or reset to origin/main"
+  else
+    fail "local main has diverged from origin/main ($BEHIND behind, $AHEAD ahead) — reconcile with pull/rebase or reset"
+  fi
+fi
 
 # Ensure working tree is clean
 [[ -z "$(git status --porcelain)" ]] || fail "working tree is not clean — commit or stash changes first"
@@ -47,7 +61,7 @@ echo ""
 echo "--- Running checks"
 go vet ./...
 go build ./cmd/dashboard
-go test ./...
+go test ./... -count=1
 
 echo ""
 echo "--- All checks passed"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<EOF
+Usage: $(basename "$0") <version>
+
+Create a GitHub Release for the dashboard.
+
+Examples:
+  $(basename "$0") 0.1.0
+  $(basename "$0") 1.0.0-beta.1
+EOF
+  exit 1
+}
+
+fail() { echo "error: $1" >&2; exit 1; }
+
+[[ $# -eq 1 ]] || usage
+
+VERSION="$1"
+TAG="v${VERSION}"
+
+# Validate version format (SemVer 2.0)
+[[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]] || \
+  fail "invalid version '$VERSION' — expected semver (e.g. 0.1.0, 1.0.0-beta.1)"
+
+# Ensure we're on main and up to date
+BRANCH=$(git branch --show-current)
+[[ "$BRANCH" == "main" ]] || fail "must be on main branch (currently on $BRANCH)"
+git fetch origin main --quiet
+LOCAL=$(git rev-parse HEAD)
+REMOTE=$(git rev-parse origin/main)
+[[ "$LOCAL" == "$REMOTE" ]] || fail "local main is not up to date with origin — run git pull"
+
+# Ensure working tree is clean
+[[ -z "$(git status --porcelain)" ]] || fail "working tree is not clean — commit or stash changes first"
+
+# Check tag doesn't already exist (locally or on remote)
+git fetch origin --tags --quiet
+git tag -l "$TAG" | grep -q . && fail "tag $TAG already exists"
+git ls-remote --tags origin "refs/tags/$TAG" | grep -q . && fail "tag $TAG already exists on origin"
+
+echo "==> Releasing dashboard v$VERSION (tag: $TAG)"
+echo ""
+
+echo "--- Running checks"
+go vet ./...
+go build ./cmd/dashboard
+go test ./...
+
+echo ""
+echo "--- All checks passed"
+echo ""
+echo "Will create release:"
+echo "  Tag:    $TAG"
+echo "  Title:  v$VERSION"
+echo ""
+read -rp "Proceed? [y/N] " confirm
+[[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
+
+REPO_URL=$(gh repo view --json url -q '.url')
+gh release create "$TAG" --title "v$VERSION" --generate-notes
+echo ""
+echo "==> Released dashboard v$VERSION"
+echo "    ${REPO_URL}/releases/tag/$TAG"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -70,8 +70,8 @@ go vet ./...
 go build ./cmd/dashboard
 go test ./... -count=1
 
-# Ensure checks did not modify tracked files (e.g. go.sum)
-[[ -z "$(git status --porcelain)" ]] || fail "working tree changed after running checks — review and commit or discard generated changes before releasing"
+# Ensure checks did not leave any working tree changes (e.g. go.sum updates, generated outputs)
+[[ -z "$(git status --porcelain)" ]] || fail "working tree changed after running checks — review and commit or discard changes before releasing"
 
 echo ""
 echo "--- All checks passed"
@@ -84,7 +84,9 @@ read -rp "Proceed? [y/N] " confirm
 [[ "$confirm" =~ ^[Yy]$ ]] || { echo "Aborted."; exit 0; }
 
 REPO_URL=$(gh repo view --json url -q '.url')
-gh release create "$TAG" --title "v$VERSION" --generate-notes
+release_args=("$TAG" --title "v$VERSION" --generate-notes)
+[[ "$VERSION" == *-* ]] && release_args+=(--prerelease)
+gh release create "${release_args[@]}"
 echo ""
 echo "==> Released dashboard v$VERSION"
 echo "    ${REPO_URL}/releases/tag/$TAG"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -16,6 +16,9 @@ EOF
 
 fail() { echo "error: $1" >&2; exit 1; }
 
+# cd to repo root so the script works from any directory
+cd "$(git rev-parse --show-toplevel)"
+
 # Preflight: ensure required tools are available
 command -v go >/dev/null 2>&1 || fail "go is not installed"
 command -v gh >/dev/null 2>&1 || fail "gh CLI is not installed — see https://cli.github.com"
@@ -26,9 +29,9 @@ gh auth status >/dev/null 2>&1 || fail "gh is not authenticated — run gh auth 
 VERSION="$1"
 TAG="v${VERSION}"
 
-# Validate version format (SemVer 2.0)
-[[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?(\+([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]] || \
-  fail "invalid version '$VERSION' — expected semver (e.g. 0.1.0, 1.0.0-beta.1)"
+# Validate version format (SemVer without build metadata — Go modules don't support +meta)
+[[ "$VERSION" =~ ^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-([0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*))?$ ]] || \
+  fail "invalid version '$VERSION' — expected semver without build metadata (e.g. 0.1.0, 1.0.0-beta.1)"
 
 # Ensure we're on main and up to date
 BRANCH=$(git branch --show-current)


### PR DESCRIPTION
## Summary
- Add `scripts/release.sh` for creating dashboard releases
- Validates: on main, clean tree, semver format, tag doesn't exist (local + remote)
- Runs `go vet`, `go build`, `go test` before releasing
- Creates GitHub Release with confirmation prompt

## Usage
```bash
./scripts/release.sh 0.1.0
```

## Test plan
- [x] Run `./scripts/release.sh` with no args — should show usage
- [x] Run on a non-main branch — should fail
- [x] Run with dirty working tree — should fail