### PR TITLE
fix(ui): cap action distribution chart to top 5

### DIFF
--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -893,14 +893,18 @@
         </div>
       `).join('') || '<div class="muted text-sm">No data</div>';
 
-      const maxAction = Math.max(...(stats.by_action || []).map(r => r.count), 1);
-      document.getElementById('action-chart').innerHTML = (stats.by_action || []).map(r => `
+      const allActions = stats.by_action || [];
+      const topActions = allActions.slice(0, 5);
+      const moreCount = allActions.length - topActions.length;
+      const maxAction = Math.max(...topActions.map(r => r.count), 1);
+      document.getElementById('action-chart').innerHTML = topActions.map(r => `
         <div class="bar-row">
           <span class="bar-label"><span class="badge">${escapeHtml(r.label)}</span></span>
           <div class="bar-track"><div class="bar-fill bar-action" style="width: ${(r.count / maxAction * 100)}%"></div></div>
           <span class="bar-count">${r.count}</span>
         </div>
-      `).join('') || '<div class="muted text-sm">No data</div>';
+      `).join('') + (moreCount > 0 ? `<div class="muted text-xs mt-1">+${moreCount} more</div>` : '')
+        || '<div class="muted text-sm">No data</div>';
     }
 
     function statCardHTML(opts) {


### PR DESCRIPTION
The action chart rendered one bar per distinct action type, which could be 20+ in a real store — pushing recent receipts far below the fold. Now shows top 5 (sorted by count, already the API order) with a "+N more" note when there are additional types.

Fixes the layout issue reported after v0.2.0.