### PR TITLE
fix: cap overview recent-receipts fetch to 20 rows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Overview "Recent receipts" now fetches only 20 rows from the server instead of the full store (up to 10,000 after #55), reducing unnecessary bandwidth and memory usage (#58)
+- Overview "Recent receipts" now fetches only `RECENT_LIMIT` (10) rows from the server instead of the full store (up to 10,000 after #55), reducing unnecessary bandwidth and memory usage. The `/api/receipts` endpoint now honours a `?limit=N` query parameter (capped at 10,000) (#58)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Overview "Recent receipts" now fetches only 20 rows from the server instead of the full store (up to 10,000 after #55), reducing unnecessary bandwidth and memory usage (#58)
+
 ### Added
 
 - Output status mismatch detection — flags receipts where the declared output hash does not match the computed value (#52)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -129,6 +130,14 @@ func (s *Server) handleReceipts(w http.ResponseWriter, r *http.Request) {
 	}
 	if v := q.Get("since"); v != "" {
 		f.Since = &v
+	}
+	if v := q.Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+			return
+		}
+		f.Limit = &n
 	}
 
 	rows, err := s.reader.ListReceipts(f)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -139,7 +139,7 @@ func (s *Server) handleReceipts(w http.ResponseWriter, r *http.Request) {
 		}
 		const maxLimit = 10000
 		if n > maxLimit {
-			writeError(w, http.StatusBadRequest, "limit must not exceed 10000")
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("limit must not exceed %d", maxLimit))
 			return
 		}
 		f.Limit = &n

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -137,6 +137,11 @@ func (s *Server) handleReceipts(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusBadRequest, "limit must be a positive integer")
 			return
 		}
+		const maxLimit = 10000
+		if n > maxLimit {
+			writeError(w, http.StatusBadRequest, "limit must not exceed 10000")
+			return
+		}
 		f.Limit = &n
 	}
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -152,6 +152,34 @@ func TestReceiptsEndpoint_FilterByRisk(t *testing.T) {
 	}
 }
 
+func TestReceiptsEndpoint_Limit(t *testing.T) {
+	srv := setupServer(t)
+
+	// Valid limit caps the result set.
+	req := httptest.NewRequest("GET", "/api/receipts?limit=1", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("limit=1: got status %d, want 200", w.Code)
+	}
+	var rows []store.ReceiptRow
+	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("limit=1: got %d rows, want 1", len(rows))
+	}
+
+	for _, bad := range []string{"0", "-1", "abc", "10001"} {
+		req = httptest.NewRequest("GET", "/api/receipts?limit="+bad, nil)
+		w = httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("limit=%s: got status %d, want 400", bad, w.Code)
+		}
+	}
+}
+
 func TestReceiptsEndpoint_FilterBySince(t *testing.T) {
 	srv := setupServer(t)
 	req := httptest.NewRequest("GET", "/api/receipts?since=2026-04-01T10:01:00Z", nil)

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -806,7 +806,7 @@
         renderStats(stats);
         renderHeaderContext(null, stats);
 
-        const receipts = await fetchJSON('/api/receipts');
+        const receipts = await fetchJSON('/api/receipts?limit=20');
         if (gen !== poller.generation) return;
         renderReceiptsTable(receipts.slice(0, RECENT_LIMIT), 'recent-receipts');
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -806,7 +806,7 @@
         renderStats(stats);
         renderHeaderContext(null, stats);
 
-        const receipts = await fetchJSON('/api/receipts?limit=20');
+        const receipts = await fetchJSON(`/api/receipts?limit=${RECENT_LIMIT}`);
         if (gen !== poller.generation) return;
         renderReceiptsTable(receipts.slice(0, RECENT_LIMIT), 'recent-receipts');
 


### PR DESCRIPTION
## Summary

The overview tab was fetching `/api/receipts` with no limit, pulling up to 10,000 rows just to display a handful in the "Recent receipts" section. Adds `?limit=20` to that specific fetch in `loadOverview()`. The full receipts view fetch is unchanged.

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [ ] Load dashboard with a large DB and confirm the overview loads quickly

Closes #58