### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2] - 2026-05-20
+
+### Fixed
+
+- Action distribution chart labels now truncate with ellipsis and show the full name on hover, preventing long action types from wrapping across multiple lines
+
 ## [0.2.1] - 2026-05-20
 
 ### Fixed


### PR DESCRIPTION
CHANGELOG entry for action chart label truncation fix.