### PR TITLE
docs: use single-dash flags to match Go flag package

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -4,7 +4,7 @@
     {
       "name": "dashboard",
       "runtimeExecutable": "go",
-      "runtimeArgs": ["run", "./cmd/dashboard", "--db", "/tmp/test-receipts.db"],
+      "runtimeArgs": ["run", "./cmd/dashboard", "-db", "/tmp/test-receipts.db"],
       "port": 8080
     }
   ]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,7 @@ internal/verify/        # Hash linkage and chain verification
 
 | Task | Command |
 |------|---------|
-| Run | `go run ./cmd/dashboard --db path/to/receipts.db` |
+| Run | `go run ./cmd/dashboard -db path/to/receipts.db` |
 | Build | `go build -o dashboard ./cmd/dashboard` |
 | Test | `go test ./...` |
 | Lint | `go vet ./...` |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,8 +22,8 @@ make test                  # test via Makefile
 ## Running
 
 ```sh
-./dashboard --db path/to/receipts.db           # open a receipt database
-./dashboard --db path/to/receipts.db --port 9090  # custom port
+./dashboard -db path/to/receipts.db           # open a receipt database
+./dashboard -db path/to/receipts.db -port 9090  # custom port
 ```
 
 ## Project structure

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ go test ./...
 | `go build ./cmd/dashboard` | Build the binary |
 | `go test ./... -count=1` | Run all tests (no cache) |
 | `go vet ./...` | Static analysis |
-| `go run ./cmd/dashboard --db path/to/receipts.db` | Run locally |
+| `go run ./cmd/dashboard -db path/to/receipts.db` | Run locally |
 
 Or via Make:
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 	go vet ./...
 
 run: build
-	./dashboard --db $(DB)
+	./dashboard -db $(DB)
 
 clean:
 	rm -f dashboard

--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ make build
 
 ```sh
 # Point at a receipt database
-dashboard --db ./receipts.db
+dashboard -db ./receipts.db
 
 # Custom port
-dashboard --db ./receipts.db --port 9090
+dashboard -db ./receipts.db -port 9090
 ```
 
 Then open http://localhost:8080 in your browser.

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -19,7 +19,7 @@ func main() {
 	flag.Parse()
 
 	if *dbPath == "" {
-		fmt.Fprintln(os.Stderr, "usage: dashboard --db <path/to/receipts.db>")
+		fmt.Fprintln(os.Stderr, "usage: dashboard -db <path/to/receipts.db>")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Summary

- Changed all CLI flag references from double-dash (`--db`, `--port`) to single-dash (`-db`, `-port`) to match Go's `flag` package canonical syntax
- Updated across 7 files: CLAUDE.md, README.md, AGENTS.md, CONTRIBUTING.md, Makefile, `cmd/dashboard/main.go` usage string, and `.claude/launch.json`

Fixes #25

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] Grep confirms no `--db`/`--port`/`--host` references remain