### PR TITLE
chore: ignore .claude/worktrees and settings.local.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Binary
 /dashboard
 
+# Claude Code
+.claude/worktrees/
+.claude/settings.local.json
+
 # IDE
 .idea/
 .vscode/


### PR DESCRIPTION
Adds `.claude/worktrees/` and `.claude/settings.local.json` to `.gitignore` so Claude Code worktrees and local settings don't show up as untracked files and block the release script's clean-tree check.