### PR TITLE
feat: show SERVER and TOOL in receipt list and detail views

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/dashboard
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.4.0
+	github.com/agent-receipts/ar/sdk/go v0.5.0
 	modernc.org/sqlite v1.49.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.3.1 h1:20mU2aszom4gG7BvZyyT/mxMgeDJniBJv630771yqUI=
-github.com/agent-receipts/ar/sdk/go v0.3.1/go.mod h1:W/Lgz1a3s8mtlNP8MQq+2llwzWukokud+4NeMMOVhXI=
-github.com/agent-receipts/ar/sdk/go v0.4.0 h1:BqybWy9ha8ePQKckG9dC2FS5Y6mCuO1Eens/JJgK/wI=
-github.com/agent-receipts/ar/sdk/go v0.4.0/go.mod h1:Y8j3xhKAyaJF7LEuo15IWZWAptOA6b489CI3OFbZC6s=
+github.com/agent-receipts/ar/sdk/go v0.5.0 h1:N5tvD3t4gqyv3OTUrwDV1LaAS0ObrdjfAygj/A8gm8Y=
+github.com/agent-receipts/ar/sdk/go v0.5.0/go.mod h1:Y8j3xhKAyaJF7LEuo15IWZWAptOA6b489CI3OFbZC6s=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -281,6 +281,8 @@
             <thead>
               <tr class="text-[#7d8590] text-left border-b border-[#30363d]">
                 <th class="pb-2 pr-4">Time</th>
+                <th class="pb-2 pr-4">Server</th>
+                <th class="pb-2 pr-4">Tool</th>
                 <th class="pb-2 pr-4">Action</th>
                 <th class="pb-2 pr-4">Risk</th>
                 <th class="pb-2 pr-4">Status</th>
@@ -292,6 +294,8 @@
               ${receipts.map(r => `
                 <tr class="border-b border-[#30363d]/50 hover:bg-[#1c2128] cursor-pointer" data-receipt-id="${escapeHtml(r.id)}" onclick="showReceipt(this.dataset.receiptId)">
                   <td class="py-2 pr-4 text-[#7d8590] whitespace-nowrap">${formatTime(r.timestamp)}</td>
+                  <td class="py-2 pr-4 font-mono text-xs text-[#7d8590]">${r.server ? escapeHtml(r.server) : '<span class="text-[#484f58]">—</span>'}</td>
+                  <td class="py-2 pr-4 font-mono text-xs">${r.tool_name ? escapeHtml(r.tool_name) : '<span class="text-[#484f58]">—</span>'}</td>
                   <td class="py-2 pr-4 font-mono text-xs">${escapeHtml(r.action_type)}</td>
                   <td class="py-2 pr-4"><span class="badge ${riskClass(r.risk_level)}">${escapeHtml(r.risk_level)}</span></td>
                   <td class="py-2 pr-4"><span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span></td>
@@ -355,6 +359,14 @@
         <div class="space-y-4">
           <div class="grid grid-cols-2 gap-4">
             <div>
+              <div class="text-[#7d8590] text-xs mb-1">Server</div>
+              <div class="font-mono text-sm">${subj.action.target ? escapeHtml(subj.action.target.system) : '<span class="text-[#484f58]">—</span>'}</div>
+            </div>
+            <div>
+              <div class="text-[#7d8590] text-xs mb-1">Tool</div>
+              <div class="font-mono text-sm">${subj.action.tool_name ? escapeHtml(subj.action.tool_name) : '<span class="text-[#484f58]">—</span>'}</div>
+            </div>
+            <div>
               <div class="text-[#7d8590] text-xs mb-1">Action Type</div>
               <div class="font-mono text-sm">${escapeHtml(subj.action.type)}</div>
             </div>
@@ -370,6 +382,16 @@
               <div class="text-[#7d8590] text-xs mb-1">Timestamp</div>
               <div class="text-sm">${formatTime(subj.action.timestamp)}</div>
             </div>
+          </div>
+
+          ${subj.action.target && subj.action.target.resource ? `
+          <div>
+            <div class="text-[#7d8590] text-xs mb-1">Resource</div>
+            <div class="font-mono text-xs">${escapeHtml(subj.action.target.resource)}</div>
+          </div>
+          ` : ''}
+
+          <div class="grid grid-cols-2 gap-4">
             <div>
               <div class="text-[#7d8590] text-xs mb-1">Issuer</div>
               <div class="font-mono text-xs">${escapeHtml(r.issuer.id)}</div>
@@ -380,13 +402,6 @@
               <div class="font-mono text-xs">${escapeHtml(subj.principal.id)}</div>
             </div>
           </div>
-
-          ${subj.action.target ? `
-          <div>
-            <div class="text-[#7d8590] text-xs mb-1">Target</div>
-            <div class="font-mono text-xs">${escapeHtml(subj.action.target.system)}${subj.action.target.resource ? ' / ' + escapeHtml(subj.action.target.resource) : ''}</div>
-          </div>
-          ` : ''}
 
           ${subj.intent ? `
           <div>

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -25,6 +25,8 @@ type ReceiptRow struct {
 	ChainID             string `json:"chain_id"`
 	Sequence            int    `json:"sequence"`
 	ActionType          string `json:"action_type"`
+	ToolName            string `json:"tool_name"`
+	Server              string `json:"server"`
 	RiskLevel           string `json:"risk_level"`
 	Status              string `json:"status"`
 	Timestamp           string `json:"timestamp"`
@@ -158,7 +160,10 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 	}
 
 	query := fmt.Sprintf(
-		`SELECT id, chain_id, sequence, action_type, risk_level, status,
+		`SELECT id, chain_id, sequence, action_type,
+		        COALESCE(tool_name, ''),
+		        COALESCE(json_extract(receipt_json, '$.credentialSubject.action.target.system'), ''),
+		        risk_level, status,
 		        timestamp, issuer_id, COALESCE(principal_id, ''),
 		        receipt_hash, COALESCE(previous_receipt_hash, '')
 		 FROM receipts %s ORDER BY timestamp DESC LIMIT ?`,
@@ -177,6 +182,7 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		var row ReceiptRow
 		if err := rows.Scan(
 			&row.ID, &row.ChainID, &row.Sequence, &row.ActionType,
+			&row.ToolName, &row.Server,
 			&row.RiskLevel, &row.Status, &row.Timestamp, &row.IssuerID,
 			&row.PrincipalID, &row.ReceiptHash, &row.PreviousReceiptHash,
 		); err != nil {

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -37,6 +37,15 @@ func makeReceipt(id, chainID string, seq int, actionType string, risk receipt.Ri
 	}
 }
 
+func makeReceiptWithTool(id, chainID string, seq int, actionType, toolName, server string, risk receipt.RiskLevel, status receipt.OutcomeStatus, ts string) receipt.AgentReceipt {
+	ar := makeReceipt(id, chainID, seq, actionType, risk, status, ts, nil)
+	ar.CredentialSubject.Action.ToolName = toolName
+	if server != "" {
+		ar.CredentialSubject.Action.Target = &receipt.ActionTarget{System: server}
+	}
+	return ar
+}
+
 func strPtr(s string) *string { return &s }
 
 // The reader must be constructable from an existing SDK store's DB.
@@ -224,6 +233,61 @@ func TestReader_ListReceipts_Limit(t *testing.T) {
 	}
 	if len(rows) != 2 {
 		t.Errorf("got %d rows, want 2", len(rows))
+	}
+}
+
+func TestReader_ListReceipts_ServerAndTool(t *testing.T) {
+	dbPath := t.TempDir() + "/tool-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	withTool := makeReceiptWithTool("urn:receipt:t1", "chain-tool", 1,
+		"tool.call", "read_file", "filesystem", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z")
+	withoutTarget := makeReceiptWithTool("urn:receipt:t2", "chain-tool", 2,
+		"tool.call", "list_dir", "", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:01:00Z")
+
+	for _, r := range []receipt.AgentReceipt{withTool, withoutTarget} {
+		hash, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatalf("hash: %v", err)
+		}
+		if err := s.Insert(r, hash); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	s.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	rows, err := reader.ListReceipts(Filter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
+	}
+
+	// rows are newest-first, so t2 is index 0 and t1 is index 1.
+	rowT2 := rows[0]
+	rowT1 := rows[1]
+
+	if rowT1.ToolName != "read_file" {
+		t.Errorf("tool_name: got %q, want %q", rowT1.ToolName, "read_file")
+	}
+	if rowT1.Server != "filesystem" {
+		t.Errorf("server: got %q, want %q", rowT1.Server, "filesystem")
+	}
+	if rowT2.ToolName != "list_dir" {
+		t.Errorf("tool_name: got %q, want %q", rowT2.ToolName, "list_dir")
+	}
+	if rowT2.Server != "" {
+		t.Errorf("server: got %q, want empty (nil target)", rowT2.Server)
 	}
 }
 

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -247,8 +247,10 @@ func TestReader_ListReceipts_ServerAndTool(t *testing.T) {
 		"tool.call", "read_file", "filesystem", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z")
 	withoutTarget := makeReceiptWithTool("urn:receipt:t2", "chain-tool", 2,
 		"tool.call", "list_dir", "", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:01:00Z")
+	withoutTool := makeReceiptWithTool("urn:receipt:t3", "chain-tool", 3,
+		"tool.call", "", "jira", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:02:00Z")
 
-	for _, r := range []receipt.AgentReceipt{withTool, withoutTarget} {
+	for _, r := range []receipt.AgentReceipt{withTool, withoutTarget, withoutTool} {
 		hash, err := receipt.HashReceipt(r)
 		if err != nil {
 			t.Fatalf("hash: %v", err)
@@ -269,13 +271,14 @@ func TestReader_ListReceipts_ServerAndTool(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	if len(rows) != 2 {
-		t.Fatalf("got %d rows, want 2", len(rows))
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
 	}
 
-	// rows are newest-first, so t2 is index 0 and t1 is index 1.
-	rowT2 := rows[0]
-	rowT1 := rows[1]
+	// rows are newest-first: t3 (index 0), t2 (index 1), t1 (index 2).
+	rowT3 := rows[0]
+	rowT2 := rows[1]
+	rowT1 := rows[2]
 
 	if rowT1.ToolName != "read_file" {
 		t.Errorf("tool_name: got %q, want %q", rowT1.ToolName, "read_file")
@@ -288,6 +291,12 @@ func TestReader_ListReceipts_ServerAndTool(t *testing.T) {
 	}
 	if rowT2.Server != "" {
 		t.Errorf("server: got %q, want empty (nil target)", rowT2.Server)
+	}
+	if rowT3.ToolName != "" {
+		t.Errorf("tool_name: got %q, want empty", rowT3.ToolName)
+	}
+	if rowT3.Server != "jira" {
+		t.Errorf("server: got %q, want %q", rowT3.Server, "jira")
 	}
 }
 


### PR DESCRIPTION
Closes #34

## Changes

**`internal/store/reader.go`**

- Added `Server` and `ToolName` fields to `ReceiptRow`
- List query selects `COALESCE(tool_name, '')` from the DB column and uses `json_extract(receipt_json, '$.credentialSubject.action.target.system')` for `Server` — no schema migration required, old receipts with no `target` return `""`

**`internal/server/static/index.html`**

- List table: added `Server` and `Tool` columns; blank values render as a muted `—`
- Detail modal: `Server` and `Tool` promoted to top of the grid (most operationally relevant); `Issuer`/`Principal` moved to a second grid below

**`internal/store/reader_test.go`**

- Added tests for both fields, including a nil-target receipt verifying `Server == ""`

**`go.mod` / `go.sum`**

- Bumped AR Go SDK to v0.5.0

## Reference

- Equivalent CLI change: [ar#232](https://github.com/agent-receipts/ar/pull/232)
