### PR TITLE
feat: add Ed25519 signature verification to chain verify endpoint

### DIFF
--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -172,6 +172,7 @@ func (s *Server) handleChains(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) handleChainVerify(w http.ResponseWriter, r *http.Request) {
 	chainID := r.PathValue("chainID")
+	publicKeyPEM := r.URL.Query().Get("public_key")
 
 	receipts, err := s.reader.GetChain(chainID)
 	if err != nil {
@@ -180,7 +181,7 @@ func (s *Server) handleChainVerify(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	result := verify.VerifyChainLinks(receipts)
+	result := verify.VerifyChainLinks(receipts, publicKeyPEM)
 	writeJSON(w, http.StatusOK, result)
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -2,8 +2,12 @@
 package server
 
 import (
+	"crypto/ed25519"
+	"crypto/x509"
 	"embed"
 	"encoding/json"
+	"encoding/pem"
+	"fmt"
 	"log"
 	"net/http"
 	"path/filepath"
@@ -174,6 +178,13 @@ func (s *Server) handleChainVerify(w http.ResponseWriter, r *http.Request) {
 	chainID := r.PathValue("chainID")
 	publicKeyPEM := r.URL.Query().Get("public_key")
 
+	if publicKeyPEM != "" {
+		if err := validateEd25519PEM(publicKeyPEM); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid public_key: "+err.Error())
+			return
+		}
+	}
+
 	receipts, err := s.reader.GetChain(chainID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "chain query failed")
@@ -183,6 +194,21 @@ func (s *Server) handleChainVerify(w http.ResponseWriter, r *http.Request) {
 
 	result := verify.VerifyChainLinks(receipts, publicKeyPEM)
 	writeJSON(w, http.StatusOK, result)
+}
+
+func validateEd25519PEM(pemStr string) error {
+	block, _ := pem.Decode([]byte(pemStr))
+	if block == nil {
+		return fmt.Errorf("not a valid PEM block")
+	}
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return fmt.Errorf("parse public key: %w", err)
+	}
+	if _, ok := key.(ed25519.PublicKey); !ok {
+		return fmt.Errorf("not an Ed25519 public key")
+	}
+	return nil
 }
 
 func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -179,8 +179,14 @@ func (s *Server) handleChainVerify(w http.ResponseWriter, r *http.Request) {
 	publicKeyPEM := r.URL.Query().Get("public_key")
 
 	if publicKeyPEM != "" {
+		const maxPEMLen = 4096
+		if len(publicKeyPEM) > maxPEMLen {
+			writeError(w, http.StatusBadRequest, "public_key must be a PEM-encoded Ed25519 public key")
+			return
+		}
 		if err := validateEd25519PEM(publicKeyPEM); err != nil {
-			writeError(w, http.StatusBadRequest, "invalid public_key: "+err.Error())
+			log.Printf("chain verify: invalid public_key: %v", err)
+			writeError(w, http.StatusBadRequest, "public_key must be a PEM-encoded Ed25519 public key")
 			return
 		}
 	}

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1579,7 +1579,11 @@
     // ---------- Utilities ----------
     async function fetchJSON(url) {
       const res = await fetch(url);
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      if (!res.ok) {
+        let msg = `HTTP ${res.status}`;
+        try { const body = await res.json(); if (body.error) msg = body.error; } catch (_) {}
+        throw new Error(msg);
+      }
       return res.json();
     }
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1320,11 +1320,15 @@
     }
 
     // ---------- Chain detail ----------
+    let chainSigKey = '';
+
     async function showChain(chainId) {
       try {
+        const verifyURL = '/api/chains/' + encodeURIComponent(chainId) + '/verify' +
+          (chainSigKey ? '?public_key=' + encodeURIComponent(chainSigKey) : '');
         const [receipts, verification] = await Promise.all([
           fetchJSON('/api/receipts?chain_id=' + encodeURIComponent(chainId)),
-          fetchJSON('/api/chains/' + encodeURIComponent(chainId) + '/verify'),
+          fetchJSON(verifyURL),
         ]);
 
         receipts.sort((a, b) => a.sequence - b.sequence);
@@ -1337,10 +1341,18 @@
       }
     }
 
+    async function reverifyChain(chainId) {
+      const ta = document.getElementById('chain-sig-key');
+      chainSigKey = ta ? ta.value.trim() : '';
+      await showChain(chainId);
+    }
+
     function renderChainDetail(chainId, receipts, verification) {
       const verifyStatus = verification.valid
         ? '<span style="color:var(--status-success);font-weight:500;">Chain valid</span>'
         : `<span style="color:var(--status-failure);font-weight:500;">Chain broken at #${verification.broken_at}</span>`;
+
+      const hasSigResults = (verification.receipts || []).some(v => v.signature_valid != null);
 
       const verifyMap = {};
       (verification.receipts || []).forEach(v => { verifyMap[v.receipt_id] = v; });
@@ -1351,10 +1363,24 @@
           <span class="muted text-sm">${verification.length} receipts</span>
         </div>
 
+        <details class="mb-4" ${chainSigKey ? 'open' : ''}>
+          <summary class="muted text-sm" style="cursor:pointer;">Signature verification</summary>
+          <div class="mt-2 space-y-2">
+            <textarea id="chain-sig-key" class="font-mono text-xs" rows="4" style="width:100%;background:var(--surface-sunken);border:1px solid var(--border);border-radius:var(--radius);padding:6px 8px;resize:vertical;" placeholder="Paste PEM public key (-----BEGIN PUBLIC KEY-----…)">${escapeHtml(chainSigKey)}</textarea>
+            <button onclick="reverifyChain('${escapeAttr(chainId)}')" style="font-size:0.75rem;padding:4px 10px;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);cursor:pointer;">Verify signatures</button>
+            ${hasSigResults ? '<span class="muted text-xs ml-2">Sig badges shown below</span>' : ''}
+          </div>
+        </details>
+
         <div class="relative ml-4">
           ${receipts.map((r) => {
             const v = verifyMap[r.id] || {};
             const valid = v.hash_link_valid !== false && v.sequence_valid !== false;
+            const sigBadge = v.signature_valid === true
+              ? '<span class="badge badge-success" title="Signature valid">Sig ✓</span>'
+              : v.signature_valid === false
+                ? '<span class="badge badge-failure" title="Signature invalid">Sig ✗</span>'
+                : '';
             return `
               <div class="relative chain-line pl-6 pb-6 last:pb-0">
                 <div class="chain-dot ${valid ? 'valid' : 'invalid'}"></div>
@@ -1363,7 +1389,7 @@
                     <span class="font-mono text-xs">#${r.sequence} ${escapeHtml(r.action_type)}</span>
                     <div class="flex gap-2 items-center">
                       <span class="badge ${riskClass(r.risk_level)}">${escapeHtml(r.risk_level)}</span>
-                      <span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span>${mismatchIndicatorHTML(r)}
+                      <span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span>${sigBadge}${mismatchIndicatorHTML(r)}
                     </div>
                   </div>
                   <div class="muted text-xs" title="${escapeAttr(r.timestamp)}">${formatRelative(r.timestamp)}</div>

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1366,7 +1366,8 @@
         <details class="mb-4" ${chainSigKey ? 'open' : ''}>
           <summary class="muted text-sm" style="cursor:pointer;">Signature verification</summary>
           <div class="mt-2 space-y-2">
-            <textarea id="chain-sig-key" class="font-mono text-xs" rows="4" style="width:100%;background:var(--surface-sunken);border:1px solid var(--border);border-radius:var(--radius);padding:6px 8px;resize:vertical;" placeholder="Paste PEM public key (-----BEGIN PUBLIC KEY-----…)">${escapeHtml(chainSigKey)}</textarea>
+            <label for="chain-sig-key" class="muted text-xs">Ed25519 public key (PEM)</label>
+            <textarea id="chain-sig-key" class="font-mono text-xs" rows="4" style="width:100%;background:var(--surface-sunken);border:1px solid var(--border);border-radius:var(--radius);padding:6px 8px;resize:vertical;" placeholder="-----BEGIN PUBLIC KEY-----…" aria-label="Ed25519 public key for signature verification">${escapeHtml(chainSigKey)}</textarea>
             <button onclick="reverifyChain('${escapeAttr(chainId)}')" style="font-size:0.75rem;padding:4px 10px;border:1px solid var(--border);border-radius:var(--radius);background:var(--surface);cursor:pointer;">Verify signatures</button>
             ${hasSigResults ? '<span class="muted text-xs ml-2">Sig badges shown below</span>' : ''}
           </div>

--- a/internal/verify/chain.go
+++ b/internal/verify/chain.go
@@ -4,6 +4,8 @@
 package verify
 
 import (
+	"log"
+
 	"github.com/agent-receipts/ar/sdk/go/receipt"
 )
 
@@ -68,7 +70,10 @@ func VerifyChainLinks(receipts []receipt.AgentReceipt, publicKeyPEM string) Chai
 		}
 
 		if publicKeyPEM != "" {
-			ok, _ := receipt.Verify(r, publicKeyPEM)
+			ok, err := receipt.Verify(r, publicKeyPEM)
+			if err != nil {
+				log.Printf("signature verify error for receipt %s: %v", r.ID, err)
+			}
 			lv.SignatureValid = &ok
 		}
 

--- a/internal/verify/chain.go
+++ b/internal/verify/chain.go
@@ -13,6 +13,9 @@ type LinkVerification struct {
 	ReceiptID     string `json:"receipt_id"`
 	HashLinkValid bool   `json:"hash_link_valid"`
 	SequenceValid bool   `json:"sequence_valid"`
+	// SignatureValid is nil when no public key was provided (not checked),
+	// true when the Ed25519 signature is valid, false when invalid.
+	SignatureValid *bool `json:"signature_valid,omitempty"`
 }
 
 // ChainLinkResult holds the verification result for an entire chain.
@@ -24,8 +27,10 @@ type ChainLinkResult struct {
 }
 
 // VerifyChainLinks verifies the hash linkage and sequence ordering of a chain.
-// It does NOT verify signatures (no public key required).
-func VerifyChainLinks(receipts []receipt.AgentReceipt) ChainLinkResult {
+// When publicKeyPEM is non-empty, each receipt's Ed25519 signature is also
+// verified using the ar SDK; SignatureValid will be set per receipt.
+// When publicKeyPEM is empty, signature checks are skipped (SignatureValid is nil).
+func VerifyChainLinks(receipts []receipt.AgentReceipt, publicKeyPEM string) ChainLinkResult {
 	if len(receipts) == 0 {
 		return ChainLinkResult{Valid: true, Length: 0, BrokenAt: -1}
 	}
@@ -55,12 +60,19 @@ func VerifyChainLinks(receipts []receipt.AgentReceipt) ChainLinkResult {
 			seqValid = chain.Sequence == receipts[i-1].CredentialSubject.Chain.Sequence+1
 		}
 
-		results = append(results, LinkVerification{
+		lv := LinkVerification{
 			Index:         i,
 			ReceiptID:     r.ID,
 			HashLinkValid: hashValid,
 			SequenceValid: seqValid,
-		})
+		}
+
+		if publicKeyPEM != "" {
+			ok, _ := receipt.Verify(r, publicKeyPEM)
+			lv.SignatureValid = &ok
+		}
+
+		results = append(results, lv)
 
 		if brokenAt == -1 && (!hashValid || !seqValid) {
 			brokenAt = i

--- a/internal/verify/chain_test.go
+++ b/internal/verify/chain_test.go
@@ -39,7 +39,7 @@ func makeReceipt(id, chainID string, seq int, prevHash *string) receipt.AgentRec
 func strPtr(s string) *string { return &s }
 
 func TestVerifyChainLinks_Empty(t *testing.T) {
-	result := VerifyChainLinks(nil)
+	result := VerifyChainLinks(nil, "")
 	if !result.Valid {
 		t.Error("empty chain should be valid")
 	}
@@ -50,7 +50,7 @@ func TestVerifyChainLinks_Empty(t *testing.T) {
 
 func TestVerifyChainLinks_SingleReceipt(t *testing.T) {
 	r := makeReceipt("urn:receipt:001", "chain-1", 1, nil)
-	result := VerifyChainLinks([]receipt.AgentReceipt{r})
+	result := VerifyChainLinks([]receipt.AgentReceipt{r}, "")
 	if !result.Valid {
 		t.Errorf("single receipt should be valid, broken at %d", result.BrokenAt)
 	}
@@ -81,7 +81,7 @@ func TestVerifyChainLinks_ValidChain(t *testing.T) {
 	}
 	r3 := makeReceipt("urn:receipt:003", "chain-1", 3, &hash2)
 
-	result := VerifyChainLinks([]receipt.AgentReceipt{r1, r2, r3})
+	result := VerifyChainLinks([]receipt.AgentReceipt{r1, r2, r3}, "")
 	if !result.Valid {
 		t.Errorf("chain should be valid, broken at %d", result.BrokenAt)
 	}
@@ -102,7 +102,7 @@ func TestVerifyChainLinks_BrokenHash(t *testing.T) {
 	r1 := makeReceipt("urn:receipt:001", "chain-1", 1, nil)
 	r2 := makeReceipt("urn:receipt:002", "chain-1", 2, strPtr("sha256:wrong"))
 
-	result := VerifyChainLinks([]receipt.AgentReceipt{r1, r2})
+	result := VerifyChainLinks([]receipt.AgentReceipt{r1, r2}, "")
 	if result.Valid {
 		t.Error("chain with wrong hash should be invalid")
 	}
@@ -119,7 +119,7 @@ func TestVerifyChainLinks_BrokenSequence(t *testing.T) {
 	hash1, _ := receipt.HashReceipt(r1)
 	r2 := makeReceipt("urn:receipt:002", "chain-1", 5, &hash1) // gap in sequence
 
-	result := VerifyChainLinks([]receipt.AgentReceipt{r1, r2})
+	result := VerifyChainLinks([]receipt.AgentReceipt{r1, r2}, "")
 	if result.Valid {
 		t.Error("chain with sequence gap should be invalid")
 	}
@@ -138,7 +138,7 @@ func TestVerifyChainLinks_BrokenSequence(t *testing.T) {
 func TestVerifyChainLinks_FirstReceiptNonNilPrevHash(t *testing.T) {
 	r1 := makeReceipt("urn:receipt:001", "chain-1", 1, strPtr("sha256:shouldbenull"))
 
-	result := VerifyChainLinks([]receipt.AgentReceipt{r1})
+	result := VerifyChainLinks([]receipt.AgentReceipt{r1}, "")
 	if result.Valid {
 		t.Error("first receipt with non-nil prev hash should be invalid")
 	}
@@ -147,5 +147,103 @@ func TestVerifyChainLinks_FirstReceiptNonNilPrevHash(t *testing.T) {
 	}
 	if result.Receipts[0].HashLinkValid {
 		t.Error("hash link should be invalid (non-nil prev hash on first receipt)")
+	}
+}
+
+func TestVerifyChainLinks_SignatureValid(t *testing.T) {
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate key pair: %v", err)
+	}
+
+	unsigned := receipt.UnsignedAgentReceipt{
+		Context:      receipt.Context(),
+		ID:           "urn:receipt:s1",
+		Type:         receipt.CredentialType(),
+		Version:      receipt.Version,
+		Issuer:       receipt.Issuer{ID: "did:agent:test"},
+		IssuanceDate: "2026-04-01T10:00:00Z",
+		CredentialSubject: receipt.CredentialSubject{
+			Principal: receipt.Principal{ID: "did:user:test"},
+			Action: receipt.Action{
+				ID:        "act_s1",
+				Type:      "filesystem.file.read",
+				RiskLevel: receipt.RiskLow,
+				Timestamp: "2026-04-01T10:00:00Z",
+			},
+			Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:   receipt.Chain{Sequence: 1, ChainID: "chain-sig"},
+		},
+	}
+	signed, err := receipt.Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	result := VerifyChainLinks([]receipt.AgentReceipt{signed}, kp.PublicKey)
+	if len(result.Receipts) != 1 {
+		t.Fatalf("got %d results, want 1", len(result.Receipts))
+	}
+	sv := result.Receipts[0].SignatureValid
+	if sv == nil {
+		t.Fatal("SignatureValid should not be nil when public key provided")
+	}
+	if !*sv {
+		t.Error("signature should be valid for correctly signed receipt")
+	}
+}
+
+func TestVerifyChainLinks_SignatureInvalid(t *testing.T) {
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate key pair: %v", err)
+	}
+	wrongKP, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate wrong key pair: %v", err)
+	}
+
+	unsigned := receipt.UnsignedAgentReceipt{
+		Context:      receipt.Context(),
+		ID:           "urn:receipt:s2",
+		Type:         receipt.CredentialType(),
+		Version:      receipt.Version,
+		Issuer:       receipt.Issuer{ID: "did:agent:test"},
+		IssuanceDate: "2026-04-01T10:00:00Z",
+		CredentialSubject: receipt.CredentialSubject{
+			Principal: receipt.Principal{ID: "did:user:test"},
+			Action: receipt.Action{
+				ID:        "act_s2",
+				Type:      "filesystem.file.read",
+				RiskLevel: receipt.RiskLow,
+				Timestamp: "2026-04-01T10:00:00Z",
+			},
+			Outcome: receipt.Outcome{Status: receipt.StatusSuccess},
+			Chain:   receipt.Chain{Sequence: 1, ChainID: "chain-sig2"},
+		},
+	}
+	signed, err := receipt.Sign(unsigned, kp.PrivateKey, "did:agent:test#key-1")
+	if err != nil {
+		t.Fatalf("sign: %v", err)
+	}
+
+	result := VerifyChainLinks([]receipt.AgentReceipt{signed}, wrongKP.PublicKey)
+	if len(result.Receipts) != 1 {
+		t.Fatalf("got %d results, want 1", len(result.Receipts))
+	}
+	sv := result.Receipts[0].SignatureValid
+	if sv == nil {
+		t.Fatal("SignatureValid should not be nil when public key provided")
+	}
+	if *sv {
+		t.Error("signature should be invalid when verified with wrong key")
+	}
+}
+
+func TestVerifyChainLinks_NoPublicKey_SignatureNotChecked(t *testing.T) {
+	r1 := makeReceipt("urn:receipt:001", "chain-1", 1, nil)
+	result := VerifyChainLinks([]receipt.AgentReceipt{r1}, "")
+	if result.Receipts[0].SignatureValid != nil {
+		t.Error("SignatureValid should be nil when no public key provided")
 	}
 }


### PR DESCRIPTION
## Summary

- Adds optional Ed25519 signature verification to `GET /api/chains/{id}/verify` via a `public_key` query parameter
- The public key is accepted as a **PEM-encoded** string (URL-encoded in the query param) — this is the SDK's native format, requiring no conversion. Example: `curl "…/verify?public_key=$(python3 -c 'import urllib.parse,sys; print(urllib.parse.quote(open(sys.argv[1]).read()))' key.pem)"`
- When provided, each receipt is verified with `receipt.Verify()` from the ar SDK; `signature_valid: true/false` is added per receipt
- When omitted, `signature_valid` is absent — existing clients are unaffected
- Chain-level `valid` continues to reflect structural integrity only (hash linkage + sequence)
- UI: collapsible "Signature verification" panel in the chain modal with a PEM textarea and "Verify signatures" button; per-receipt **Sig ✓** (green) / **Sig ✗** (red) badges appear after verification

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes — new tests: `TestVerifyChainLinks_SignatureValid`, `_SignatureInvalid`, `_NoPublicKey_SignatureNotChecked` using ephemeral keys from `receipt.GenerateKeyPair()`
- [ ] Open a chain in the UI, paste a valid PEM public key, click "Verify signatures" → Sig ✓ badges appear
- [ ] Use wrong key → Sig ✗ badges appear
- [ ] Leave key empty → no badges, existing behaviour unchanged

Closes #5