### PR TITLE
chore: bump sdk/go dependency to v0.6.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/dashboard
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.5.0
+	github.com/agent-receipts/ar/sdk/go v0.6.0
 	modernc.org/sqlite v1.50.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.5.0 h1:N5tvD3t4gqyv3OTUrwDV1LaAS0ObrdjfAygj/A8gm8Y=
-github.com/agent-receipts/ar/sdk/go v0.5.0/go.mod h1:Y8j3xhKAyaJF7LEuo15IWZWAptOA6b489CI3OFbZC6s=
+github.com/agent-receipts/ar/sdk/go v0.6.0 h1:zSpXnUOJFWRBikQmT1brOaEVv68eiFsLQSp+ZPAgHxw=
+github.com/agent-receipts/ar/sdk/go v0.6.0/go.mod h1:Y8j3xhKAyaJF7LEuo15IWZWAptOA6b489CI3OFbZC6s=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=


### PR DESCRIPTION
## Summary

Bumps `github.com/agent-receipts/ar/sdk/go` from v0.5.0 to [v0.6.0](https://github.com/agent-receipts/ar/releases/tag/sdk/go/v0.6.0).

## What's in v0.6.0

- **Additive** — new `Action.ParametersDisclosure map[string]string` field (per ADR-0012). Operator-controlled disclosure map alongside `ParametersHash`. Not surfaced in the dashboard UI yet — possible follow-up for the receipt detail view.
- **Bug fix** — SDK's `VerifyChain` now surfaces `HashReceipt` errors via `ChainVerification.Error` instead of silently flagging `HashLinkValid: false`. Informational only — the dashboard implements its own `verify.VerifyChainLinks` and does not call the SDK's `VerifyChain`.
- **Spec/encoding** — `proofValue` aligned to base64url throughout.

## Compatibility

No source changes needed. All `receipt.Action{...}` literals in tests still compile (new field is optional). `go vet` clean, full test suite passes.

## Test plan

- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] CI green