### PR TITLE
feat: default -db to ~/.agent-receipts/receipts.db

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,8 +23,9 @@ internal/verify/        # Hash linkage and chain verification
 
 | Task | Command |
 |------|---------|
-| Run | `go run ./cmd/dashboard -db path/to/receipts.db` |
-| Run (custom port) | `go run ./cmd/dashboard -db path/to/receipts.db -port 9090` |
+| Run (default `~/.agent-receipts/receipts.db`) | `go run ./cmd/dashboard` |
+| Run (custom db) | `go run ./cmd/dashboard -db path/to/receipts.db` |
+| Run (custom port) | `go run ./cmd/dashboard -port 9090` |
 | Build | `go build -o dashboard ./cmd/dashboard` |
 | Build (make) | `make build` |
 | Test | `go test ./...` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,8 @@ go test ./...
 | `go build ./cmd/dashboard` | Build the binary |
 | `go test ./... -count=1` | Run all tests (no cache) |
 | `go vet ./...` | Static analysis |
-| `go run ./cmd/dashboard -db path/to/receipts.db` | Run locally |
+| `go run ./cmd/dashboard` | Run locally (reads `~/.agent-receipts/receipts.db` by default) |
+| `go run ./cmd/dashboard -db path/to/receipts.db` | Run locally against a specific db |
 
 Or via Make:
 
@@ -40,7 +41,8 @@ Or via Make:
 | `make build` | Build the binary |
 | `make test` | Run tests |
 | `make lint` | Run `go vet` |
-| `make run DB=path/to/receipts.db` | Build and run |
+| `make run` | Build and run (reads `~/.agent-receipts/receipts.db` by default) |
+| `make run DB=path/to/receipts.db` | Build and run against a specific db |
 
 ## Development process
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 	go vet ./...
 
 run: build
-	./dashboard -db $(DB)
+	./dashboard $(if $(DB),-db $(DB))
 
 clean:
 	rm -f dashboard

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ lint:
 	go vet ./...
 
 run: build
-	./dashboard $(if $(DB),-db $(DB))
+	./dashboard $(if $(DB),-db "$(DB)")
 
 clean:
 	rm -f dashboard

--- a/README.md
+++ b/README.md
@@ -39,11 +39,14 @@ make build
 ## Usage
 
 ```sh
-# Point at a receipt database
+# Reads ~/.agent-receipts/receipts.db by default (matches mcp-proxy / SDK convention)
+dashboard
+
+# Point at a different receipt database
 dashboard -db ./receipts.db
 
 # Custom port
-dashboard -db ./receipts.db -port 9090
+dashboard -port 9090
 ```
 
 Then open http://localhost:8080 in your browser.

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -62,7 +62,11 @@ func main() {
 	flag.Parse()
 
 	if *dbPath == "" {
-		fmt.Fprintln(os.Stderr, "dashboard: cannot resolve home directory; pass -db <path/to/receipts.db>")
+		if defaultDB == "" {
+			fmt.Fprintln(os.Stderr, "dashboard: cannot resolve home directory; pass -db <path/to/receipts.db>")
+		} else {
+			fmt.Fprintln(os.Stderr, "dashboard: -db cannot be empty")
+		}
 		os.Exit(1)
 	}
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -61,6 +61,13 @@ func main() {
 	port := flag.Int("port", 8080, "HTTP server port")
 	flag.Parse()
 
+	dbExplicit := false
+	flag.Visit(func(f *flag.Flag) {
+		if f.Name == "db" {
+			dbExplicit = true
+		}
+	})
+
 	if *dbPath == "" {
 		if defaultDB == "" {
 			fmt.Fprintln(os.Stderr, "dashboard: cannot resolve home directory; pass -db <path/to/receipts.db>")
@@ -72,7 +79,7 @@ func main() {
 
 	reader, err := store.OpenReadOnly(*dbPath)
 	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) && *dbPath == defaultDB {
+		if errors.Is(err, fs.ErrNotExist) && !dbExplicit {
 			log.Fatalf("no receipts database at default path %s\n\nPass -db <path/to/receipts.db>, or run mcp-proxy / an Agent Receipts SDK to create one.", defaultDB)
 		}
 		log.Fatalf("open database: %v", err)

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -2,11 +2,14 @@
 package main
 
 import (
+	"errors"
 	"flag"
 	"fmt"
+	"io/fs"
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"runtime/debug"
 
 	"github.com/agent-receipts/dashboard/internal/server"
@@ -18,6 +21,9 @@ import (
 // for binaries installed with `go install`), then to "dev".
 var version string
 
+// userHomeDir is overridable in tests.
+var userHomeDir = os.UserHomeDir
+
 func resolveVersion() string {
 	if version != "" {
 		return version
@@ -26,6 +32,18 @@ func resolveVersion() string {
 		return info.Main.Version
 	}
 	return "dev"
+}
+
+// defaultDBPath returns the conventional `~/.agent-receipts/receipts.db`
+// shared by mcp-proxy and the daemon. Returns "" if the home directory
+// cannot be resolved to an absolute path; main surfaces a clear error in
+// that case.
+func defaultDBPath() string {
+	home, err := userHomeDir()
+	if err != nil || home == "" || !filepath.IsAbs(home) {
+		return ""
+	}
+	return filepath.Join(home, ".agent-receipts", "receipts.db")
 }
 
 func main() {
@@ -37,18 +55,22 @@ func main() {
 		}
 	}
 
-	dbPath := flag.String("db", "", "path to receipts SQLite database")
+	defaultDB := defaultDBPath()
+	dbPath := flag.String("db", defaultDB, "path to receipts SQLite database")
 	host := flag.String("host", "127.0.0.1", "address to bind to (use 0.0.0.0 for all interfaces)")
 	port := flag.Int("port", 8080, "HTTP server port")
 	flag.Parse()
 
 	if *dbPath == "" {
-		fmt.Fprintln(os.Stderr, "usage: dashboard -db <path/to/receipts.db>")
+		fmt.Fprintln(os.Stderr, "dashboard: cannot resolve home directory; pass -db <path/to/receipts.db>")
 		os.Exit(1)
 	}
 
 	reader, err := store.OpenReadOnly(*dbPath)
 	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) && *dbPath == defaultDB {
+			log.Fatalf("no receipts database at default path %s\n\nPass -db <path/to/receipts.db>, or run mcp-proxy / an Agent Receipts SDK to create one.", defaultDB)
+		}
 		log.Fatalf("open database: %v", err)
 	}
 	defer reader.Close()

--- a/cmd/dashboard/main_test.go
+++ b/cmd/dashboard/main_test.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"errors"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultDBPath(t *testing.T) {
+	original := userHomeDir
+	t.Cleanup(func() { userHomeDir = original })
+
+	tests := []struct {
+		name    string
+		home    string
+		homeErr error
+		want    string
+	}{
+		{
+			name: "absolute home resolves under .agent-receipts",
+			home: "/home/test",
+			want: filepath.Join("/home/test", ".agent-receipts", "receipts.db"),
+		},
+		{
+			name:    "home lookup error returns empty",
+			homeErr: errors.New("no home"),
+			want:    "",
+		},
+		{
+			name: "empty home returns empty",
+			home: "",
+			want: "",
+		},
+		{
+			name: "relative home returns empty",
+			home: "relative/path",
+			want: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			userHomeDir = func() (string, error) { return tc.home, tc.homeErr }
+			if got := defaultDBPath(); got != tc.want {
+				t.Errorf("defaultDBPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

Defaults the `-db` flag to `~/.agent-receipts/receipts.db` so `dashboard` runs with no arguments against a standard local install. Explicit `-db <path>` still works exactly as before.

## Why

Every other tool in the ecosystem (mcp-proxy, daemon, ADR 0015) already uses `~/.agent-receipts/` as the canonical per-user location. Forcing dashboard users to type `-db ~/.agent-receipts/receipts.db` every time is gratuitous friction.

Behavior when the default doesn't apply:

- **Home directory cannot be resolved** → `dashboard: cannot resolve home directory; pass -db <path/to/receipts.db>` (exit 1).
- **Default path does not exist yet** → `no receipts database at default path …` plus a hint to pass `-db` or run mcp-proxy / an SDK.

The `defaultDBPath` helper mirrors the pattern in `mcp-proxy/cmd/mcp-proxy/main.go` (test seam via `var userHomeDir = os.UserHomeDir`).

## Tradeoff

`dashboard` invoked with no flags on a machine that has never produced receipts now fails with "default db doesn't exist" instead of the old "usage:" line. That matches mcp-proxy UX and the new error explicitly tells the user how to recover.

## Files

- `cmd/dashboard/main.go` — `defaultDBPath()` helper, default applied to `-db`, friendlier error paths.
- `cmd/dashboard/main_test.go` — table-driven coverage for the four `defaultDBPath` branches (absolute home, lookup error, empty home, relative home).
- `README.md`, `AGENTS.md`, `CONTRIBUTING.md` — usage examples updated to lead with the no-flag form.
- `Makefile` — `make run` now passes `-db` only when `DB=` is set, so `make run` alone uses the default.

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] New functionality includes tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] AGENTS.md updated
- [ ] Request a Copilot review for automated checks