### PR TITLE
feat: surface parameters_disclosure on receipts list and detail

### DIFF
--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -409,7 +409,8 @@
         parts.push(`<span class="label">Output</span><span class="value">${escapeHtml(output)}</span>`);
       }
       const tooltipContent = parts.length > 0 ? parts.join('') : '<span class="text-[#7d8590] text-xs">Additional disclosure fields present — see detail view</span>';
-      return `<button type="button" class="disclosure-indicator" onclick="event.stopPropagation()" aria-label="View parameters disclosure">&#128203;<span class="disclosure-tooltip" role="tooltip">${tooltipContent}</span></button>`;
+      const tooltipId = `disclosure-tooltip-${r.id}`;
+      return `<button type="button" class="disclosure-indicator" onclick="event.stopPropagation()" aria-label="View parameters disclosure" aria-describedby="${tooltipId}">&#128203;<span class="disclosure-tooltip" id="${tooltipId}" role="tooltip">${tooltipContent}</span></button>`;
     }
 
     function tbodyIdFor(containerId) {
@@ -594,8 +595,9 @@
       `;
     }
 
-    // Threshold above which a disclosure block collapses behind a toggle. Kept
-    // in lockstep with the CSS max-height on .disclosure-block (~9 lines).
+    // Threshold above which a disclosure block collapses behind a toggle.
+    // Approximate: JS uses character count, CSS uses height, so they won't
+    // perfectly align across all fonts and screen sizes.
     const DISCLOSURE_COLLAPSE_CHARS = 400;
     function disclosureBlockHTML(label, value) {
       const long = value.length > DISCLOSURE_COLLAPSE_CHARS;

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -75,8 +75,10 @@
     .disclosure-indicator {
       position: relative; display: inline-block; margin-left: 6px;
       color: #7d8590; cursor: help; font-size: 0.85rem;
+      background: none; border: none; padding: 0;
     }
     .disclosure-indicator:hover { color: #58a6ff; }
+    .disclosure-indicator:focus { outline: 2px solid #58a6ff; outline-offset: 2px; }
     .disclosure-tooltip {
       visibility: hidden; opacity: 0;
       position: absolute; left: 0; top: calc(100% + 6px); z-index: 70;
@@ -100,10 +102,12 @@
       max-height: 9em; overflow: hidden; position: relative;
     }
     .disclosure-block.expanded { max-height: none; }
-    .disclosure-block .toggle {
+    .toggle {
       color: #58a6ff; cursor: pointer; font-family: -apple-system, BlinkMacSystemFont, sans-serif;
-      font-size: 0.75rem; margin-top: 6px; display: inline-block;
+      font-size: 0.75rem; margin-top: 6px; display: inline-block; background: none; border: none;
+      padding: 0; text-decoration: underline;
     }
+    .toggle:focus { outline: 2px solid #58a6ff; outline-offset: 2px; }
   </style>
 </head>
 <body class="min-h-screen">
@@ -394,9 +398,9 @@
     // carry parameters_disclosure. Click is swallowed so it doesn't double-fire
     // the row click; hover reveals input/output snippets from the list payload.
     function disclosureIndicatorHTML(r) {
+      if (!r.has_parameters_disclosure) return '';
       const input = r.parameters_input_preview || '';
       const output = r.parameters_output_preview || '';
-      if (!input && !output) return '';
       const parts = [];
       if (input) {
         parts.push(`<span class="label">Input</span><span class="value">${escapeHtml(input)}</span>`);
@@ -404,7 +408,7 @@
       if (output) {
         parts.push(`<span class="label">Output</span><span class="value">${escapeHtml(output)}</span>`);
       }
-      return `<span class="disclosure-indicator" onclick="event.stopPropagation()" aria-label="Has parameters disclosure">&#128203;<span class="disclosure-tooltip" role="tooltip">${parts.join('')}</span></span>`;
+      return `<button type="button" class="disclosure-indicator" onclick="event.stopPropagation()" aria-label="View parameters disclosure">&#128203;<span class="disclosure-tooltip" role="tooltip">${parts.join('')}</span></button>`;
     }
 
     function tbodyIdFor(containerId) {

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -404,7 +404,7 @@
       if (output) {
         parts.push(`<span class="label">Output</span><span class="value">${escapeHtml(output)}</span>`);
       }
-      return `<span class="disclosure-indicator" tabindex="0" onclick="event.stopPropagation()" aria-label="Has parameters disclosure">&#128203;<span class="disclosure-tooltip" role="tooltip">${parts.join('')}</span></span>`;
+      return `<span class="disclosure-indicator" onclick="event.stopPropagation()" aria-label="Has parameters disclosure">&#128203;<span class="disclosure-tooltip" role="tooltip">${parts.join('')}</span></span>`;
     }
 
     function tbodyIdFor(containerId) {
@@ -597,8 +597,8 @@
       return `
         <div>
           <div class="text-[#7d8590] text-xs mb-1 font-mono">${escapeHtml(label)}</div>
-          <div class="disclosure-block${long ? '' : ' expanded'}">${escapeHtml(value)}</div>
-          ${long ? `<span class="toggle" onclick="toggleDisclosure(this)">Show more</span>` : ''}
+          <div class="disclosure-block${long ? '' : ' expanded'}" id="disclosure-${Math.random().toString(36).substr(2, 9)}">${escapeHtml(value)}</div>
+          ${long ? `<button type="button" class="toggle" onclick="toggleDisclosure(this)" aria-expanded="false">Show more</button>` : ''}
         </div>
       `;
     }
@@ -607,6 +607,7 @@
       const block = el.previousElementSibling;
       const expanded = block.classList.toggle('expanded');
       el.textContent = expanded ? 'Show less' : 'Show more';
+      el.setAttribute('aria-expanded', expanded ? 'true' : 'false');
     }
 
     function closeModal() {

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -409,7 +409,9 @@
         parts.push(`<span class="label">Output</span><span class="value">${escapeHtml(output)}</span>`);
       }
       const tooltipContent = parts.length > 0 ? parts.join('') : '<span class="text-[#7d8590] text-xs">Additional disclosure fields present — see detail view</span>';
-      const tooltipId = `disclosure-tooltip-${r.id}`;
+      // Sanitize receipt ID for use as DOM id: replace non-alphanumeric chars with underscore.
+      const safeId = r.id.replace(/[^A-Za-z0-9_-]/g, '_');
+      const tooltipId = `disclosure-tooltip-${safeId}`;
       return `<button type="button" class="disclosure-indicator" onclick="event.stopPropagation()" aria-label="View parameters disclosure" aria-describedby="${tooltipId}">&#128203;<span class="disclosure-tooltip" id="${tooltipId}" role="tooltip">${tooltipContent}</span></button>`;
     }
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -408,7 +408,8 @@
       if (output) {
         parts.push(`<span class="label">Output</span><span class="value">${escapeHtml(output)}</span>`);
       }
-      return `<button type="button" class="disclosure-indicator" onclick="event.stopPropagation()" aria-label="View parameters disclosure">&#128203;<span class="disclosure-tooltip" role="tooltip">${parts.join('')}</span></button>`;
+      const tooltipContent = parts.length > 0 ? parts.join('') : '<span class="text-[#7d8590] text-xs">Additional disclosure fields present — see detail view</span>';
+      return `<button type="button" class="disclosure-indicator" onclick="event.stopPropagation()" aria-label="View parameters disclosure">&#128203;<span class="disclosure-tooltip" role="tooltip">${tooltipContent}</span></button>`;
     }
 
     function tbodyIdFor(containerId) {
@@ -601,7 +602,7 @@
       return `
         <div>
           <div class="text-[#7d8590] text-xs mb-1 font-mono">${escapeHtml(label)}</div>
-          <div class="disclosure-block${long ? '' : ' expanded'}" id="disclosure-${Math.random().toString(36).substr(2, 9)}">${escapeHtml(value)}</div>
+          <div class="disclosure-block${long ? '' : ' expanded'}">${escapeHtml(value)}</div>
           ${long ? `<button type="button" class="toggle" onclick="toggleDisclosure(this)" aria-expanded="false">Show more</button>` : ''}
         </div>
       `;

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -69,6 +69,41 @@
       transition: opacity 0.2s ease, transform 0.2s ease;
     }
     #live-toast.show { opacity: 1; transform: translateY(0); }
+
+    /* Parameters-disclosure hover preview on the receipts table. The full
+       value lives in the detail modal; the tooltip is a quick triage hint. */
+    .disclosure-indicator {
+      position: relative; display: inline-block; margin-left: 6px;
+      color: #7d8590; cursor: help; font-size: 0.85rem;
+    }
+    .disclosure-indicator:hover { color: #58a6ff; }
+    .disclosure-tooltip {
+      visibility: hidden; opacity: 0;
+      position: absolute; left: 0; top: calc(100% + 6px); z-index: 70;
+      width: max-content; max-width: 480px;
+      background: #161b22; border: 1px solid #30363d; border-radius: 6px;
+      padding: 8px 10px; box-shadow: 0 4px 12px rgba(0,0,0,0.5);
+      font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.75rem; color: #e6edf3; white-space: pre-wrap;
+      word-break: break-word; pointer-events: none;
+      transition: opacity 0.1s ease;
+    }
+    .disclosure-indicator:hover .disclosure-tooltip,
+    .disclosure-indicator:focus .disclosure-tooltip { visibility: visible; opacity: 1; }
+    .disclosure-tooltip .label { color: #7d8590; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; }
+    .disclosure-tooltip .value { display: block; margin-top: 2px; margin-bottom: 6px; }
+    .disclosure-tooltip .value:last-child { margin-bottom: 0; }
+    .disclosure-block {
+      background: #0d1117; border: 1px solid #30363d; border-radius: 6px;
+      padding: 8px 10px; font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+      font-size: 0.8rem; white-space: pre-wrap; word-break: break-word;
+      max-height: 9em; overflow: hidden; position: relative;
+    }
+    .disclosure-block.expanded { max-height: none; }
+    .disclosure-block .toggle {
+      color: #58a6ff; cursor: pointer; font-family: -apple-system, BlinkMacSystemFont, sans-serif;
+      font-size: 0.75rem; margin-top: 6px; display: inline-block;
+    }
   </style>
 </head>
 <body class="min-h-screen">
@@ -346,13 +381,30 @@
           <td class="py-2 pr-4 text-[#7d8590] whitespace-nowrap">${formatTime(r.timestamp)}</td>
           <td class="py-2 pr-4 font-mono text-xs text-[#7d8590]">${r.server ? escapeHtml(r.server) : '<span class="text-[#484f58]">—</span>'}</td>
           <td class="py-2 pr-4 font-mono text-xs">${r.tool_name ? escapeHtml(r.tool_name) : '<span class="text-[#484f58]">—</span>'}</td>
-          <td class="py-2 pr-4 font-mono text-xs">${escapeHtml(r.action_type)}</td>
+          <td class="py-2 pr-4 font-mono text-xs">${escapeHtml(r.action_type)}${disclosureIndicatorHTML(r)}</td>
           <td class="py-2 pr-4"><span class="badge ${riskClass(r.risk_level)}">${escapeHtml(r.risk_level)}</span></td>
           <td class="py-2 pr-4"><span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span></td>
           <td class="py-2 pr-4 text-[#7d8590] font-mono text-xs cursor-pointer hover:text-[#58a6ff]" data-chain-id="${escapeHtml(r.chain_id)}" onclick="event.stopPropagation(); showChain(this.dataset.chainId)">${escapeHtml(truncate(r.chain_id, 20))}</td>
           <td class="py-2 pr-4 text-[#7d8590]">#${r.sequence}</td>
         </tr>
       `;
+    }
+
+    // disclosureIndicatorHTML renders the 📋 hover-preview marker on rows that
+    // carry parameters_disclosure. Click is swallowed so it doesn't double-fire
+    // the row click; hover reveals input/output snippets from the list payload.
+    function disclosureIndicatorHTML(r) {
+      const input = r.parameters_input_preview || '';
+      const output = r.parameters_output_preview || '';
+      if (!input && !output) return '';
+      const parts = [];
+      if (input) {
+        parts.push(`<span class="label">Input</span><span class="value">${escapeHtml(input)}</span>`);
+      }
+      if (output) {
+        parts.push(`<span class="label">Output</span><span class="value">${escapeHtml(output)}</span>`);
+      }
+      return `<span class="disclosure-indicator" tabindex="0" onclick="event.stopPropagation()" aria-label="Has parameters disclosure">&#128203;<span class="disclosure-tooltip" role="tooltip">${parts.join('')}</span></span>`;
     }
 
     function tbodyIdFor(containerId) {
@@ -488,6 +540,8 @@
           </div>
           ` : ''}
 
+          ${parametersDisclosureHTML(subj.action.parameters_disclosure)}
+
           <div>
             <div class="text-[#7d8590] text-xs mb-1">Chain</div>
             <div class="text-sm">
@@ -502,6 +556,57 @@
           </details>
         </div>
       `;
+    }
+
+    // parametersDisclosureHTML renders the operator-disclosed parameter map
+    // (ADR-0012). Input/output get top billing because that's the common
+    // shape; any other keys fall through to a generic key/value list. Long
+    // values collapse with a "show more" toggle so big payloads don't blow
+    // out the modal.
+    const DISCLOSURE_PRIMARY_KEYS = ['input', 'output'];
+    function parametersDisclosureHTML(disclosure) {
+      if (!disclosure || typeof disclosure !== 'object') return '';
+      const keys = Object.keys(disclosure);
+      if (keys.length === 0) return '';
+
+      const primary = DISCLOSURE_PRIMARY_KEYS
+        .filter(k => disclosure[k] != null && String(disclosure[k]) !== '')
+        .map(k => disclosureBlockHTML(k.charAt(0).toUpperCase() + k.slice(1), String(disclosure[k])));
+      const others = keys
+        .filter(k => !DISCLOSURE_PRIMARY_KEYS.includes(k))
+        .map(k => disclosureBlockHTML(k, String(disclosure[k])));
+
+      if (primary.length === 0 && others.length === 0) return '';
+
+      return `
+        <div>
+          <div class="text-[#7d8590] text-xs mb-1">Parameters Disclosure</div>
+          <div class="space-y-3">
+            ${primary.join('')}
+            ${others.join('')}
+          </div>
+        </div>
+      `;
+    }
+
+    // Threshold above which a disclosure block collapses behind a toggle. Kept
+    // in lockstep with the CSS max-height on .disclosure-block (~9 lines).
+    const DISCLOSURE_COLLAPSE_CHARS = 400;
+    function disclosureBlockHTML(label, value) {
+      const long = value.length > DISCLOSURE_COLLAPSE_CHARS;
+      return `
+        <div>
+          <div class="text-[#7d8590] text-xs mb-1 font-mono">${escapeHtml(label)}</div>
+          <div class="disclosure-block${long ? '' : ' expanded'}">${escapeHtml(value)}</div>
+          ${long ? `<span class="toggle" onclick="toggleDisclosure(this)">Show more</span>` : ''}
+        </div>
+      `;
+    }
+
+    function toggleDisclosure(el) {
+      const block = el.previousElementSibling;
+      const expanded = block.classList.toggle('expanded');
+      el.textContent = expanded ? 'Show less' : 'Show more';
     }
 
     function closeModal() {

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -37,7 +37,7 @@ type ReceiptRow struct {
 	// ParametersInputPreview and ParametersOutputPreview are short, operator-
 	// disclosed snippets of the call's input/output (ADR-0012). They power the
 	// list-view hover tooltip; the full disclosure map is fetched via the
-	// detail endpoint. Truncated to disclosurePreviewMaxLen bytes in SQL so a
+	// detail endpoint. Truncated to disclosurePreviewMaxLen characters in SQL so a
 	// large disclosure doesn't bloat list responses.
 	ParametersInputPreview  string `json:"parameters_input_preview,omitempty"`
 	ParametersOutputPreview string `json:"parameters_output_preview,omitempty"`

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -202,7 +202,7 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		        receipt_hash, COALESCE(previous_receipt_hash, ''),
 		        COALESCE(substr(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.input'), 1, ?), ''),
 		        COALESCE(substr(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.output'), 1, ?), ''),
-		        json_type(receipt_json, '$.credentialSubject.action.parameters_disclosure') IS NOT NULL
+		        COALESCE(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure'), 'null') NOT IN ('null', '{}')
 		 FROM receipts %s ORDER BY %s LIMIT ?`,
 		where, orderBy,
 	)

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -34,7 +34,18 @@ type ReceiptRow struct {
 	PrincipalID         string `json:"principal_id"`
 	ReceiptHash         string `json:"receipt_hash"`
 	PreviousReceiptHash string `json:"previous_receipt_hash"`
+	// ParametersInputPreview and ParametersOutputPreview are short, operator-
+	// disclosed snippets of the call's input/output (ADR-0012). They power the
+	// list-view hover tooltip; the full disclosure map is fetched via the
+	// detail endpoint. Truncated to disclosurePreviewMaxLen bytes in SQL so a
+	// large disclosure doesn't bloat list responses.
+	ParametersInputPreview  string `json:"parameters_input_preview,omitempty"`
+	ParametersOutputPreview string `json:"parameters_output_preview,omitempty"`
 }
+
+// disclosurePreviewMaxLen bounds the size of input/output previews returned
+// in list rows. The modal still shows the full value via the detail endpoint.
+const disclosurePreviewMaxLen = 200
 
 // ChainSummary holds aggregate information about a receipt chain.
 type ChainSummary struct {
@@ -184,10 +195,15 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		        COALESCE(json_extract(receipt_json, '$.credentialSubject.action.target.system'), ''),
 		        risk_level, status,
 		        timestamp, issuer_id, COALESCE(principal_id, ''),
-		        receipt_hash, COALESCE(previous_receipt_hash, '')
+		        receipt_hash, COALESCE(previous_receipt_hash, ''),
+		        COALESCE(substr(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.input'), 1, ?), ''),
+		        COALESCE(substr(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.output'), 1, ?), '')
 		 FROM receipts %s ORDER BY %s LIMIT ?`,
 		where, orderBy,
 	)
+	// substr args come before the WHERE-clause args in the SELECT list, so
+	// prepend them.
+	args = append([]any{disclosurePreviewMaxLen, disclosurePreviewMaxLen}, args...)
 	args = append(args, limit)
 
 	rows, err := r.db.Query(query, args...)
@@ -204,6 +220,7 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 			&row.ToolName, &row.Server,
 			&row.RiskLevel, &row.Status, &row.Timestamp, &row.IssuerID,
 			&row.PrincipalID, &row.ReceiptHash, &row.PreviousReceiptHash,
+			&row.ParametersInputPreview, &row.ParametersOutputPreview,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -41,6 +41,10 @@ type ReceiptRow struct {
 	// large disclosure doesn't bloat list responses.
 	ParametersInputPreview  string `json:"parameters_input_preview,omitempty"`
 	ParametersOutputPreview string `json:"parameters_output_preview,omitempty"`
+	// HasParametersDisclosure is true if the receipt has any parameters_disclosure
+	// data, regardless of which keys are present. Allows list UI to show the
+	// disclosure indicator even when only non-primary keys exist.
+	HasParametersDisclosure bool `json:"has_parameters_disclosure"`
 }
 
 // disclosurePreviewMaxLen bounds the size of input/output previews returned
@@ -197,7 +201,8 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		        timestamp, issuer_id, COALESCE(principal_id, ''),
 		        receipt_hash, COALESCE(previous_receipt_hash, ''),
 		        COALESCE(substr(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.input'), 1, ?), ''),
-		        COALESCE(substr(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.output'), 1, ?), '')
+		        COALESCE(substr(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.output'), 1, ?), ''),
+		        json_type(receipt_json, '$.credentialSubject.action.parameters_disclosure') IS NOT NULL
 		 FROM receipts %s ORDER BY %s LIMIT ?`,
 		where, orderBy,
 	)
@@ -221,6 +226,7 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 			&row.RiskLevel, &row.Status, &row.Timestamp, &row.IssuerID,
 			&row.PrincipalID, &row.ReceiptHash, &row.PreviousReceiptHash,
 			&row.ParametersInputPreview, &row.ParametersOutputPreview,
+			&row.HasParametersDisclosure,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -417,10 +417,18 @@ func TestReader_ListReceipts_ParametersDisclosurePreview(t *testing.T) {
 		"input": long,
 	}
 
-	withoutDisclosure := makeReceipt("urn:receipt:d3", "chain-d", 3,
+	// A receipt with disclosure containing only non-primary keys (no input/output).
+	withNonPrimaryKeys := makeReceipt("urn:receipt:d2b", "chain-d", 3,
+		"tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:01:30Z", nil)
+	withNonPrimaryKeys.CredentialSubject.Action.ParametersDisclosure = map[string]string{
+		"api_key": "sk-...",
+		"region": "us-west-2",
+	}
+
+	withoutDisclosure := makeReceipt("urn:receipt:d3", "chain-d", 4,
 		"tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:02:00Z", nil)
 
-	for _, r := range []receipt.AgentReceipt{withDisclosure, withLong, withoutDisclosure} {
+	for _, r := range []receipt.AgentReceipt{withDisclosure, withLong, withNonPrimaryKeys, withoutDisclosure} {
 		hash, err := receipt.HashReceipt(r)
 		if err != nil {
 			t.Fatalf("hash: %v", err)
@@ -441,27 +449,47 @@ func TestReader_ListReceipts_ParametersDisclosurePreview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	if len(rows) != 3 {
-		t.Fatalf("got %d rows, want 3", len(rows))
+	if len(rows) != 4 {
+		t.Fatalf("got %d rows, want 4", len(rows))
 	}
 
-	// newest-first: d3, d2, d1.
+	// newest-first: d3, d2b, d2, d1.
 	if rows[0].ParametersInputPreview != "" || rows[0].ParametersOutputPreview != "" {
 		t.Errorf("d3 (no disclosure) got input=%q output=%q, want empty",
 			rows[0].ParametersInputPreview, rows[0].ParametersOutputPreview)
 	}
-	if got := len(rows[1].ParametersInputPreview); got != disclosurePreviewMaxLen {
+	if rows[0].HasParametersDisclosure {
+		t.Errorf("d3 (no disclosure) got HasParametersDisclosure=true, want false")
+	}
+
+	// d2b: has disclosure (non-primary keys only) but no input/output previews.
+	if rows[1].ParametersInputPreview != "" || rows[1].ParametersOutputPreview != "" {
+		t.Errorf("d2b (non-primary keys only) got input=%q output=%q, want both empty",
+			rows[1].ParametersInputPreview, rows[1].ParametersOutputPreview)
+	}
+	if !rows[1].HasParametersDisclosure {
+		t.Errorf("d2b (has disclosure) got HasParametersDisclosure=false, want true")
+	}
+
+	if got := len(rows[2].ParametersInputPreview); got != disclosurePreviewMaxLen {
 		t.Errorf("d2 input preview length = %d, want %d (truncated)", got, disclosurePreviewMaxLen)
 	}
-	if rows[1].ParametersOutputPreview != "" {
-		t.Errorf("d2 output preview = %q, want empty", rows[1].ParametersOutputPreview)
+	if rows[2].ParametersOutputPreview != "" {
+		t.Errorf("d2 output preview = %q, want empty", rows[2].ParametersOutputPreview)
 	}
-	if rows[2].ParametersInputPreview != "read /etc/passwd" {
-		t.Errorf("d1 input preview = %q, want %q", rows[2].ParametersInputPreview, "read /etc/passwd")
+	if !rows[2].HasParametersDisclosure {
+		t.Errorf("d2 (has disclosure) got HasParametersDisclosure=false, want true")
 	}
-	if rows[2].ParametersOutputPreview != "root:x:0:0:root:/root:/bin/bash" {
+
+	if rows[3].ParametersInputPreview != "read /etc/passwd" {
+		t.Errorf("d1 input preview = %q, want %q", rows[3].ParametersInputPreview, "read /etc/passwd")
+	}
+	if rows[3].ParametersOutputPreview != "root:x:0:0:root:/root:/bin/bash" {
 		t.Errorf("d1 output preview = %q, want %q",
-			rows[2].ParametersOutputPreview, "root:x:0:0:root:/root:/bin/bash")
+			rows[3].ParametersOutputPreview, "root:x:0:0:root:/root:/bin/bash")
+	}
+	if !rows[3].HasParametersDisclosure {
+		t.Errorf("d1 (has disclosure) got HasParametersDisclosure=false, want true")
 	}
 }
 

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -390,6 +391,77 @@ func TestReader_ListReceipts_ServerAndTool(t *testing.T) {
 	}
 	if rowT3.Server != "jira" {
 		t.Errorf("server: got %q, want %q", rowT3.Server, "jira")
+	}
+}
+
+func TestReader_ListReceipts_ParametersDisclosurePreview(t *testing.T) {
+	dbPath := t.TempDir() + "/disclosure-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	withDisclosure := makeReceipt("urn:receipt:d1", "chain-d", 1,
+		"tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z", nil)
+	withDisclosure.CredentialSubject.Action.ParametersDisclosure = map[string]string{
+		"input":  "read /etc/passwd",
+		"output": "root:x:0:0:root:/root:/bin/bash",
+	}
+
+	// A receipt with a disclosure value longer than the preview cap so we can
+	// confirm SQL truncates rather than streaming the whole thing.
+	long := strings.Repeat("A", 500)
+	withLong := makeReceipt("urn:receipt:d2", "chain-d", 2,
+		"tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:01:00Z", nil)
+	withLong.CredentialSubject.Action.ParametersDisclosure = map[string]string{
+		"input": long,
+	}
+
+	withoutDisclosure := makeReceipt("urn:receipt:d3", "chain-d", 3,
+		"tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:02:00Z", nil)
+
+	for _, r := range []receipt.AgentReceipt{withDisclosure, withLong, withoutDisclosure} {
+		hash, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatalf("hash: %v", err)
+		}
+		if err := s.Insert(r, hash); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	s.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	rows, err := reader.ListReceipts(Filter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+
+	// newest-first: d3, d2, d1.
+	if rows[0].ParametersInputPreview != "" || rows[0].ParametersOutputPreview != "" {
+		t.Errorf("d3 (no disclosure) got input=%q output=%q, want empty",
+			rows[0].ParametersInputPreview, rows[0].ParametersOutputPreview)
+	}
+	if got := len(rows[1].ParametersInputPreview); got != disclosurePreviewMaxLen {
+		t.Errorf("d2 input preview length = %d, want %d (truncated)", got, disclosurePreviewMaxLen)
+	}
+	if rows[1].ParametersOutputPreview != "" {
+		t.Errorf("d2 output preview = %q, want empty", rows[1].ParametersOutputPreview)
+	}
+	if rows[2].ParametersInputPreview != "read /etc/passwd" {
+		t.Errorf("d1 input preview = %q, want %q", rows[2].ParametersInputPreview, "read /etc/passwd")
+	}
+	if rows[2].ParametersOutputPreview != "root:x:0:0:root:/root:/bin/bash" {
+		t.Errorf("d1 output preview = %q, want %q",
+			rows[2].ParametersOutputPreview, "root:x:0:0:root:/root:/bin/bash")
 	}
 }
 


### PR DESCRIPTION
## Summary

The operator-disclosed parameter map (ADR-0012) was only reachable via the raw-JSON section of the detail modal. Triage now needs to see what a tool actually saw without expanding every receipt, so this PR surfaces `parameters_disclosure.input` / `.output` on both the list and the detail views.

- **Receipts list**: rows with a non-empty `parameters_disclosure` render a 📋 indicator next to the action type. Hovering shows a CSS tooltip with truncated Input/Output snippets pulled directly from the row payload — no extra fetch.
- **Reader**: `ListReceipts` extracts short input/output previews via `json_extract` + `substr(…, 1, 200)` so list responses stay bounded even when a disclosure value is large. Two new omitempty fields on `ReceiptRow` (`parameters_input_preview`, `parameters_output_preview`).
- **Detail modal**: new "Parameters Disclosure" section between Intent and Chain. Input and Output get top billing; any other disclosure keys fall through to a generic key/value list. Values longer than ~400 chars collapse behind a "Show more" toggle so big payloads don't blow out the modal.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` green, including new `TestReader_ListReceipts_ParametersDisclosurePreview` covering full round-trip, SQL-side truncation at the 200-char cap, and empty preview for receipts without disclosure
- [x] Built the binary and exercised the rendered UI with Playwright against a seeded DB:
  - 📋 indicator shown only on rows that carry disclosure
  - Hover tooltip renders the Input snippet
  - Modal shows the Parameters Disclosure section with separate Input / Output blocks
  - "Show more" toggle expands a long input and flips to "Show less"
  - Section is omitted on receipts that have no disclosure
- [ ] Manual smoke against a real receipt store before merging

## Follow-ups (not in this PR)

- The "all prehook calls are logged as medium" observation is upstream — needs a fix in the emitter / MCP proxy SDK, not the dashboard.
- Clickable Risk Distribution bars on the main Dashboard view (drill-in to the receipts list with the risk filter pre-set) — happy to do this as a separate PR; the branch name hints at it but it's out of scope here.