### PR TITLE
fix: migrate default db path to ~/.local/share/agent-receipts/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ internal/verify/        # Hash linkage and chain verification
 
 | Task | Command |
 |------|---------|
-| Run (default `~/.agent-receipts/receipts.db`) | `go run ./cmd/dashboard` |
+| Run (default `~/.local/share/agent-receipts/receipts.db`) | `go run ./cmd/dashboard` |
 | Run (custom db) | `go run ./cmd/dashboard -db path/to/receipts.db` |
 | Run (custom port) | `go run ./cmd/dashboard -port 9090` |
 | Build | `go build -o dashboard ./cmd/dashboard` |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,7 +31,7 @@ go test ./...
 | `go build ./cmd/dashboard` | Build the binary |
 | `go test ./... -count=1` | Run all tests (no cache) |
 | `go vet ./...` | Static analysis |
-| `go run ./cmd/dashboard` | Run locally (reads `~/.agent-receipts/receipts.db` by default) |
+| `go run ./cmd/dashboard` | Run locally (reads `~/.local/share/agent-receipts/receipts.db` by default) |
 | `go run ./cmd/dashboard -db path/to/receipts.db` | Run locally against a specific db |
 
 Or via Make:
@@ -41,7 +41,7 @@ Or via Make:
 | `make build` | Build the binary |
 | `make test` | Run tests |
 | `make lint` | Run `go vet` |
-| `make run` | Build and run (reads `~/.agent-receipts/receipts.db` by default) |
+| `make run` | Build and run (reads `~/.local/share/agent-receipts/receipts.db` by default) |
 | `make run DB=path/to/receipts.db` | Build and run against a specific db |
 
 ## Development process

--- a/README.md
+++ b/README.md
@@ -50,18 +50,18 @@ make build
 ./dashboard
 ```
 
-Opens http://localhost:8080 and reads `~/.agent-receipts/receipts.db` by default — the same path used by the SDKs and MCP proxy.
+Opens http://localhost:8080 and reads `~/.local/share/agent-receipts/receipts.db` by default — the same path used by the SDKs and MCP proxy.
 
 ## CLI reference
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `-db` | `~/.agent-receipts/receipts.db` | Path to receipts SQLite database |
+| `-db` | `~/.local/share/agent-receipts/receipts.db` | Path to receipts SQLite database |
 | `-port` | `8080` | HTTP server port |
 | `-host` | `127.0.0.1` | Address to bind (use `0.0.0.0` for all interfaces) |
 
 ```sh
-# Default — reads ~/.agent-receipts/receipts.db
+# Reads ~/.local/share/agent-receipts/receipts.db by default
 dashboard
 
 # Custom database

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -34,16 +34,28 @@ func resolveVersion() string {
 	return "dev"
 }
 
-// defaultDBPath returns the conventional `~/.agent-receipts/receipts.db`
-// shared by mcp-proxy and the daemon. Returns "" if the home directory
-// cannot be resolved to an absolute path; main surfaces a clear error in
-// that case.
-func defaultDBPath() string {
+// xdgDataHome returns the XDG data home directory. It honours $XDG_DATA_HOME
+// when set to an absolute path, and falls back to ~/.local/share.
+func xdgDataHome() string {
+	if dataHome := os.Getenv("XDG_DATA_HOME"); dataHome != "" && filepath.IsAbs(dataHome) {
+		return dataHome
+	}
 	home, err := userHomeDir()
 	if err != nil || home == "" || !filepath.IsAbs(home) {
 		return ""
 	}
-	return filepath.Join(home, ".agent-receipts", "receipts.db")
+	return filepath.Join(home, ".local", "share")
+}
+
+// defaultDBPath returns the conventional ~/.local/share/agent-receipts/receipts.db
+// shared by mcp-proxy, daemon, and hook. Returns "" if the data home directory
+// cannot be resolved; main surfaces a clear error in that case.
+func defaultDBPath() string {
+	dh := xdgDataHome()
+	if dh == "" {
+		return ""
+	}
+	return filepath.Join(dh, "agent-receipts", "receipts.db")
 }
 
 func main() {

--- a/cmd/dashboard/main_test.go
+++ b/cmd/dashboard/main_test.go
@@ -17,9 +17,9 @@ func TestDefaultDBPath(t *testing.T) {
 		want    string
 	}{
 		{
-			name: "absolute home resolves under .agent-receipts",
+			name: "absolute home resolves under .local/share/agent-receipts",
 			home: "/home/test",
-			want: filepath.Join("/home/test", ".agent-receipts", "receipts.db"),
+			want: filepath.Join("/home/test", ".local", "share", "agent-receipts", "receipts.db"),
 		},
 		{
 			name:    "home lookup error returns empty",
@@ -40,7 +40,45 @@ func TestDefaultDBPath(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_DATA_HOME", "") // ensure env var doesn't interfere
 			userHomeDir = func() (string, error) { return tc.home, tc.homeErr }
+			if got := defaultDBPath(); got != tc.want {
+				t.Errorf("defaultDBPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDefaultDBPath_XDGDataHome(t *testing.T) {
+	original := userHomeDir
+	t.Cleanup(func() { userHomeDir = original })
+	userHomeDir = func() (string, error) { return "/home/test", nil }
+
+	tests := []struct {
+		name        string
+		xdgDataHome string
+		want        string
+	}{
+		{
+			name:        "absolute XDG_DATA_HOME is used",
+			xdgDataHome: "/custom/data",
+			want:        filepath.Join("/custom/data", "agent-receipts", "receipts.db"),
+		},
+		{
+			name:        "relative XDG_DATA_HOME is ignored",
+			xdgDataHome: "relative/data",
+			want:        filepath.Join("/home/test", ".local", "share", "agent-receipts", "receipts.db"),
+		},
+		{
+			name:        "empty XDG_DATA_HOME falls back to home",
+			xdgDataHome: "",
+			want:        filepath.Join("/home/test", ".local", "share", "agent-receipts", "receipts.db"),
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv("XDG_DATA_HOME", tc.xdgDataHome)
 			if got := defaultDBPath(); got != tc.want {
 				t.Errorf("defaultDBPath() = %q, want %q", got, tc.want)
 			}


### PR DESCRIPTION
## Summary

Migrates the dashboard's default database path from `~/.agent-receipts/receipts.db` to `~/.local/share/agent-receipts/receipts.db` to match the daemon, hook, and mcp-proxy (ar#414).

Part of ar#413 — path consolidation across all tools.

## Changes

- `cmd/dashboard/main.go` — replaced `defaultDBPath()` with XDG-aware version: honours `$XDG_DATA_HOME` when absolute, falls back to `~/.local/share`
- `cmd/dashboard/main_test.go` — updated existing path assertion; added `TestDefaultDBPath_XDGDataHome` covering absolute XDG override, relative XDG (ignored), and empty fallback
- `README.md`, `AGENTS.md`, `CONTRIBUTING.md` — updated path references

## Test plan

- [ ] `go test ./...` — all 4 packages pass
- [ ] `go vet ./...` — clean