### PR TITLE
Add output status mismatch detection for receipts

### DIFF
--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -91,7 +91,9 @@
       transition: opacity 0.1s ease;
     }
     .disclosure-indicator:hover .disclosure-tooltip,
-    .disclosure-indicator:focus .disclosure-tooltip { visibility: visible; opacity: 1; }
+    .disclosure-indicator:focus .disclosure-tooltip,
+    .mismatch-indicator:hover .disclosure-tooltip,
+    .mismatch-indicator:focus .disclosure-tooltip { visibility: visible; opacity: 1; }
     .disclosure-tooltip .label { color: #7d8590; font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.05em; }
     .disclosure-tooltip .value { display: block; margin-top: 2px; margin-bottom: 6px; }
     .disclosure-tooltip .value:last-child { margin-bottom: 0; }

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -108,6 +108,24 @@
       padding: 0; text-decoration: underline;
     }
     .toggle:focus { outline: 2px solid #58a6ff; outline-offset: 2px; }
+
+    /* Status/output mismatch indicator. Surfaces receipts whose outcome was
+       stamped success while the MCP tool payload reports isError:true. Shares
+       the disclosure-tooltip styles for hover/focus reveal — see issue #50. */
+    .mismatch-indicator {
+      position: relative; display: inline-block; margin-left: 6px;
+      color: #d29922; cursor: help; font-size: 0.85rem;
+      background: none; border: none; padding: 0; vertical-align: middle;
+    }
+    .mismatch-indicator:hover { color: #f0b429; }
+    .mismatch-indicator:focus { outline: 2px solid #d29922; outline-offset: 2px; }
+    .mismatch-indicator .disclosure-tooltip { color: #e6edf3; }
+    .mismatch-banner {
+      background: rgba(210,153,34,0.08); border: 1px solid rgba(210,153,34,0.35);
+      border-left: 3px solid #d29922; border-radius: 6px;
+      padding: 8px 12px; font-size: 0.8rem; color: #e6edf3;
+    }
+    .mismatch-banner .label { color: #d29922; font-weight: 600; margin-right: 6px; }
   </style>
 </head>
 <body class="min-h-screen">
@@ -387,11 +405,22 @@
           <td class="py-2 pr-4 font-mono text-xs">${r.tool_name ? escapeHtml(r.tool_name) : '<span class="text-[#484f58]">—</span>'}</td>
           <td class="py-2 pr-4 font-mono text-xs">${escapeHtml(r.action_type)}${disclosureIndicatorHTML(r)}</td>
           <td class="py-2 pr-4"><span class="badge ${riskClass(r.risk_level)}">${escapeHtml(r.risk_level)}</span></td>
-          <td class="py-2 pr-4"><span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span></td>
+          <td class="py-2 pr-4"><span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span>${mismatchIndicatorHTML(r)}</td>
           <td class="py-2 pr-4 text-[#7d8590] font-mono text-xs cursor-pointer hover:text-[#58a6ff]" data-chain-id="${escapeHtml(r.chain_id)}" onclick="event.stopPropagation(); showChain(this.dataset.chainId)">${escapeHtml(truncate(r.chain_id, 20))}</td>
           <td class="py-2 pr-4 text-[#7d8590]">#${r.sequence}</td>
         </tr>
       `;
+    }
+
+    // mismatchIndicatorHTML renders the ⚠️ marker next to a status badge when
+    // the row's status disagrees with its disclosed output payload (issue #50).
+    // The hint is opt-in cosmetics — the underlying receipt and hash are
+    // untouched. Click is swallowed so it doesn't double-fire the row click.
+    function mismatchIndicatorHTML(r) {
+      if (!r.output_status_mismatch) return '';
+      const safeId = (r.id || '').replace(/[^A-Za-z0-9_-]/g, '_');
+      const tooltipId = `mismatch-tooltip-${safeId}`;
+      return `<button type="button" class="mismatch-indicator" onclick="event.stopPropagation()" aria-label="Status/output mismatch" aria-describedby="${tooltipId}">&#9888;<span class="disclosure-tooltip" id="${tooltipId}" role="tooltip"><span class="label">Status/output mismatch</span><span class="value">Outcome recorded as success, but the disclosed tool output reports isError: true.</span></span></button>`;
     }
 
     // disclosureIndicatorHTML renders the 📋 hover-preview marker on rows that
@@ -491,10 +520,35 @@
       }
     }
 
+    // outputStatusMismatchFromReceipt mirrors the SQL detection in reader.go:
+    // status=success while parameters_disclosure.output is a JSON object with
+    // isError: true. Computed client-side for the detail modal because the
+    // modal payload is the full receipt, not the indexed list row.
+    function outputStatusMismatchFromReceipt(r) {
+      const subj = r && r.credentialSubject;
+      if (!subj || !subj.outcome || subj.outcome.status !== 'success') return false;
+      const disclosure = subj.action && subj.action.parameters_disclosure;
+      if (!disclosure || typeof disclosure.output !== 'string') return false;
+      try {
+        const parsed = JSON.parse(disclosure.output);
+        return parsed !== null && typeof parsed === 'object' && parsed.isError === true;
+      } catch (_) {
+        return false;
+      }
+    }
+
     function renderReceiptDetail(r) {
       const subj = r.credentialSubject;
+      const mismatch = outputStatusMismatchFromReceipt(r);
       return `
         <div class="space-y-4">
+          ${mismatch ? `
+          <div class="mismatch-banner">
+            <span class="label">&#9888; Status/output mismatch</span>
+            Outcome recorded as <code>success</code>, but the disclosed tool output reports <code>isError: true</code>. This is a display hint only — the receipt and its hash are unchanged. See issue #50.
+          </div>
+          ` : ''}
+
           <div class="grid grid-cols-2 gap-4">
             <div>
               <div class="text-[#7d8590] text-xs mb-1">Server</div>
@@ -666,9 +720,9 @@
                 <div class="bg-[#0d1117] border border-[#30363d] rounded-lg p-3 hover:border-[#484f58] cursor-pointer" data-receipt-id="${escapeHtml(r.id)}" onclick="closeChainModal(); showReceipt(this.dataset.receiptId)">
                   <div class="flex items-center justify-between mb-1">
                     <span class="font-mono text-xs">#${r.sequence} ${escapeHtml(r.action_type)}</span>
-                    <div class="flex gap-2">
+                    <div class="flex gap-2 items-center">
                       <span class="badge ${riskClass(r.risk_level)}">${escapeHtml(r.risk_level)}</span>
-                      <span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span>
+                      <span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span>${mismatchIndicatorHTML(r)}
                     </div>
                   </div>
                   <div class="text-[#7d8590] text-xs">${formatTime(r.timestamp)}</div>

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -45,6 +45,13 @@ type ReceiptRow struct {
 	// data, regardless of which keys are present. Allows list UI to show the
 	// disclosure indicator even when only non-primary keys exist.
 	HasParametersDisclosure bool `json:"has_parameters_disclosure"`
+	// OutputStatusMismatch is true when outcome.status is "success" but
+	// parameters_disclosure.output parses as a JSON object with isError: true.
+	// MCP tool emitters historically stamp the outcome before inspecting the
+	// response payload, so older receipts in existing stores carry a misleading
+	// status (see issue #50). This is a read-only display hint; the dashboard
+	// never rewrites the receipt or its hash.
+	OutputStatusMismatch bool `json:"output_status_mismatch"`
 }
 
 // disclosurePreviewMaxLen bounds the size of input/output previews returned
@@ -193,6 +200,13 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		orderBy = "timestamp ASC, id ASC"
 	}
 
+	// output_status_mismatch flags receipts whose outcome.status is "success"
+	// while their parameters_disclosure.output parses as a JSON object with
+	// isError: true. parameters_disclosure values are JSON-encoded strings
+	// (per ADR-0012), so we extract twice: once to get the string, once to
+	// reach into it. The CASE gate ensures the inner json_extract only runs
+	// on text that json_valid has cleared — SQL AND does not short-circuit,
+	// and json_extract on non-JSON text raises a "malformed JSON" error.
 	query := fmt.Sprintf(
 		`SELECT id, chain_id, sequence, action_type,
 		        COALESCE(tool_name, ''),
@@ -202,7 +216,13 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		        receipt_hash, COALESCE(previous_receipt_hash, ''),
 		        COALESCE(substr(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.input'), 1, ?), ''),
 		        COALESCE(substr(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.output'), 1, ?), ''),
-		        COALESCE(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure'), 'null') NOT IN ('null', '{}')
+		        COALESCE(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure'), 'null') NOT IN ('null', '{}'),
+		        CASE
+		          WHEN status = 'success'
+		           AND json_valid(IFNULL(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.output'), 'null')) = 1
+		          THEN IFNULL(json_extract(IFNULL(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.output'), 'null'), '$.isError'), 0) = 1
+		          ELSE 0
+		        END
 		 FROM receipts %s ORDER BY %s LIMIT ?`,
 		where, orderBy,
 	)
@@ -227,6 +247,7 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 			&row.PrincipalID, &row.ReceiptHash, &row.PreviousReceiptHash,
 			&row.ParametersInputPreview, &row.ParametersOutputPreview,
 			&row.HasParametersDisclosure,
+			&row.OutputStatusMismatch,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -493,6 +493,102 @@ func TestReader_ListReceipts_ParametersDisclosurePreview(t *testing.T) {
 	}
 }
 
+func TestReader_ListReceipts_OutputStatusMismatch(t *testing.T) {
+	dbPath := t.TempDir() + "/mismatch-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	// status=success + output JSON with isError:true → mismatch.
+	mismatch := makeReceipt("urn:receipt:m1", "chain-m", 1,
+		"mcp.tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z", nil)
+	mismatch.CredentialSubject.Action.ParametersDisclosure = map[string]string{
+		"output": `{"content":[{"text":"401 Bad credentials","type":"text"}],"isError":true}`,
+	}
+
+	// status=success + output JSON with isError:false → consistent, no mismatch.
+	clean := makeReceipt("urn:receipt:m2", "chain-m", 2,
+		"mcp.tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:01:00Z", nil)
+	clean.CredentialSubject.Action.ParametersDisclosure = map[string]string{
+		"output": `{"content":[{"text":"ok"}],"isError":false}`,
+	}
+
+	// status=success + output JSON without isError key → no mismatch.
+	noFlag := makeReceipt("urn:receipt:m3", "chain-m", 3,
+		"mcp.tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:02:00Z", nil)
+	noFlag.CredentialSubject.Action.ParametersDisclosure = map[string]string{
+		"output": `{"content":[{"text":"ok"}]}`,
+	}
+
+	// status=failure + output JSON with isError:true → consistent, no mismatch.
+	expectedFail := makeReceipt("urn:receipt:m4", "chain-m", 4,
+		"mcp.tool.call", receipt.RiskLow, receipt.StatusFailure, "2026-04-01T10:03:00Z", nil)
+	expectedFail.CredentialSubject.Action.ParametersDisclosure = map[string]string{
+		"output": `{"isError":true}`,
+	}
+
+	// status=success + plain (non-JSON) string output → no mismatch.
+	plain := makeReceipt("urn:receipt:m5", "chain-m", 5,
+		"mcp.tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:04:00Z", nil)
+	plain.CredentialSubject.Action.ParametersDisclosure = map[string]string{
+		"output": "plain text body, not JSON",
+	}
+
+	// status=success + no disclosure at all → no mismatch.
+	bare := makeReceipt("urn:receipt:m6", "chain-m", 6,
+		"mcp.tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:05:00Z", nil)
+
+	for _, r := range []receipt.AgentReceipt{mismatch, clean, noFlag, expectedFail, plain, bare} {
+		hash, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatalf("hash: %v", err)
+		}
+		if err := s.Insert(r, hash); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	s.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	rows, err := reader.ListReceipts(Filter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+
+	byID := map[string]ReceiptRow{}
+	for _, r := range rows {
+		byID[r.ID] = r
+	}
+
+	cases := []struct {
+		id   string
+		want bool
+	}{
+		{"urn:receipt:m1", true},
+		{"urn:receipt:m2", false},
+		{"urn:receipt:m3", false},
+		{"urn:receipt:m4", false},
+		{"urn:receipt:m5", false},
+		{"urn:receipt:m6", false},
+	}
+	for _, tc := range cases {
+		row, ok := byID[tc.id]
+		if !ok {
+			t.Errorf("%s missing from results", tc.id)
+			continue
+		}
+		if row.OutputStatusMismatch != tc.want {
+			t.Errorf("%s: OutputStatusMismatch=%v, want %v", tc.id, row.OutputStatusMismatch, tc.want)
+		}
+	}
+}
+
 func TestReader_GetChain(t *testing.T) {
 	dbPath := seedFileDB(t)
 	r, err := OpenReadOnly(dbPath)


### PR DESCRIPTION
## What

Adds detection and display of status/output mismatches in agent receipts. A mismatch occurs when a receipt's outcome is recorded as "success" but the disclosed MCP tool output contains `isError: true`. This is surfaced as a read-only display hint in both the receipt list and detail views.

Changes include:
- **Backend**: New `OutputStatusMismatch` field in `ReceiptRow` with SQL detection logic that safely parses nested JSON to identify mismatches
- **Frontend**: Visual indicators (⚠️ badge) in the receipt list and a prominent banner in the detail view explaining the mismatch
- **Tests**: Comprehensive test coverage for various scenarios (mismatched status, consistent status, missing fields, non-JSON output, etc.)

## Why

MCP tool emitters historically stamp the outcome status before inspecting the response payload, leading to receipts with misleading success statuses when the actual tool output indicates an error (issue #50). This change provides visibility into such inconsistencies without modifying the underlying receipt or hash, allowing operators to identify potentially problematic tool integrations.

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] New functionality includes tests (`TestReader_ListReceipts_OutputStatusMismatch`)
- [x] Commit messages follow Conventional Commits
- [x] AGENTS.md not applicable (no project structure changes)

https://claude.ai/code/session_01SDvKmTXoHHcw6K5J23MuyG