### PR TITLE
docs: add CHANGELOG.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,6 +43,7 @@ internal/verify/        # Hash linkage and chain verification
 - Tests sit alongside source files as `*_test.go`
 - Tests use the SDK's `store.Open()` to create seeded test databases, then open them read-only
 - Commit messages must follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat:`, `fix:`, `docs:`, `chore:`, etc.)
+- Every PR that adds, changes, fixes, or removes user-facing behaviour must include a `CHANGELOG.md` entry under `[Unreleased]`
 
 ## Dependencies
 
@@ -99,6 +100,7 @@ Before marking work as complete:
 4. Mention any opportunistic papercut fixes made along the way.
 5. Call out TODOs, follow-up work, or uncertainties.
 6. If opening a PR, verify the description accurately reflects the changes.
+7. Add a `CHANGELOG.md` entry under `[Unreleased]` for any user-facing change.
 
 ## Agent safety rules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,84 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Output status mismatch detection — flags receipts where the declared output hash does not match the computed value (#52)
+- Dashboard UI polish: context header showing active database, keyboard navigation between receipts, and loading skeletons (#53)
+
+## [0.1.6] - 2026-05-19
+
+### Added
+
+- `parameters_disclosure` field surfaced in the receipts list and detail views (#49)
+
+## [0.1.5] - 2026-05-18
+
+### Added
+
+- Live polling for new receipts — the list auto-refreshes without a page reload (#48)
+
+## [0.1.4] - 2026-05-16
+
+### Added
+
+- Default `-db` path: dashboard now defaults to `~/.local/share/agent-receipts/receipts.db` when no flag is supplied (#44, #46)
+
+## [0.1.3] - 2026-05-01
+
+### Changed
+
+- SDK dependency bumped to v0.6.0 (#42)
+
+## [0.1.2] - 2026-04-24
+
+### Added
+
+- SERVER and TOOL columns in the receipt list and detail views (#35)
+
+## [0.1.1] - 2026-04-24
+
+### Added
+
+- GoReleaser build pipeline with GitHub Actions release workflow and Homebrew formula (#33)
+- Dependabot config for automated Go module and GitHub Actions dependency updates (#24)
+
+### Changed
+
+- SDK dependency bumped to v0.4.0 (#31)
+
+### Security
+
+- SHA-pinned all GitHub Actions to commit SHAs for supply chain integrity (#23)
+
+## [0.1.0] - 2026-04-05
+
+### Added
+
+- Initial dashboard — read-only receipt viewer for Agent Receipts SQLite stores, built with Go and htmx
+- CI workflow, PR template, and Copilot review instructions (#19)
+- Conventional Commits enforcement via Lefthook and convco (#18)
+- shellcheck linting in CI and Lefthook (#22)
+- Go module publish workflow (#20)
+- Release script (#21)
+- `CONTRIBUTING.md` for new contributors (#16)
+- GitHub YAML issue templates for bugs and feature requests (#17)
+
+### Fixed
+
+- Server now binds to `localhost` by default; `--host` flag added for custom binding
+
+[Unreleased]: https://github.com/agent-receipts/dashboard/compare/v0.1.6...HEAD
+[0.1.6]: https://github.com/agent-receipts/dashboard/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/agent-receipts/dashboard/compare/v0.1.4...v0.1.5
+[0.1.4]: https://github.com/agent-receipts/dashboard/compare/v0.1.3...v0.1.4
+[0.1.3]: https://github.com/agent-receipts/dashboard/compare/v0.1.2...v0.1.3
+[0.1.2]: https://github.com/agent-receipts/dashboard/compare/v0.1.1...v0.1.2
+[0.1.1]: https://github.com/agent-receipts/dashboard/compare/v0.1.0...v0.1.1
+[0.1.0]: https://github.com/agent-receipts/dashboard/releases/tag/v0.1.0


### PR DESCRIPTION
## What

Adds `CHANGELOG.md` following [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions, retroactively documenting all releases from v0.1.0 through v0.1.6 plus the two unreleased features on HEAD. Updates `AGENTS.md` to require a changelog entry with every user-facing PR.

## Why

Closes #41 — contributors and users currently have no single place to track what changed between releases.

## Changes

- **`CHANGELOG.md`** (new): full history from initial release through `[Unreleased]`, with version comparison links
- **`AGENTS.md`**: added changelog rule to Conventions and a step 7 to the Completing work checklist

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] New functionality includes tests (docs-only change, no new code)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] AGENTS.md updated if project structure changed
- [ ] Request a Copilot review for automated checks