### PR TITLE
feat: live polling for new receipts

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Opens http://localhost:8080 and reads `~/.local/share/agent-receipts/receipts.db
 | `-db` | `~/.local/share/agent-receipts/receipts.db` | Path to receipts SQLite database |
 | `-port` | `8080` | HTTP server port |
 | `-host` | `127.0.0.1` | Address to bind (use `0.0.0.0` for all interfaces) |
+| `-poll-interval` | `5s` | How often the UI polls for new receipts. Also honoured via `AR_DASHBOARD_POLL_INTERVAL`. |
 
 ```sh
 # Reads ~/.local/share/agent-receipts/receipts.db by default
@@ -69,10 +70,14 @@ dashboard -db ./my-receipts.db
 
 # Custom port and bind address
 dashboard -host 0.0.0.0 -port 9090
+
+# Slower live polling (env var also works: AR_DASHBOARD_POLL_INTERVAL=10s)
+dashboard -poll-interval 10s
 ```
 
 ## Features
 
+- **Live updates** — new receipts stream into the list without a manual refresh; polling pauses when the tab is hidden
 - **Read-only** — opens the SQLite database in read-only mode and never modifies your data
 - **Universal** — reads databases produced by any Agent Receipts SDK (Go, TypeScript, Python) or MCP proxy
 - **Filter** — narrow receipts by action type, risk level, status, time range, and chain ID

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -11,10 +11,15 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"time"
 
 	"github.com/agent-receipts/dashboard/internal/server"
 	"github.com/agent-receipts/dashboard/internal/store"
 )
+
+// pollIntervalEnv is the environment variable used to override the default
+// live-polling cadence. Parsed as a Go time.Duration.
+const pollIntervalEnv = "AR_DASHBOARD_POLL_INTERVAL"
 
 // version is set at build time via -ldflags "-X main.version=vX.Y.Z".
 // Falls back to the module version from Go's build info (set automatically
@@ -47,6 +52,23 @@ func xdgDataHome() string {
 	return filepath.Join(home, ".local", "share")
 }
 
+// resolvePollInterval returns the polling cadence from the environment if set,
+// otherwise the server default. An empty env var is treated as unset.
+func resolvePollInterval() (time.Duration, error) {
+	v := os.Getenv(pollIntervalEnv)
+	if v == "" {
+		return server.DefaultPollInterval, nil
+	}
+	d, err := time.ParseDuration(v)
+	if err != nil {
+		return 0, err
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("must be positive, got %s", d)
+	}
+	return d, nil
+}
+
 // defaultDBPath returns the conventional ~/.local/share/agent-receipts/receipts.db
 // shared by mcp-proxy, daemon, and hook. Returns "" if the data home directory
 // cannot be resolved; main surfaces a clear error in that case.
@@ -68,10 +90,19 @@ func main() {
 	}
 
 	defaultDB := defaultDBPath()
+	defaultPoll, err := resolvePollInterval()
+	if err != nil {
+		log.Fatalf("invalid %s: %v", pollIntervalEnv, err)
+	}
 	dbPath := flag.String("db", defaultDB, "path to receipts SQLite database")
 	host := flag.String("host", "127.0.0.1", "address to bind to (use 0.0.0.0 for all interfaces)")
 	port := flag.Int("port", 8080, "HTTP server port")
+	pollInterval := flag.Duration("poll-interval", defaultPoll, "interval between live receipt polls (e.g. 5s)")
 	flag.Parse()
+
+	if *pollInterval <= 0 {
+		log.Fatalf("poll-interval must be positive, got %s", *pollInterval)
+	}
 
 	dbExplicit := false
 	flag.Visit(func(f *flag.Flag) {
@@ -98,10 +129,11 @@ func main() {
 	}
 	defer reader.Close()
 
-	srv := server.New(reader)
+	srv := server.New(reader, server.Config{PollInterval: *pollInterval})
 	addr := fmt.Sprintf("%s:%d", *host, *port)
 	log.Printf("dashboard listening on http://%s", addr)
 	log.Printf("reading from %s (read-only)", *dbPath)
+	log.Printf("polling for new receipts every %s", *pollInterval)
 
 	if err := http.ListenAndServe(addr, srv.Handler()); err != nil {
 		log.Fatalf("server: %v", err)

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -69,6 +69,26 @@ func resolvePollInterval() (time.Duration, error) {
 	return d, nil
 }
 
+// choosePollInterval applies the flag > env > default precedence. When the
+// flag was set explicitly its value wins outright, so a malformed env var
+// can't lock a user out of an otherwise valid configuration.
+func choosePollInterval(flagValue time.Duration, flagSet bool, fromEnv func() (time.Duration, error)) (time.Duration, error) {
+	if flagSet {
+		if flagValue <= 0 {
+			return 0, fmt.Errorf("poll-interval must be positive, got %s", flagValue)
+		}
+		return flagValue, nil
+	}
+	d, err := fromEnv()
+	if err != nil {
+		return 0, fmt.Errorf("invalid %s: %w", pollIntervalEnv, err)
+	}
+	if d <= 0 {
+		return 0, fmt.Errorf("poll-interval must be positive, got %s", d)
+	}
+	return d, nil
+}
+
 // defaultDBPath returns the conventional ~/.local/share/agent-receipts/receipts.db
 // shared by mcp-proxy, daemon, and hook. Returns "" if the data home directory
 // cannot be resolved; main surfaces a clear error in that case.
@@ -90,26 +110,27 @@ func main() {
 	}
 
 	defaultDB := defaultDBPath()
-	defaultPoll, err := resolvePollInterval()
-	if err != nil {
-		log.Fatalf("invalid %s: %v", pollIntervalEnv, err)
-	}
 	dbPath := flag.String("db", defaultDB, "path to receipts SQLite database")
 	host := flag.String("host", "127.0.0.1", "address to bind to (use 0.0.0.0 for all interfaces)")
 	port := flag.Int("port", 8080, "HTTP server port")
-	pollInterval := flag.Duration("poll-interval", defaultPoll, "interval between live receipt polls (e.g. 5s)")
+	pollInterval := flag.Duration("poll-interval", server.DefaultPollInterval, "interval between live receipt polls (e.g. 5s)")
 	flag.Parse()
 
-	if *pollInterval <= 0 {
-		log.Fatalf("poll-interval must be positive, got %s", *pollInterval)
-	}
-
+	pollFlagSet := false
 	dbExplicit := false
 	flag.Visit(func(f *flag.Flag) {
-		if f.Name == "db" {
+		switch f.Name {
+		case "poll-interval":
+			pollFlagSet = true
+		case "db":
 			dbExplicit = true
 		}
 	})
+	chosen, err := choosePollInterval(*pollInterval, pollFlagSet, resolvePollInterval)
+	if err != nil {
+		log.Fatal(err)
+	}
+	*pollInterval = chosen
 
 	if *dbPath == "" {
 		if defaultDB == "" {

--- a/cmd/dashboard/main_test.go
+++ b/cmd/dashboard/main_test.go
@@ -52,6 +52,75 @@ func TestDefaultDBPath(t *testing.T) {
 	}
 }
 
+func TestChoosePollInterval(t *testing.T) {
+	envErr := errors.New("boom")
+	good := func(d time.Duration) func() (time.Duration, error) {
+		return func() (time.Duration, error) { return d, nil }
+	}
+	bad := func() (time.Duration, error) { return 0, envErr }
+
+	cases := []struct {
+		name      string
+		flagValue time.Duration
+		flagSet   bool
+		fromEnv   func() (time.Duration, error)
+		want      time.Duration
+		wantErr   bool
+	}{
+		{
+			name:      "flag wins over env even when env is broken",
+			flagValue: 7 * time.Second,
+			flagSet:   true,
+			fromEnv:   bad,
+			want:      7 * time.Second,
+		},
+		{
+			name:      "flag wins over env when both are valid",
+			flagValue: 7 * time.Second,
+			flagSet:   true,
+			fromEnv:   good(2 * time.Second),
+			want:      7 * time.Second,
+		},
+		{
+			name:      "non-positive flag is rejected",
+			flagValue: 0,
+			flagSet:   true,
+			fromEnv:   good(2 * time.Second),
+			wantErr:   true,
+		},
+		{
+			name:    "env is used when flag was not set",
+			flagSet: false,
+			fromEnv: good(3 * time.Second),
+			want:    3 * time.Second,
+		},
+		{
+			name:    "env error surfaces when flag was not set",
+			flagSet: false,
+			fromEnv: bad,
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := choosePollInterval(tc.flagValue, tc.flagSet, tc.fromEnv)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %s", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
+			}
+		})
+	}
+}
+
 func TestResolvePollInterval(t *testing.T) {
 	cases := []struct {
 		name    string

--- a/cmd/dashboard/main_test.go
+++ b/cmd/dashboard/main_test.go
@@ -4,6 +4,9 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/agent-receipts/dashboard/internal/server"
 )
 
 func TestDefaultDBPath(t *testing.T) {
@@ -44,6 +47,41 @@ func TestDefaultDBPath(t *testing.T) {
 			userHomeDir = func() (string, error) { return tc.home, tc.homeErr }
 			if got := defaultDBPath(); got != tc.want {
 				t.Errorf("defaultDBPath() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolvePollInterval(t *testing.T) {
+	cases := []struct {
+		name    string
+		env     string
+		want    time.Duration
+		wantErr bool
+	}{
+		{"unset uses server default", "", server.DefaultPollInterval, false},
+		{"valid duration is honoured", "2s", 2 * time.Second, false},
+		{"sub-second duration is honoured", "250ms", 250 * time.Millisecond, false},
+		{"unparseable rejected", "five seconds", 0, true},
+		{"zero rejected", "0s", 0, true},
+		{"negative rejected", "-1s", 0, true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Setenv(pollIntervalEnv, tc.env)
+			got, err := resolvePollInterval()
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got %s", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %s, want %s", got, tc.want)
 			}
 		})
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -64,8 +64,12 @@ func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
+	// server_time gives the frontend an authoritative watermark for live polling
+	// when the store is empty at load — relying on the client's wall clock would
+	// silently drop receipts whenever the two clocks disagree.
 	writeJSON(w, http.StatusOK, map[string]any{
 		"poll_interval_ms": s.cfg.PollInterval.Milliseconds(),
+		"server_time":      time.Now().UTC().Format(time.RFC3339),
 	})
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,10 +7,20 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"time"
 
 	"github.com/agent-receipts/dashboard/internal/store"
 	"github.com/agent-receipts/dashboard/internal/verify"
 )
+
+// DefaultPollInterval is the polling cadence used when none is configured.
+const DefaultPollInterval = 5 * time.Second
+
+// Config controls server behaviour exposed to the frontend.
+type Config struct {
+	// PollInterval is how often the dashboard polls /api/receipts for new rows.
+	PollInterval time.Duration
+}
 
 //go:embed static
 var staticFS embed.FS
@@ -18,11 +28,16 @@ var staticFS embed.FS
 // Server is the dashboard HTTP server.
 type Server struct {
 	reader *store.Reader
+	cfg    Config
 }
 
-// New creates a new Server backed by the given reader.
-func New(reader *store.Reader) *Server {
-	return &Server{reader: reader}
+// New creates a new Server backed by the given reader. A zero PollInterval
+// in cfg falls back to DefaultPollInterval.
+func New(reader *store.Reader, cfg Config) *Server {
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = DefaultPollInterval
+	}
+	return &Server{reader: reader, cfg: cfg}
 }
 
 // Handler returns the HTTP handler with all routes registered.
@@ -31,6 +46,7 @@ func (s *Server) Handler() http.Handler {
 
 	// API endpoints (JSON).
 	mux.HandleFunc("GET /api/health", s.handleHealth)
+	mux.HandleFunc("GET /api/config", s.handleConfig)
 	mux.HandleFunc("GET /api/stats", s.handleStats)
 	mux.HandleFunc("GET /api/receipts", s.handleReceipts)
 	mux.HandleFunc("GET /api/receipts/{id...}", s.handleReceiptDetail)
@@ -45,6 +61,12 @@ func (s *Server) Handler() http.Handler {
 
 func (s *Server) handleHealth(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+}
+
+func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
+	writeJSON(w, http.StatusOK, map[string]any{
+		"poll_interval_ms": s.cfg.PollInterval.Milliseconds(),
+	})
 }
 
 func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
@@ -78,6 +100,9 @@ func (s *Server) handleReceipts(w http.ResponseWriter, r *http.Request) {
 	}
 	if v := q.Get("before"); v != "" {
 		f.Before = &v
+	}
+	if v := q.Get("since"); v != "" {
+		f.Since = &v
 	}
 
 	rows, err := s.reader.ListReceipts(f)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
+	"time"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
 	sdkstore "github.com/agent-receipts/ar/sdk/go/store"
@@ -73,7 +74,7 @@ func setupServer(t *testing.T) *Server {
 		t.Fatalf("open reader: %v", err)
 	}
 	t.Cleanup(func() { reader.Close() })
-	return New(reader)
+	return New(reader, Config{})
 }
 
 func TestHealthEndpoint(t *testing.T) {
@@ -148,6 +149,70 @@ func TestReceiptsEndpoint_FilterByRisk(t *testing.T) {
 	}
 	if len(rows) != 1 {
 		t.Errorf("got %d high-risk rows, want 1", len(rows))
+	}
+}
+
+func TestReceiptsEndpoint_FilterBySince(t *testing.T) {
+	srv := setupServer(t)
+	req := httptest.NewRequest("GET", "/api/receipts?since=2026-04-01T10:01:00Z", nil)
+	w := httptest.NewRecorder()
+
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200", w.Code)
+	}
+
+	var rows []store.ReceiptRow
+	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	// since is exclusive: only the receipt strictly newer than the watermark.
+	if len(rows) != 1 {
+		t.Errorf("got %d rows, want 1", len(rows))
+	}
+	if len(rows) > 0 && rows[0].ID != "urn:receipt:003" {
+		t.Errorf("got ID %q, want urn:receipt:003", rows[0].ID)
+	}
+}
+
+func TestConfigEndpoint(t *testing.T) {
+	dbPath := seedTestDB(t)
+	reader, err := store.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { reader.Close() })
+
+	cases := []struct {
+		name   string
+		cfg    Config
+		wantMs int64
+	}{
+		{"zero falls back to default", Config{}, DefaultPollInterval.Milliseconds()},
+		{"explicit interval is echoed", Config{PollInterval: 2500 * time.Millisecond}, 2500},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := New(reader, tc.cfg)
+			req := httptest.NewRequest("GET", "/api/config", nil)
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("got status %d, want 200", w.Code)
+			}
+			var got struct {
+				PollIntervalMs int64 `json:"poll_interval_ms"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got.PollIntervalMs != tc.wantMs {
+				t.Errorf("poll_interval_ms = %d, want %d", got.PollIntervalMs, tc.wantMs)
+			}
+		})
 	}
 }
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -167,12 +167,15 @@ func TestReceiptsEndpoint_FilterBySince(t *testing.T) {
 	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
-	// since is exclusive: only the receipt strictly newer than the watermark.
-	if len(rows) != 1 {
-		t.Errorf("got %d rows, want 1", len(rows))
+	// since is inclusive: the row at the boundary plus everything newer.
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
 	}
-	if len(rows) > 0 && rows[0].ID != "urn:receipt:003" {
-		t.Errorf("got ID %q, want urn:receipt:003", rows[0].ID)
+	gotIDs := map[string]bool{rows[0].ID: true, rows[1].ID: true}
+	for _, want := range []string{"urn:receipt:002", "urn:receipt:003"} {
+		if !gotIDs[want] {
+			t.Errorf("missing %s in response", want)
+		}
 	}
 }
 
@@ -204,13 +207,17 @@ func TestConfigEndpoint(t *testing.T) {
 				t.Fatalf("got status %d, want 200", w.Code)
 			}
 			var got struct {
-				PollIntervalMs int64 `json:"poll_interval_ms"`
+				PollIntervalMs int64  `json:"poll_interval_ms"`
+				ServerTime     string `json:"server_time"`
 			}
 			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
 				t.Fatalf("decode: %v", err)
 			}
 			if got.PollIntervalMs != tc.wantMs {
 				t.Errorf("poll_interval_ms = %d, want %d", got.PollIntervalMs, tc.wantMs)
+			}
+			if _, err := time.Parse(time.RFC3339, got.ServerTime); err != nil {
+				t.Errorf("server_time %q is not RFC3339: %v", got.ServerTime, err)
 			}
 		})
 	}

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -222,9 +222,11 @@
         renderStats(stats);
         const receipts = await fetchJSON('/api/receipts');
         if (gen !== poller.generation) return;
-        const recent = receipts.slice(0, RECENT_LIMIT);
-        renderRecentReceipts(recent);
-        startPolling('overview', 'recent-receipts', recent, () => ({}));
+        renderRecentReceipts(receipts.slice(0, RECENT_LIMIT));
+        // Seed polling from the full fetch, not the displayed slice, so the
+        // next poll doesn't surface receipts that share the watermark
+        // second but fell below RECENT_LIMIT in tie-ordering.
+        startPolling('overview', 'recent-receipts', receipts, () => ({}));
       } catch (err) {
         console.error('load overview:', err);
       }
@@ -648,9 +650,16 @@
 
     function prependFreshRows(fresh) {
       const tbody = document.getElementById(tbodyIdFor(poller.containerId));
+      // Sort newest-first so the prepended block keeps the table's descending order.
+      const sorted = fresh.slice().sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1));
+
       if (!tbody) {
-        // Container was re-rendered as the empty state; rebuild it.
-        renderReceiptsTable(fresh, poller.containerId);
+        // Container was re-rendered as the empty state; rebuild it. The
+        // overview is still capped at RECENT_LIMIT visible rows, but every
+        // fresh id goes into knownIds so the next poll won't re-flash the
+        // ones we didn't display.
+        const toRender = poller.activeView === 'overview' ? sorted.slice(0, RECENT_LIMIT) : sorted;
+        renderReceiptsTable(toRender, poller.containerId);
         fresh.forEach(r => poller.knownIds.add(r.id));
         bumpWatermark(fresh);
         if (poller.activeView === 'overview') refreshOverviewStats();
@@ -658,8 +667,6 @@
         return;
       }
 
-      // Sort newest-first so the prepended block keeps the table's descending order.
-      const sorted = fresh.slice().sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1));
       const html = sorted.map(r => receiptRowHTML(r, { flash: true })).join('');
       tbody.insertAdjacentHTML('afterbegin', html);
       sorted.forEach(r => poller.knownIds.add(r.id));

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -186,6 +186,7 @@
 
     const poller = {
       intervalMs: POLL_FALLBACK_MS,
+      serverTime: null,        // ISO timestamp returned by /api/config, used as empty-store baseline
       timer: null,
       activeView: null,        // 'overview' | 'receipts' | null
       containerId: null,       // tbody container id for the active view
@@ -193,6 +194,10 @@
       watermark: null,         // ISO timestamp of newest row currently displayed
       knownIds: new Set(),     // dedup across polls
       emptyCount: 0,
+      // generation invalidates in-flight requests after a view/filter change.
+      // Both loadOverview/loadReceipts and pollOnce capture it before awaiting
+      // and bail on mismatch so stale responses can't pollute the new view.
+      generation: 0,
     };
 
     // View switching
@@ -210,15 +215,28 @@
 
     // Overview
     async function loadOverview() {
+      const gen = ++poller.generation;
       try {
         const stats = await fetchJSON('/api/stats');
+        if (gen !== poller.generation) return;
         renderStats(stats);
         const receipts = await fetchJSON('/api/receipts');
+        if (gen !== poller.generation) return;
         const recent = receipts.slice(0, RECENT_LIMIT);
         renderRecentReceipts(recent);
         startPolling('overview', 'recent-receipts', recent, () => ({}));
       } catch (err) {
         console.error('load overview:', err);
+      }
+    }
+
+    async function refreshOverviewStats() {
+      try {
+        const stats = await fetchJSON('/api/stats');
+        if (poller.activeView !== 'overview') return;
+        renderStats(stats);
+      } catch (err) {
+        console.warn('refresh stats:', err);
       }
     }
 
@@ -304,8 +322,10 @@
       const params = new URLSearchParams(filters);
 
       stopPolling();
+      const gen = ++poller.generation;
       try {
         const receipts = await fetchJSON('/api/receipts?' + params.toString());
+        if (gen !== poller.generation) return;
         renderReceiptsTable(receipts, 'receipts-table');
         startPolling('receipts', 'receipts-table', receipts, currentReceiptFilters);
       } catch (err) {
@@ -556,6 +576,7 @@
     // Live polling
     function startPolling(view, containerId, initialRows, filtersFn) {
       stopPolling();
+      poller.generation++;
       poller.activeView = view;
       poller.containerId = containerId;
       poller.filtersFn = filtersFn;
@@ -564,9 +585,9 @@
         (max, r) => (r.timestamp && r.timestamp > max) ? r.timestamp : max,
         '',
       );
-      // Fall back to "now" when there's no baseline so an empty store still
-      // picks up the first real receipt that arrives after page load.
-      poller.watermark = maxSeen || new Date().toISOString();
+      // Prefer the server clock when there's no baseline so an empty store
+      // still picks up new receipts even if the browser clock is skewed.
+      poller.watermark = maxSeen || poller.serverTime || new Date().toISOString();
       poller.emptyCount = 0;
       schedulePoll(poller.intervalMs);
     }
@@ -596,19 +617,23 @@
     async function pollOnce() {
       if (!poller.activeView) return;
       if (document.visibilityState !== 'visible') return; // resumed by visibilitychange
+      const gen = poller.generation;
       const params = new URLSearchParams(poller.filtersFn ? poller.filtersFn() : {});
       params.set('since', poller.watermark);
       let rows;
       try {
         rows = await fetchJSON('/api/receipts?' + params.toString());
       } catch (err) {
+        if (gen !== poller.generation) return;
         console.error('poll:', err);
         poller.emptyCount++;
         schedulePoll(nextPollDelay());
         return;
       }
 
-      // The view or filters may have changed while the request was in flight.
+      // The view or filters may have changed while the request was in flight;
+      // a stale response must not pollute the freshly-rendered table.
+      if (gen !== poller.generation) return;
       if (!poller.activeView) return;
 
       const fresh = (rows || []).filter(r => !poller.knownIds.has(r.id));
@@ -628,6 +653,7 @@
         renderReceiptsTable(fresh, poller.containerId);
         fresh.forEach(r => poller.knownIds.add(r.id));
         bumpWatermark(fresh);
+        if (poller.activeView === 'overview') refreshOverviewStats();
         showLiveToast(fresh.length);
         return;
       }
@@ -639,7 +665,7 @@
       sorted.forEach(r => poller.knownIds.add(r.id));
       bumpWatermark(sorted);
 
-      // Overview keeps the recent list bounded.
+      // Overview keeps the recent list bounded and its stats in sync.
       if (poller.activeView === 'overview') {
         while (tbody.rows.length > RECENT_LIMIT) {
           const dropped = tbody.rows[tbody.rows.length - 1];
@@ -647,6 +673,7 @@
           if (id) poller.knownIds.delete(id);
           dropped.remove();
         }
+        refreshOverviewStats();
       }
 
       showLiveToast(fresh.length);
@@ -683,8 +710,12 @@
     async function loadPollConfig() {
       try {
         const cfg = await fetchJSON('/api/config');
-        if (cfg && Number.isFinite(cfg.poll_interval_ms) && cfg.poll_interval_ms > 0) {
+        if (!cfg) return;
+        if (Number.isFinite(cfg.poll_interval_ms) && cfg.poll_interval_ms > 0) {
           poller.intervalMs = cfg.poll_interval_ms;
+        }
+        if (typeof cfg.server_time === 'string' && cfg.server_time) {
+          poller.serverTime = cfg.server_time;
         }
       } catch (err) {
         console.warn('config:', err);

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -53,6 +53,22 @@
       border-radius: 6px; padding: 6px 10px; font-size: 0.875rem;
     }
     select:focus, input[type="text"]:focus { outline: none; border-color: #58a6ff; }
+
+    @keyframes row-flash {
+      0% { background-color: rgba(88,166,255,0.25); }
+      100% { background-color: transparent; }
+    }
+    tr.row-new { animation: row-flash 2.5s ease-out; }
+
+    #live-toast {
+      position: fixed; bottom: 20px; right: 20px; z-index: 60;
+      background: #161b22; border: 1px solid #30363d; border-left: 3px solid #58a6ff;
+      color: #e6edf3; font-size: 0.875rem; padding: 8px 14px; border-radius: 6px;
+      box-shadow: 0 4px 12px rgba(0,0,0,0.4);
+      opacity: 0; transform: translateY(10px); pointer-events: none;
+      transition: opacity 0.2s ease, transform 0.2s ease;
+    }
+    #live-toast.show { opacity: 1; transform: translateY(0); }
   </style>
 </head>
 <body class="min-h-screen">
@@ -131,6 +147,9 @@
       <div id="chains-list"></div>
     </div>
 
+    <!-- Live polling toast -->
+    <div id="live-toast" role="status" aria-live="polite"></div>
+
     <!-- Receipt detail modal -->
     <div id="receipt-modal" class="hidden fixed inset-0 bg-black/60 z-50 flex items-start justify-center pt-16 px-4">
       <div class="bg-[#161b22] border border-[#30363d] rounded-lg w-full max-w-3xl max-h-[80vh] overflow-y-auto">
@@ -158,6 +177,24 @@
     // State
     let debounceTimer = null;
 
+    // Live polling state. The poller tails /api/receipts using `since=<timestamp>`
+    // and prepends fresh rows into whichever view is currently visible.
+    const POLL_FALLBACK_MS = 5000;
+    const POLL_BACKOFF_AFTER_EMPTY = 3;
+    const POLL_MAX_INTERVAL_MS = 30000;
+    const RECENT_LIMIT = 10;
+
+    const poller = {
+      intervalMs: POLL_FALLBACK_MS,
+      timer: null,
+      activeView: null,        // 'overview' | 'receipts' | null
+      containerId: null,       // tbody container id for the active view
+      filtersFn: null,         // () => object of query params (filters)
+      watermark: null,         // ISO timestamp of newest row currently displayed
+      knownIds: new Set(),     // dedup across polls
+      emptyCount: 0,
+    };
+
     // View switching
     function showView(view) {
       document.querySelectorAll('[id^="view-"]').forEach(el => el.classList.add('hidden'));
@@ -165,6 +202,7 @@
       document.getElementById('view-' + view).classList.remove('hidden');
       document.getElementById('tab-' + view).classList.add('active');
 
+      stopPolling();
       if (view === 'overview') loadOverview();
       if (view === 'receipts') loadReceipts();
       if (view === 'chains') loadChains();
@@ -176,7 +214,9 @@
         const stats = await fetchJSON('/api/stats');
         renderStats(stats);
         const receipts = await fetchJSON('/api/receipts');
-        renderRecentReceipts(receipts.slice(0, 10));
+        const recent = receipts.slice(0, RECENT_LIMIT);
+        renderRecentReceipts(recent);
+        startPolling('overview', 'recent-receipts', recent, () => ({}));
       } catch (err) {
         console.error('load overview:', err);
       }
@@ -246,21 +286,28 @@
       debounceTimer = setTimeout(loadReceipts, 300);
     }
 
-    async function loadReceipts() {
-      const params = new URLSearchParams();
+    function currentReceiptFilters() {
+      const filters = {};
       const risk = document.getElementById('filter-risk').value;
       const status = document.getElementById('filter-status').value;
       const action = document.getElementById('filter-action').value;
       const chain = document.getElementById('filter-chain').value;
+      if (risk) filters.risk_level = risk;
+      if (status) filters.status = status;
+      if (action) filters.action_type = action;
+      if (chain) filters.chain_id = chain;
+      return filters;
+    }
 
-      if (risk) params.set('risk_level', risk);
-      if (status) params.set('status', status);
-      if (action) params.set('action_type', action);
-      if (chain) params.set('chain_id', chain);
+    async function loadReceipts() {
+      const filters = currentReceiptFilters();
+      const params = new URLSearchParams(filters);
 
+      stopPolling();
       try {
         const receipts = await fetchJSON('/api/receipts?' + params.toString());
         renderReceiptsTable(receipts, 'receipts-table');
+        startPolling('receipts', 'receipts-table', receipts, currentReceiptFilters);
       } catch (err) {
         console.error('load receipts:', err);
       }
@@ -268,6 +315,26 @@
 
     function renderRecentReceipts(receipts) {
       renderReceiptsTable(receipts, 'recent-receipts');
+    }
+
+    function receiptRowHTML(r, opts) {
+      const flash = opts && opts.flash ? ' row-new' : '';
+      return `
+        <tr class="border-b border-[#30363d]/50 hover:bg-[#1c2128] cursor-pointer${flash}" data-receipt-id="${escapeHtml(r.id)}" onclick="showReceipt(this.dataset.receiptId)">
+          <td class="py-2 pr-4 text-[#7d8590] whitespace-nowrap">${formatTime(r.timestamp)}</td>
+          <td class="py-2 pr-4 font-mono text-xs text-[#7d8590]">${r.server ? escapeHtml(r.server) : '<span class="text-[#484f58]">—</span>'}</td>
+          <td class="py-2 pr-4 font-mono text-xs">${r.tool_name ? escapeHtml(r.tool_name) : '<span class="text-[#484f58]">—</span>'}</td>
+          <td class="py-2 pr-4 font-mono text-xs">${escapeHtml(r.action_type)}</td>
+          <td class="py-2 pr-4"><span class="badge ${riskClass(r.risk_level)}">${escapeHtml(r.risk_level)}</span></td>
+          <td class="py-2 pr-4"><span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span></td>
+          <td class="py-2 pr-4 text-[#7d8590] font-mono text-xs cursor-pointer hover:text-[#58a6ff]" data-chain-id="${escapeHtml(r.chain_id)}" onclick="event.stopPropagation(); showChain(this.dataset.chainId)">${truncate(r.chain_id, 20)}</td>
+          <td class="py-2 pr-4 text-[#7d8590]">#${r.sequence}</td>
+        </tr>
+      `;
+    }
+
+    function tbodyIdFor(containerId) {
+      return 'tbody-' + containerId;
     }
 
     function renderReceiptsTable(receipts, containerId) {
@@ -290,19 +357,8 @@
                 <th class="pb-2 pr-4">Seq</th>
               </tr>
             </thead>
-            <tbody>
-              ${receipts.map(r => `
-                <tr class="border-b border-[#30363d]/50 hover:bg-[#1c2128] cursor-pointer" data-receipt-id="${escapeHtml(r.id)}" onclick="showReceipt(this.dataset.receiptId)">
-                  <td class="py-2 pr-4 text-[#7d8590] whitespace-nowrap">${formatTime(r.timestamp)}</td>
-                  <td class="py-2 pr-4 font-mono text-xs text-[#7d8590]">${r.server ? escapeHtml(r.server) : '<span class="text-[#484f58]">—</span>'}</td>
-                  <td class="py-2 pr-4 font-mono text-xs">${r.tool_name ? escapeHtml(r.tool_name) : '<span class="text-[#484f58]">—</span>'}</td>
-                  <td class="py-2 pr-4 font-mono text-xs">${escapeHtml(r.action_type)}</td>
-                  <td class="py-2 pr-4"><span class="badge ${riskClass(r.risk_level)}">${escapeHtml(r.risk_level)}</span></td>
-                  <td class="py-2 pr-4"><span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span></td>
-                  <td class="py-2 pr-4 text-[#7d8590] font-mono text-xs cursor-pointer hover:text-[#58a6ff]" data-chain-id="${escapeHtml(r.chain_id)}" onclick="event.stopPropagation(); showChain(this.dataset.chainId)">${truncate(r.chain_id, 20)}</td>
-                  <td class="py-2 pr-4 text-[#7d8590]">#${r.sequence}</td>
-                </tr>
-              `).join('')}
+            <tbody id="${tbodyIdFor(containerId)}">
+              ${receipts.map(r => receiptRowHTML(r)).join('')}
             </tbody>
           </table>
         </div>
@@ -497,6 +553,144 @@
       document.getElementById('chain-modal').classList.add('hidden');
     }
 
+    // Live polling
+    function startPolling(view, containerId, initialRows, filtersFn) {
+      stopPolling();
+      poller.activeView = view;
+      poller.containerId = containerId;
+      poller.filtersFn = filtersFn;
+      poller.knownIds = new Set((initialRows || []).map(r => r.id));
+      const maxSeen = (initialRows || []).reduce(
+        (max, r) => (r.timestamp && r.timestamp > max) ? r.timestamp : max,
+        '',
+      );
+      // Fall back to "now" when there's no baseline so an empty store still
+      // picks up the first real receipt that arrives after page load.
+      poller.watermark = maxSeen || new Date().toISOString();
+      poller.emptyCount = 0;
+      schedulePoll(poller.intervalMs);
+    }
+
+    function stopPolling() {
+      if (poller.timer) {
+        clearTimeout(poller.timer);
+        poller.timer = null;
+      }
+      poller.activeView = null;
+      poller.containerId = null;
+      poller.filtersFn = null;
+    }
+
+    function schedulePoll(delay) {
+      if (poller.timer) clearTimeout(poller.timer);
+      poller.timer = setTimeout(pollOnce, delay);
+    }
+
+    function nextPollDelay() {
+      if (poller.emptyCount < POLL_BACKOFF_AFTER_EMPTY) return poller.intervalMs;
+      // Exponential backoff once the stream goes quiet, capped at POLL_MAX_INTERVAL_MS.
+      const factor = Math.pow(2, poller.emptyCount - POLL_BACKOFF_AFTER_EMPTY + 1);
+      return Math.min(poller.intervalMs * factor, POLL_MAX_INTERVAL_MS);
+    }
+
+    async function pollOnce() {
+      if (!poller.activeView) return;
+      if (document.visibilityState !== 'visible') return; // resumed by visibilitychange
+      const params = new URLSearchParams(poller.filtersFn ? poller.filtersFn() : {});
+      params.set('since', poller.watermark);
+      let rows;
+      try {
+        rows = await fetchJSON('/api/receipts?' + params.toString());
+      } catch (err) {
+        console.error('poll:', err);
+        poller.emptyCount++;
+        schedulePoll(nextPollDelay());
+        return;
+      }
+
+      // The view or filters may have changed while the request was in flight.
+      if (!poller.activeView) return;
+
+      const fresh = (rows || []).filter(r => !poller.knownIds.has(r.id));
+      if (fresh.length === 0) {
+        poller.emptyCount++;
+      } else {
+        prependFreshRows(fresh);
+        poller.emptyCount = 0;
+      }
+      schedulePoll(nextPollDelay());
+    }
+
+    function prependFreshRows(fresh) {
+      const tbody = document.getElementById(tbodyIdFor(poller.containerId));
+      if (!tbody) {
+        // Container was re-rendered as the empty state; rebuild it.
+        renderReceiptsTable(fresh, poller.containerId);
+        fresh.forEach(r => poller.knownIds.add(r.id));
+        bumpWatermark(fresh);
+        showLiveToast(fresh.length);
+        return;
+      }
+
+      // Sort newest-first so the prepended block keeps the table's descending order.
+      const sorted = fresh.slice().sort((a, b) => (a.timestamp < b.timestamp ? 1 : -1));
+      const html = sorted.map(r => receiptRowHTML(r, { flash: true })).join('');
+      tbody.insertAdjacentHTML('afterbegin', html);
+      sorted.forEach(r => poller.knownIds.add(r.id));
+      bumpWatermark(sorted);
+
+      // Overview keeps the recent list bounded.
+      if (poller.activeView === 'overview') {
+        while (tbody.rows.length > RECENT_LIMIT) {
+          const dropped = tbody.rows[tbody.rows.length - 1];
+          const id = dropped.dataset.receiptId;
+          if (id) poller.knownIds.delete(id);
+          dropped.remove();
+        }
+      }
+
+      showLiveToast(fresh.length);
+    }
+
+    function bumpWatermark(rows) {
+      poller.watermark = rows.reduce(
+        (max, r) => (r.timestamp && r.timestamp > max) ? r.timestamp : max,
+        poller.watermark || '',
+      );
+    }
+
+    let liveToastTimer = null;
+    function showLiveToast(count) {
+      const el = document.getElementById('live-toast');
+      if (!el) return;
+      el.textContent = count === 1 ? '1 new receipt' : `${count} new receipts`;
+      el.classList.add('show');
+      if (liveToastTimer) clearTimeout(liveToastTimer);
+      liveToastTimer = setTimeout(() => el.classList.remove('show'), 2500);
+    }
+
+    document.addEventListener('visibilitychange', () => {
+      if (!poller.activeView) return;
+      if (document.visibilityState === 'visible') {
+        poller.emptyCount = 0;
+        schedulePoll(0); // catch up immediately
+      } else if (poller.timer) {
+        clearTimeout(poller.timer);
+        poller.timer = null;
+      }
+    });
+
+    async function loadPollConfig() {
+      try {
+        const cfg = await fetchJSON('/api/config');
+        if (cfg && Number.isFinite(cfg.poll_interval_ms) && cfg.poll_interval_ms > 0) {
+          poller.intervalMs = cfg.poll_interval_ms;
+        }
+      } catch (err) {
+        console.warn('config:', err);
+      }
+    }
+
     // Utilities
     async function fetchJSON(url) {
       const res = await fetch(url);
@@ -549,7 +743,7 @@
     });
 
     // Boot
-    loadOverview();
+    loadPollConfig().then(loadOverview);
   </script>
 </body>
 </html>

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -349,7 +349,7 @@
           <td class="py-2 pr-4 font-mono text-xs">${escapeHtml(r.action_type)}</td>
           <td class="py-2 pr-4"><span class="badge ${riskClass(r.risk_level)}">${escapeHtml(r.risk_level)}</span></td>
           <td class="py-2 pr-4"><span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span></td>
-          <td class="py-2 pr-4 text-[#7d8590] font-mono text-xs cursor-pointer hover:text-[#58a6ff]" data-chain-id="${escapeHtml(r.chain_id)}" onclick="event.stopPropagation(); showChain(this.dataset.chainId)">${truncate(r.chain_id, 20)}</td>
+          <td class="py-2 pr-4 text-[#7d8590] font-mono text-xs cursor-pointer hover:text-[#58a6ff]" data-chain-id="${escapeHtml(r.chain_id)}" onclick="event.stopPropagation(); showChain(this.dataset.chainId)">${escapeHtml(truncate(r.chain_id, 20))}</td>
           <td class="py-2 pr-4 text-[#7d8590]">#${r.sequence}</td>
         </tr>
       `;
@@ -675,10 +675,12 @@
       // Overview keeps the recent list bounded and its stats in sync.
       if (poller.activeView === 'overview') {
         while (tbody.rows.length > RECENT_LIMIT) {
-          const dropped = tbody.rows[tbody.rows.length - 1];
-          const id = dropped.dataset.receiptId;
-          if (id) poller.knownIds.delete(id);
-          dropped.remove();
+          // Trim from the DOM only — leave the id in knownIds. Removing it
+          // would re-flash boundary-timestamp rows on the next inclusive
+          // `since` poll. knownIds growth is bounded by traffic volume; the
+          // overview's only callers are the initial fetch (≤ store limit)
+          // and live polls (≤ store limit per call).
+          tbody.rows[tbody.rows.length - 1].remove();
         }
         refreshOverviewStats();
       }

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -66,6 +66,7 @@ type Filter struct {
 	Status     *string
 	After      *string // ISO 8601 timestamp, inclusive
 	Before     *string // ISO 8601 timestamp, inclusive
+	Since      *string // ISO 8601 timestamp, exclusive — watermark for live polling
 	Limit      *int
 }
 
@@ -147,6 +148,10 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 	if f.Before != nil {
 		conds = append(conds, "timestamp <= ?")
 		args = append(args, *f.Before)
+	}
+	if f.Since != nil {
+		conds = append(conds, "timestamp > ?")
+		args = append(args, *f.Since)
 	}
 
 	where := ""

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -167,6 +167,17 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		limit = *f.Limit
 	}
 
+	// When Since is set we are acting as a chronological tail: order ASC so a
+	// burst larger than the LIMIT is drained correctly across successive polls
+	// (the client advances the watermark to the newest returned row, and the
+	// next call picks up from there). DESC + LIMIT would silently skip the
+	// middle of an overflow. The id tie-break keeps the order deterministic
+	// across rows that share a timestamp.
+	orderBy := "timestamp DESC"
+	if f.Since != nil {
+		orderBy = "timestamp ASC, id ASC"
+	}
+
 	query := fmt.Sprintf(
 		`SELECT id, chain_id, sequence, action_type,
 		        COALESCE(tool_name, ''),
@@ -174,8 +185,8 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		        risk_level, status,
 		        timestamp, issuer_id, COALESCE(principal_id, ''),
 		        receipt_hash, COALESCE(previous_receipt_hash, '')
-		 FROM receipts %s ORDER BY timestamp DESC LIMIT ?`,
-		where,
+		 FROM receipts %s ORDER BY %s LIMIT ?`,
+		where, orderBy,
 	)
 	args = append(args, limit)
 

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -66,7 +66,7 @@ type Filter struct {
 	Status     *string
 	After      *string // ISO 8601 timestamp, inclusive
 	Before     *string // ISO 8601 timestamp, inclusive
-	Since      *string // ISO 8601 timestamp, exclusive — watermark for live polling
+	Since      *string // ISO 8601 timestamp, inclusive — watermark for live polling; clients dedup by id
 	Limit      *int
 }
 
@@ -150,7 +150,10 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		args = append(args, *f.Before)
 	}
 	if f.Since != nil {
-		conds = append(conds, "timestamp > ?")
+		// Inclusive so receipts that share a second with the watermark aren't
+		// silently lost when timestamps lack sub-second precision; the client
+		// dedups by id.
+		conds = append(conds, "timestamp >= ?")
 		args = append(args, *f.Since)
 	}
 

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -218,6 +218,39 @@ func TestReader_ListReceipts_FilterByTimeRange(t *testing.T) {
 	}
 }
 
+func TestReader_ListReceipts_FilterBySince(t *testing.T) {
+	dbPath := seedFileDB(t)
+	r, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer r.Close()
+
+	// Since is exclusive: a watermark equal to a row's timestamp must not
+	// re-emit that row (otherwise live polling would surface duplicates).
+	rows, err := r.ListReceipts(Filter{Since: strPtr("2026-04-01T10:01:00Z")})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+	for _, row := range rows {
+		if row.Timestamp <= "2026-04-01T10:01:00Z" {
+			t.Errorf("row %s has timestamp %q, want strictly greater than watermark", row.ID, row.Timestamp)
+		}
+	}
+
+	// A watermark at or beyond the newest row returns nothing.
+	rows, err = r.ListReceipts(Filter{Since: strPtr("2026-04-01T11:01:00Z")})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("got %d rows, want 0", len(rows))
+	}
+}
+
 func TestReader_ListReceipts_Limit(t *testing.T) {
 	dbPath := seedFileDB(t)
 	r, err := OpenReadOnly(dbPath)

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -226,23 +226,32 @@ func TestReader_ListReceipts_FilterBySince(t *testing.T) {
 	}
 	defer r.Close()
 
-	// Since is exclusive: a watermark equal to a row's timestamp must not
-	// re-emit that row (otherwise live polling would surface duplicates).
+	// Since is inclusive: a row whose timestamp equals the watermark must be
+	// returned so callers don't silently lose receipts that share a second
+	// with the boundary (timestamps may have only second precision). The
+	// client dedups against the rows it already shows.
 	rows, err := r.ListReceipts(Filter{Since: strPtr("2026-04-01T10:01:00Z")})
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	if len(rows) != 3 {
-		t.Fatalf("got %d rows, want 3", len(rows))
+	if len(rows) != 4 {
+		t.Fatalf("got %d rows, want 4", len(rows))
 	}
+	var sawBoundary bool
 	for _, row := range rows {
-		if row.Timestamp <= "2026-04-01T10:01:00Z" {
-			t.Errorf("row %s has timestamp %q, want strictly greater than watermark", row.ID, row.Timestamp)
+		if row.Timestamp < "2026-04-01T10:01:00Z" {
+			t.Errorf("row %s has timestamp %q, want >= watermark", row.ID, row.Timestamp)
+		}
+		if row.ID == "urn:receipt:002" {
+			sawBoundary = true
 		}
 	}
+	if !sawBoundary {
+		t.Error("inclusive watermark must re-emit the row at the boundary")
+	}
 
-	// A watermark at or beyond the newest row returns nothing.
-	rows, err = r.ListReceipts(Filter{Since: strPtr("2026-04-01T11:01:00Z")})
+	// A watermark strictly newer than every row returns nothing.
+	rows, err = r.ListReceipts(Filter{Since: strPtr("2027-01-01T00:00:00Z")})
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -260,6 +260,57 @@ func TestReader_ListReceipts_FilterBySince(t *testing.T) {
 	}
 }
 
+func TestReader_ListReceipts_Since_DrainsBurstAcrossPolls(t *testing.T) {
+	// A burst larger than the LIMIT must not leak rows: with `Since` set the
+	// query orders ASC, so two successive polls (advancing the watermark)
+	// recover every row instead of dropping the middle of the range.
+	dbPath := seedFileDB(t)
+	r, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer r.Close()
+
+	since := "2026-04-01T10:00:00Z"
+	limit := 3
+
+	first, err := r.ListReceipts(Filter{Since: &since, Limit: &limit})
+	if err != nil {
+		t.Fatalf("first page: %v", err)
+	}
+	if len(first) != 3 {
+		t.Fatalf("first page got %d rows, want 3", len(first))
+	}
+	// ASC ordering so the oldest rows come first.
+	for i := 1; i < len(first); i++ {
+		if first[i-1].Timestamp > first[i].Timestamp {
+			t.Errorf("row %d (%s) older than row %d (%s); want ASC order",
+				i, first[i].Timestamp, i-1, first[i-1].Timestamp)
+		}
+	}
+
+	// Advance the watermark to the newest returned row and poll again.
+	watermark := first[len(first)-1].Timestamp
+	second, err := r.ListReceipts(Filter{Since: &watermark, Limit: &limit})
+	if err != nil {
+		t.Fatalf("second page: %v", err)
+	}
+	// Merge by id (the inclusive boundary may re-emit one row; the client
+	// dedups, which we mirror here) and confirm we recovered every row in
+	// the burst — not the middle-of-range silent drop that DESC + LIMIT
+	// would have produced.
+	seen := map[string]bool{}
+	for _, row := range first {
+		seen[row.ID] = true
+	}
+	for _, row := range second {
+		seen[row.ID] = true
+	}
+	if len(seen) != 5 {
+		t.Errorf("paginated drain saw %d distinct rows, want 5", len(seen))
+	}
+}
+
 func TestReader_ListReceipts_Limit(t *testing.T) {
 	dbPath := seedFileDB(t)
 	r, err := OpenReadOnly(dbPath)


### PR DESCRIPTION
## Summary

- Tails `/api/receipts` on a configurable interval and prepends fresh rows into the active view — new receipts appear without a manual refresh.
- Pauses polling when the tab is hidden (`document.visibilityState`); resumes with an immediate catch-up poll on focus.
- Exponential backoff after 3 consecutive empty polls, capped at 30s; resets on activity or refocus.
- Subtle row flash + "N new receipts" toast on arrival.

## Backend

- `Filter.Since` (inclusive `timestamp >= ?`) watermark, surfaced via the `since` query param on `/api/receipts`. Inclusive on purpose: receipt timestamps may lack sub-second precision, so a strict `>` watermark would silently lose any row sharing the second with the watermark. The client deduplicates by `id`, so re-emitting the watermark row is harmless.
- New `GET /api/config` returning `poll_interval_ms` so the frontend matches the server-side cadence.
- `-poll-interval` flag and `AR_DASHBOARD_POLL_INTERVAL` env var (Go `time.Duration`, default `5s`), validated as positive. Precedence is flag > env > default — a malformed env var no longer aborts startup when the flag is set explicitly.

I picked a `since` timestamp watermark over the spec's `?after=<id>` because receipt IDs are UUIDs with no inherent ordering; inclusive `timestamp` filter + client-side ID dedup gives the same no-duplicate guarantee without relying on sub-second precision. Existing `after`/`before` inclusive-timestamp filters are unchanged.

## Frontend

- Single `poller` object tracks active view, container, filter snapshot, watermark, and known IDs.
- `pollOnce` calls `/api/receipts?since=<watermark>&[filters]`, dedupes by ID, and `insertAdjacentHTML('afterbegin', ...)` into a stable `tbody-{containerId}`.
- Overview keeps the recent list bounded at 10 rows (both incremental and empty-state rebuild paths); switching views or changing filters resets polling state cleanly.
- Overview dedup state is seeded from the full `/api/receipts` result, not the 10-row slice, so rows sharing the watermark second but falling below `RECENT_LIMIT` don't re-emerge as "new" on the next poll.

## Test plan

- [x] `go vet ./...` and `go test ./... -count=1` green
- [x] `Filter.Since` is inclusive — rows sharing the watermark second are re-emitted and the client dedups by id
- [x] `/api/receipts?since=...` returns rows at or after the timestamp
- [x] `/api/config` falls back to `DefaultPollInterval` on zero-config; explicit value is echoed
- [x] `AR_DASHBOARD_POLL_INTERVAL` parsing: unset, valid (`s`/`ms`), unparseable, zero, and negative
- [x] `choosePollInterval` precedence: flag wins over env (incl. when env is broken), non-positive flag rejected, env used and surfaced when flag unset
- [ ] Manual browser check of row flash, toast, visibility pause, and backoff (couldn't render UI from this environment)

## Out of scope

- WebSocket/SSE push (noted in the original proposal as follow-on)
- Persisting poll interval preference across sessions