### PR TITLE
feat(ui): render structured Intent and Authorization fields in receipt detail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Output status mismatch detection — flags receipts where the declared output hash does not match the computed value (#52)
 - Dashboard UI polish: context header showing active database, keyboard navigation between receipts, and loading skeletons (#53)
 - JSON export buttons in the receipt detail and chain detail modals — download individual receipts as `receipt-{id}.json` or entire chains as `chain-{chainId}.json` (#7)
+- Structured rendering of Intent and Authorization fields in the receipt detail modal: conversation/reasoning hashes (truncated with full hash on hover), truncated-preview indicator, and a new Authorization section showing scopes as badges, granted/expires timestamps, and grant ref (#6)
 
 ## [0.1.6] - 2026-05-19
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1376,7 +1376,7 @@
       if (hasScopes) {
         const badges = auth.scopes.map(s =>
           `<span class="badge badge-unknown" style="font-family:var(--font-mono);">${escapeHtml(s)}</span>`
-        ).join(' ');
+        ).join('');
         rows.push(`
           <div>
             <div class="muted text-xs mb-1">Scopes</div>
@@ -1391,7 +1391,8 @@
         ));
       }
       if (hasExpiresAt) {
-        const expired = new Date(auth.expires_at) < new Date();
+        const expiresDate = new Date(auth.expires_at);
+        const expired = !Number.isNaN(expiresDate.getTime()) && expiresDate < new Date();
         const expiredNote = expired
           ? ` <span style="color:var(--status-failure);font-size:0.75rem;">(expired)</span>`
           : '';

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1278,11 +1278,9 @@
             </div>
           </div>
 
-          ${subj.intent && subj.intent.prompt_preview ? `
-          <div>
-            <div class="muted text-xs mb-1">Intent</div>
-            <div class="text-sm" style="background:var(--surface-sunken);border:1px solid var(--border);border-radius:var(--radius);padding:8px 10px;">${escapeHtml(subj.intent.prompt_preview)}</div>
-          </div>` : ''}
+          ${intentSectionHTML(subj.intent)}
+
+          ${authorizationSectionHTML(subj.authorization)}
 
           ${parametersDisclosureHTML(subj.action.parameters_disclosure)}
 
@@ -1313,6 +1311,110 @@
           <div class="${cls}">${valueHTML}</div>
         </div>
       `;
+    }
+
+    // ---------- Intent section (modal body) ----------
+    function intentSectionHTML(intent) {
+      if (!intent) return '';
+      const hasPreview     = intent.prompt_preview && intent.prompt_preview.length > 0;
+      const hasConvHash    = intent.conversation_hash && intent.conversation_hash.length > 0;
+      const hasReasonHash  = intent.reasoning_hash && intent.reasoning_hash.length > 0;
+      if (!hasPreview && !hasConvHash && !hasReasonHash) return '';
+
+      const rows = [];
+
+      if (hasPreview) {
+        const truncatedNote = intent.prompt_preview_truncated
+          ? ` <span class="muted text-xs" style="font-style:italic;">(truncated)</span>`
+          : '';
+        rows.push(`
+          <div>
+            <div class="muted text-xs mb-1">Preview${truncatedNote}</div>
+            <div class="text-sm" style="background:var(--surface-sunken);border:1px solid var(--border);border-radius:var(--radius);padding:8px 10px;">${escapeHtml(intent.prompt_preview)}</div>
+          </div>`);
+      }
+
+      const hashRows = [];
+      if (hasConvHash) {
+        hashRows.push(kvBlock('Conversation',
+          `<span class="font-mono text-xs" title="${escapeAttr(intent.conversation_hash)}">${escapeHtml(truncateHash16(intent.conversation_hash))}</span>`
+        ));
+      }
+      if (hasReasonHash) {
+        hashRows.push(kvBlock('Reasoning',
+          `<span class="font-mono text-xs" title="${escapeAttr(intent.reasoning_hash)}">${escapeHtml(truncateHash16(intent.reasoning_hash))}</span>`
+        ));
+      }
+      if (hashRows.length > 0) {
+        rows.push(`<div class="grid grid-cols-2 gap-4">${hashRows.join('')}</div>`);
+      }
+
+      return `
+        <div>
+          <div class="muted text-xs mb-2">Intent</div>
+          <div class="space-y-2">${rows.join('')}</div>
+        </div>`;
+    }
+
+    function truncateHash16(h) {
+      if (!h) return '';
+      return h.length > 16 ? h.slice(0, 16) + '…' : h;
+    }
+
+    // ---------- Authorization section (modal body) ----------
+    function authorizationSectionHTML(auth) {
+      if (!auth || typeof auth !== 'object') return '';
+
+      const hasScopes    = Array.isArray(auth.scopes) && auth.scopes.length > 0;
+      const hasGrantedAt = auth.granted_at && auth.granted_at.length > 0;
+      const hasExpiresAt = auth.expires_at && auth.expires_at.length > 0;
+      const hasGrantRef  = auth.grant_ref && auth.grant_ref.length > 0;
+      if (!hasScopes && !hasGrantedAt && !hasExpiresAt && !hasGrantRef) return '';
+
+      const rows = [];
+
+      if (hasScopes) {
+        const badges = auth.scopes.map(s =>
+          `<span class="badge badge-unknown" style="font-family:var(--font-mono);">${escapeHtml(s)}</span>`
+        ).join(' ');
+        rows.push(`
+          <div>
+            <div class="muted text-xs mb-1">Scopes</div>
+            <div class="flex flex-wrap gap-1">${badges}</div>
+          </div>`);
+      }
+
+      const kvRows = [];
+      if (hasGrantedAt) {
+        kvRows.push(kvBlock('Granted',
+          `<span title="${escapeAttr(auth.granted_at)}">${escapeHtml(formatTime(auth.granted_at))}</span>`
+        ));
+      }
+      if (hasExpiresAt) {
+        const expired = new Date(auth.expires_at) < new Date();
+        const expiredNote = expired
+          ? ` <span style="color:var(--status-failure);font-size:0.75rem;">(expired)</span>`
+          : '';
+        kvRows.push(kvBlock('Expires',
+          `<span title="${escapeAttr(auth.expires_at)}">${escapeHtml(formatTime(auth.expires_at))}</span>${expiredNote}`
+        ));
+      }
+      if (kvRows.length > 0) {
+        rows.push(`<div class="grid grid-cols-2 gap-4">${kvRows.join('')}</div>`);
+      }
+
+      if (hasGrantRef) {
+        rows.push(kvBlock('Grant ref',
+          `<span class="font-mono text-xs">${escapeHtml(auth.grant_ref)}</span>`,
+          { small: true }
+        ));
+      }
+
+      return `
+        <div>
+          <div class="muted text-xs mb-2">Authorization</div>
+          <div class="space-y-2">${rows.join('')}</div>
+        </div>`;
     }
 
     // ---------- Outcome details (modal body) ----------

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1386,8 +1386,12 @@
 
       const kvRows = [];
       if (hasGrantedAt) {
+        const grantedDate = new Date(auth.granted_at);
+        const grantedVal = !Number.isNaN(grantedDate.getTime())
+          ? escapeHtml(formatTime(auth.granted_at))
+          : escapeHtml(auth.granted_at);
         kvRows.push(kvBlock('Granted',
-          `<span title="${escapeAttr(auth.granted_at)}">${escapeHtml(formatTime(auth.granted_at))}</span>`
+          `<span title="${escapeAttr(auth.granted_at)}">${grantedVal}</span>`
         ));
       }
       if (hasExpiresAt) {

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1337,12 +1337,12 @@
       const hashRows = [];
       if (hasConvHash) {
         hashRows.push(kvBlock('Conversation',
-          `<span class="font-mono text-xs" title="${escapeAttr(intent.conversation_hash)}">${escapeHtml(truncateHash16(intent.conversation_hash))}</span>`
+          `<span class="font-mono text-xs" title="${escapeAttr(intent.conversation_hash)}">${escapeHtml(truncateHash(intent.conversation_hash, 16))}</span>`
         ));
       }
       if (hasReasonHash) {
         hashRows.push(kvBlock('Reasoning',
-          `<span class="font-mono text-xs" title="${escapeAttr(intent.reasoning_hash)}">${escapeHtml(truncateHash16(intent.reasoning_hash))}</span>`
+          `<span class="font-mono text-xs" title="${escapeAttr(intent.reasoning_hash)}">${escapeHtml(truncateHash(intent.reasoning_hash, 16))}</span>`
         ));
       }
       if (hashRows.length > 0) {
@@ -1356,9 +1356,9 @@
         </div>`;
     }
 
-    function truncateHash16(h) {
+    function truncateHash(h, n = 12) {
       if (!h) return '';
-      return h.length > 16 ? h.slice(0, 16) + '…' : h;
+      return h.length > n ? h.slice(0, n) + '…' : h;
     }
 
     // ---------- Authorization section (modal body) ----------
@@ -1458,10 +1458,6 @@
       return `<div><div class="muted text-xs mb-2">Outcome</div><div class="space-y-2">${rows.join('')}</div></div>`;
     }
 
-    function truncateHash(h) {
-      if (!h) return '';
-      return h.length > 12 ? h.slice(0, 12) + '…' : h;
-    }
 
     function formatDuration(seconds) {
       if (seconds < 60) return `${seconds}s`;


### PR DESCRIPTION
## Summary

- Expands the **Intent** section in the receipt detail modal: shows `conversation_hash` and `reasoning_hash` as truncated monospace (first 16 chars, full hash in tooltip), and appends a gray "(truncated)" note to the prompt preview label when `prompt_preview_truncated` is true
- Adds an **Authorization** section between Intent and parameters disclosure: renders `scopes` as badges, `granted_at` / `expires_at` timestamps via `formatTime()` in a 2-col grid (with a red "(expired)" indicator when past), and `grant_ref` as monospace
- Both sections are omitted entirely when no relevant fields are present — no visual noise for minimal receipts
- No backend changes needed: `/api/receipts/{id}` already returns the full receipt JSON

Closes #6