### PR TITLE
ci: add shellcheck to CI and lefthook

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,23 @@
+name: "CI: shellcheck"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "**/*.sh"
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.sh"
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run shellcheck on all shell scripts
+        run: find . -name '*.sh' -not -path './.git/*' -print0 | xargs -0 --no-run-if-empty shellcheck

--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -5,10 +5,12 @@ on:
     branches: [main]
     paths:
       - "**/*.sh"
+      - ".github/workflows/shellcheck.yml"
   pull_request:
     branches: [main]
     paths:
       - "**/*.sh"
+      - ".github/workflows/shellcheck.yml"
 
 permissions:
   contents: read

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@
 # Docs: https://lefthook.dev/configuration/
 #
 # Glob patterns determine whether a job runs (based on staged files).
-# The run commands then check the entire module — not just staged files.
+# Go checks run on the entire module; shellcheck runs on staged files only.
 
 pre-commit:
   parallel: true
@@ -22,7 +22,7 @@ pre-commit:
 
     - name: shellcheck
       glob: "**/*.sh"
-      run: command -v shellcheck >/dev/null 2>&1 && shellcheck {staged_files} || echo "shellcheck not installed — skipping"
+      run: if command -v shellcheck >/dev/null 2>&1; then shellcheck {staged_files}; else echo "shellcheck not installed — skipping"; fi
 
 commit-msg:
   commands:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -20,6 +20,10 @@ pre-commit:
       glob: "**/*.{go,mod,sum}"
       run: go test ./...
 
+    - name: shellcheck
+      glob: "**/*.sh"
+      run: command -v shellcheck >/dev/null 2>&1 && shellcheck {staged_files} || echo "shellcheck not installed — skipping"
+
 commit-msg:
   commands:
     conventional-commit:


### PR DESCRIPTION
## Summary
- Add `shellcheck.yml` workflow triggered on `.sh` file changes
- Add shellcheck pre-commit hook to lefthook (gracefully skips if not installed)
- Matches the pattern used in the ar monorepo

## Test plan
- [x] Push a `.sh` file change and verify shellcheck workflow runs
- [x] Verify lefthook runs shellcheck on staged `.sh` files