### PR TITLE
docs: ADR 0001 — adopt Wails as desktop wrapper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 # Binary
 /dashboard
 
+# Claude Code
+.claude/worktrees/
+.claude/settings.local.json
+
 # IDE
 .idea/
 .vscode/

--- a/docs/adr/0001-wails-desktop-wrapper.md
+++ b/docs/adr/0001-wails-desktop-wrapper.md
@@ -41,9 +41,9 @@ Both modes coexist:
 
 ## Rationale
 
-- **Supply chain:** Electron pulls in Node plus hundreds of transitive npm packages (past incidents: `event-stream`, `ua-parser-js`, `node-ipc`). Wails' dependency footprint is a Go module tree plus a small frontend bundler — auditable in `go.sum`.
-- **OS webview security:** Instead of shipping a pinned Chromium, Wails delegates rendering to the OS webview (WebKit on macOS/Linux, WebView2 on Windows). Security patches arrive through OS updates rather than requiring a separate Chromium patch cadence.
-- **Go-first ethos:** The codebase is pure Go today. Wails keeps backend logic in Go with no Node runtime required at build or runtime.
+- **Supply chain:** Electron pulls in Node plus hundreds of transitive npm packages (past incidents: `event-stream`, `ua-parser-js`, `node-ipc`). Wails' Go deps are auditable in `go.sum`; any frontend tooling (e.g. Tailwind CLI) is tracked in a lockfile (`package-lock.json` / `pnpm-lock.yaml`) — still far smaller than Electron's tree.
+- **OS webview security:** Instead of shipping a pinned Chromium, Wails delegates rendering to the OS webview — WKWebView on macOS, WebView2 on Windows, WebKitGTK on Linux. Security patches arrive through OS updates rather than requiring a separate Chromium patch cadence.
+- **Go-first ethos:** The codebase is pure Go today. Wails keeps backend logic and the runtime entirely in Go — no Node at runtime. Build-time tooling depends on the chosen frontend pipeline (e.g. Tailwind CLI requires Node).
 - **Binary size:** ~15–30 MB (platform-dependent) vs ~100 MB for Electron.
 - **go-webview** was ruled out because it provides no built-in menus or native dialogs — features needed for a polished file-picker experience. Neither Wails nor go-webview ship a first-party auto-updater; that's acceptable for now.
 

--- a/docs/adr/0001-wails-desktop-wrapper.md
+++ b/docs/adr/0001-wails-desktop-wrapper.md
@@ -7,31 +7,58 @@
 
 The dashboard is currently a Go HTTP server served in a browser tab. Users must launch it from the terminal and navigate to `localhost:<port>` manually. A native desktop experience — double-click to open, native file picker for `.db` files, menu bar integration — would significantly improve usability.
 
-Three options were evaluated:
+Options evaluated:
 
 | Option | Binary size | Supply chain | Native feel |
 |---|---|---|---|
 | Electron | ~100 MB (bundled Chromium) | Large (hundreds of npm deps) | Excellent |
-| Wails | ~15 MB (OS webview) | Small (Go modules + minimal JS) | Very good |
-| go-webview | ~5 MB (OS webview) | Smallest | Minimal (DIY menus/dialogs) |
+| Wails v2 | ~15–30 MB (OS webview) | Small (Go modules + minimal JS) | Very good |
+| go-webview | ~5–10 MB (OS webview) | Smallest | Minimal (DIY menus/dialogs) |
+| Tauri | ~10–20 MB (OS webview) | Small (Rust crates) | Very good |
+
+Tauri was set aside because it would introduce a Rust toolchain to an otherwise pure-Go codebase.
 
 ## Decision
 
-Adopt **Wails v2** as the desktop wrapper.
+Adopt **Wails v2** as the desktop wrapper, running alongside (not replacing) the existing CLI/HTTP mode.
 
-The existing HTTP server and htmx/Tailwind frontend remain intact. Wails replaces the standalone `net/http` listener with its own IPC bridge, keeping Go as the primary language throughout.
+### Architecture
+
+The existing `net/http` server is **retained**. htmx drives the UI via HTTP requests (`hx-get`, `hx-post`), which are incompatible with Wails' JS-binding IPC model. The pragmatic path is:
+
+- Wails launches the dashboard's HTTP server on a local loopback port.
+- Wails' embedded webview loads `http://127.0.0.1:<port>/`.
+- Wails bindings are used only for features the webview can't provide — native file-open dialog, menu actions, window lifecycle.
+
+This keeps the htmx/Tailwind UI and the `internal/server` routes completely unchanged. The read-only `internal/store` layer is untouched — the Wails wrapper adds no write paths.
+
+### Distribution modes
+
+Both modes coexist:
+
+- **CLI mode** (`./dashboard -db <path>`): unchanged, for headless / server / SSH use.
+- **Desktop mode** (`Dashboard.app` / `.exe` / `.deb`): Wails-wrapped, for double-click launch with a native file picker.
 
 ## Rationale
 
-- **Supply chain:** Electron pulls in Node plus hundreds of transitive npm packages (past incidents: `event-stream`, `ua-parser-js`, `node-ipc`). Wails' dependency footprint is a Go module tree plus an optional small frontend bundler — auditable in `go.sum`.
+- **Supply chain:** Electron pulls in Node plus hundreds of transitive npm packages (past incidents: `event-stream`, `ua-parser-js`, `node-ipc`). Wails' dependency footprint is a Go module tree plus a small frontend bundler — auditable in `go.sum`.
 - **OS webview security:** Instead of shipping a pinned Chromium, Wails delegates rendering to the OS webview (WebKit on macOS/Linux, WebView2 on Windows). Security patches arrive through OS updates rather than requiring a separate Chromium patch cadence.
 - **Go-first ethos:** The codebase is pure Go today. Wails keeps backend logic in Go with no Node runtime required at build or runtime.
-- **Binary size:** ~15 MB vs ~100 MB for Electron; single distributable per platform.
-- **go-webview** was ruled out because it provides no built-in menus, dialogs, or auto-update hooks — features needed for a polished file-picker experience.
+- **Binary size:** ~15–30 MB (platform-dependent) vs ~100 MB for Electron.
+- **go-webview** was ruled out because it provides no built-in menus or native dialogs — features needed for a polished file-picker experience. Neither Wails nor go-webview ship a first-party auto-updater; that's acceptable for now.
 
 ## Consequences
 
-- Rendering is subject to OS webview engine differences (WebKit vs WebView2 vs WebKitGTK). The htmx + Tailwind UI must be tested on each platform.
-- The `./dashboard -db <path> -port <port>` CLI flow is preserved; Wails wraps it and adds a native open-file dialog as an alternative entry point.
-- Distribution changes: platform-specific bundles (`.app`, `.exe`, `.deb`) replace the single cross-platform binary. Code signing and notarization are required for macOS and Windows distribution.
-- A GitHub Actions workflow will need updating to build Wails targets per platform.
+### Architectural
+
+- The htmx + Tailwind UI must be tested on each platform's webview (WebKit, WebView2, WebKitGTK) — rendering differences are possible.
+- Wails v2's default templates assume a Vite + Svelte/React/Vue frontend. Using raw htmx + Tailwind is off the paved road; we accept owning a custom Wails project layout.
+- **Tailwind CDN must be replaced** with a vendored build (Tailwind CLI or a small embedded bundle) so the desktop app works offline. The current CDN dependency is the single biggest blocker.
+- The read-only guarantee is preserved — `internal/store` continues to open SQLite in read-only mode; Wails does not introduce new write paths.
+
+### Build & distribution
+
+- Platform-specific bundles (`.app`, `.exe`, `.deb`) are produced in addition to the existing single Go binary.
+- Code signing and notarization are required for distributing macOS and Windows builds.
+- CI (`.github/workflows`, `lefthook.yml`) needs updating to build Wails targets per platform.
+- Go `go test ./...` continues to work unchanged for backend logic; UI testing strategy for the Wails shell is TBD.

--- a/docs/adr/0001-wails-desktop-wrapper.md
+++ b/docs/adr/0001-wails-desktop-wrapper.md
@@ -1,0 +1,37 @@
+# ADR 0001: Wails as Desktop Wrapper
+
+**Status:** Accepted  
+**Date:** 2026-04-24
+
+## Context
+
+The dashboard is currently a Go HTTP server served in a browser tab. Users must launch it from the terminal and navigate to `localhost:<port>` manually. A native desktop experience — double-click to open, native file picker for `.db` files, menu bar integration — would significantly improve usability.
+
+Three options were evaluated:
+
+| Option | Binary size | Supply chain | Native feel |
+|---|---|---|---|
+| Electron | ~100 MB (bundled Chromium) | Large (hundreds of npm deps) | Excellent |
+| Wails | ~15 MB (OS webview) | Small (Go modules + minimal JS) | Very good |
+| go-webview | ~5 MB (OS webview) | Smallest | Minimal (DIY menus/dialogs) |
+
+## Decision
+
+Adopt **Wails v2** as the desktop wrapper.
+
+The existing HTTP server and htmx/Tailwind frontend remain intact. Wails replaces the standalone `net/http` listener with its own IPC bridge, keeping Go as the primary language throughout.
+
+## Rationale
+
+- **Supply chain:** Electron pulls in Node plus hundreds of transitive npm packages (past incidents: `event-stream`, `ua-parser-js`, `node-ipc`). Wails' dependency footprint is a Go module tree plus an optional small frontend bundler — auditable in `go.sum`.
+- **OS webview security:** Instead of shipping a pinned Chromium, Wails delegates rendering to the OS webview (WebKit on macOS/Linux, WebView2 on Windows). Security patches arrive through OS updates rather than requiring a separate Chromium patch cadence.
+- **Go-first ethos:** The codebase is pure Go today. Wails keeps backend logic in Go with no Node runtime required at build or runtime.
+- **Binary size:** ~15 MB vs ~100 MB for Electron; single distributable per platform.
+- **go-webview** was ruled out because it provides no built-in menus, dialogs, or auto-update hooks — features needed for a polished file-picker experience.
+
+## Consequences
+
+- Rendering is subject to OS webview engine differences (WebKit vs WebView2 vs WebKitGTK). The htmx + Tailwind UI must be tested on each platform.
+- The `./dashboard -db <path> -port <port>` CLI flow is preserved; Wails wraps it and adds a native open-file dialog as an alternative entry point.
+- Distribution changes: platform-specific bundles (`.app`, `.exe`, `.deb`) replace the single cross-platform binary. Code signing and notarization are required for macOS and Windows distribution.
+- A GitHub Actions workflow will need updating to build Wails targets per platform.


### PR DESCRIPTION
## Summary

- Adds `docs/adr/0001-wails-desktop-wrapper.md` (status: Accepted)
- Records the decision to use Wails v2 over Electron and go-webview as the native desktop wrapper
- Key rationale: smaller supply chain, OS webview security model, keeps Go as primary language

## No code changes

This is a documentation-only PR. Implementation will follow in a separate issue/branch.