### PR TITLE
chore(deps): bump sdk/go to v0.11.0 (v0.3.0 envelope migration)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,16 +3,18 @@ module github.com/agent-receipts/dashboard
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.9.0
+	github.com/agent-receipts/ar/sdk/go v0.11.0
 	modernc.org/sqlite v1.50.1
 )
 
 require (
+	github.com/cloudflare/circl v1.6.3 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	golang.org/x/crypto v0.45.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	modernc.org/libc v1.72.3 // indirect
 	modernc.org/mathutil v1.7.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-github.com/agent-receipts/ar/sdk/go v0.9.0 h1:UfFy16p/zaIgS31kmvC+c9dDthaINnSqSkIvfSQjyg4=
-github.com/agent-receipts/ar/sdk/go v0.9.0/go.mod h1:UW18urf7kPUlg49FcJe76/FuvS0mr+qYIVmMQ7ePECs=
+github.com/agent-receipts/ar/sdk/go v0.11.0 h1:qfwmZGO6yFgYaP6thtBGQouipyFid/lTwZ8DZ918KeU=
+github.com/agent-receipts/ar/sdk/go v0.11.0/go.mod h1:rV1TjisR+09QWX3JQ6/gP5KFVyCF8fteM4u9+VTFB9g=
+github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
+github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=
@@ -14,6 +16,8 @@ github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOF
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
+golang.org/x/crypto v0.45.0 h1:jMBrvKuj23MTlT0bQEOBcAE0mjg8mK9RXFhRH6nyF3Q=
+golang.org/x/crypto v0.45.0/go.mod h1:XTGrrkGJve7CYK7J8PEww4aY7gM3qMCElcJQ8n8JdX4=
 golang.org/x/mod v0.33.0 h1:tHFzIWbBifEmbwtGz65eaWyGiGZatSrT9prnU8DbVL8=
 golang.org/x/mod v0.33.0/go.mod h1:swjeQEj+6r7fODbD2cqrnje9PnziFuw4bmLbBZFrQ5w=
 golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -1,12 +1,28 @@
 package store
 
 import (
-	"strings"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
 	sdkstore "github.com/agent-receipts/ar/sdk/go/store"
 )
+
+// testDisclosureEnvelope returns a sentinel HPKE disclosure envelope sized to
+// match the v1 ciphersuite (ADR-0012). Values are placeholder bytes — never
+// decryptable — but the receipt store does not validate envelope contents, so
+// they exercise the "has disclosure" code paths end-to-end.
+func testDisclosureEnvelope(kid string, ct string) *receipt.DisclosureEnvelope {
+	return &receipt.DisclosureEnvelope{
+		V:   "1",
+		Alg: "hpke-x25519-hkdf-sha256-aes-256-gcm",
+		Recipients: []receipt.DisclosureRecipient{{
+			KID: kid,
+			// 43-char unpadded base64url placeholder matching X25519 enc width.
+			Enc: "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		}},
+		CT: ct,
+	}
+}
 
 func makeReceipt(id, chainID string, seq int, actionType string, risk receipt.RiskLevel, status receipt.OutcomeStatus, ts string, prevHash *string) receipt.AgentReceipt {
 	return receipt.AgentReceipt{
@@ -394,7 +410,14 @@ func TestReader_ListReceipts_ServerAndTool(t *testing.T) {
 	}
 }
 
-func TestReader_ListReceipts_ParametersDisclosurePreview(t *testing.T) {
+func TestReader_ListReceipts_ParametersDisclosurePresence(t *testing.T) {
+	// Under the v0.3.0 envelope shape (ADR-0012), parameters_disclosure is an
+	// opaque HPKE ciphertext blob — there are no `input`/`output` keys to
+	// preview. The list view's HasParametersDisclosure indicator must still
+	// fire whenever an envelope is present, and the preview columns must
+	// remain empty (the SQL json_extract paths target keys that no longer
+	// exist on the wire). Rendering the envelope itself is out of scope here;
+	// see the follow-up issue for the detail-view UX.
 	dbPath := t.TempDir() + "/disclosure-test.db"
 	s, err := sdkstore.Open(dbPath)
 	if err != nil {
@@ -403,32 +426,13 @@ func TestReader_ListReceipts_ParametersDisclosurePreview(t *testing.T) {
 
 	withDisclosure := makeReceipt("urn:receipt:d1", "chain-d", 1,
 		"tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z", nil)
-	withDisclosure.CredentialSubject.Action.ParametersDisclosure = map[string]string{
-		"input":  "read /etc/passwd",
-		"output": "root:x:0:0:root:/root:/bin/bash",
-	}
+	withDisclosure.CredentialSubject.Action.ParametersDisclosure = testDisclosureEnvelope(
+		"did:key:test#enc-1", "ciphertext-placeholder-d1")
 
-	// A receipt with a disclosure value longer than the preview cap so we can
-	// confirm SQL truncates rather than streaming the whole thing.
-	long := strings.Repeat("A", 500)
-	withLong := makeReceipt("urn:receipt:d2", "chain-d", 2,
+	withoutDisclosure := makeReceipt("urn:receipt:d2", "chain-d", 2,
 		"tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:01:00Z", nil)
-	withLong.CredentialSubject.Action.ParametersDisclosure = map[string]string{
-		"input": long,
-	}
 
-	// A receipt with disclosure containing only non-primary keys (no input/output).
-	withNonPrimaryKeys := makeReceipt("urn:receipt:d2b", "chain-d", 3,
-		"tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:01:30Z", nil)
-	withNonPrimaryKeys.CredentialSubject.Action.ParametersDisclosure = map[string]string{
-		"api_key": "sk-...",
-		"region": "us-west-2",
-	}
-
-	withoutDisclosure := makeReceipt("urn:receipt:d3", "chain-d", 4,
-		"tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:02:00Z", nil)
-
-	for _, r := range []receipt.AgentReceipt{withDisclosure, withLong, withNonPrimaryKeys, withoutDisclosure} {
+	for _, r := range []receipt.AgentReceipt{withDisclosure, withoutDisclosure} {
 		hash, err := receipt.HashReceipt(r)
 		if err != nil {
 			t.Fatalf("hash: %v", err)
@@ -449,97 +453,56 @@ func TestReader_ListReceipts_ParametersDisclosurePreview(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-	if len(rows) != 4 {
-		t.Fatalf("got %d rows, want 4", len(rows))
+	if len(rows) != 2 {
+		t.Fatalf("got %d rows, want 2", len(rows))
 	}
 
-	// newest-first: d3, d2b, d2, d1.
+	// newest-first: d2 (no envelope), d1 (envelope).
+	if rows[0].HasParametersDisclosure {
+		t.Errorf("d2 (no envelope) got HasParametersDisclosure=true, want false")
+	}
 	if rows[0].ParametersInputPreview != "" || rows[0].ParametersOutputPreview != "" {
-		t.Errorf("d3 (no disclosure) got input=%q output=%q, want empty",
+		t.Errorf("d2 (no envelope) got non-empty previews input=%q output=%q",
 			rows[0].ParametersInputPreview, rows[0].ParametersOutputPreview)
 	}
-	if rows[0].HasParametersDisclosure {
-		t.Errorf("d3 (no disclosure) got HasParametersDisclosure=true, want false")
-	}
 
-	// d2b: has disclosure (non-primary keys only) but no input/output previews.
-	if rows[1].ParametersInputPreview != "" || rows[1].ParametersOutputPreview != "" {
-		t.Errorf("d2b (non-primary keys only) got input=%q output=%q, want both empty",
-			rows[1].ParametersInputPreview, rows[1].ParametersOutputPreview)
-	}
 	if !rows[1].HasParametersDisclosure {
-		t.Errorf("d2b (has disclosure) got HasParametersDisclosure=false, want true")
+		t.Errorf("d1 (envelope present) got HasParametersDisclosure=false, want true")
 	}
-
-	if got := len(rows[2].ParametersInputPreview); got != disclosurePreviewMaxLen {
-		t.Errorf("d2 input preview length = %d, want %d (truncated)", got, disclosurePreviewMaxLen)
-	}
-	if rows[2].ParametersOutputPreview != "" {
-		t.Errorf("d2 output preview = %q, want empty", rows[2].ParametersOutputPreview)
-	}
-	if !rows[2].HasParametersDisclosure {
-		t.Errorf("d2 (has disclosure) got HasParametersDisclosure=false, want true")
-	}
-
-	if rows[3].ParametersInputPreview != "read /etc/passwd" {
-		t.Errorf("d1 input preview = %q, want %q", rows[3].ParametersInputPreview, "read /etc/passwd")
-	}
-	if rows[3].ParametersOutputPreview != "root:x:0:0:root:/root:/bin/bash" {
-		t.Errorf("d1 output preview = %q, want %q",
-			rows[3].ParametersOutputPreview, "root:x:0:0:root:/root:/bin/bash")
-	}
-	if !rows[3].HasParametersDisclosure {
-		t.Errorf("d1 (has disclosure) got HasParametersDisclosure=false, want true")
+	// The envelope is opaque to the reader, so the legacy input/output
+	// previews must be empty — surfacing ciphertext would be misleading.
+	if rows[1].ParametersInputPreview != "" || rows[1].ParametersOutputPreview != "" {
+		t.Errorf("d1 (envelope) got non-empty previews input=%q output=%q; envelope payload must not leak into list view",
+			rows[1].ParametersInputPreview, rows[1].ParametersOutputPreview)
 	}
 }
 
 func TestReader_ListReceipts_OutputStatusMismatch(t *testing.T) {
+	// Pre-v0.3.0 the reader inspected parameters_disclosure.output for an
+	// isError:true marker so it could flag MCP receipts whose outcome.status
+	// had been stamped before the response payload was inspected (issue #50).
+	// Under ADR-0012 the envelope is opaque ciphertext — the dashboard cannot
+	// peek inside without the forensic private key — so OutputStatusMismatch
+	// must always be false at the list-view layer, regardless of whether an
+	// envelope is attached. Detecting the mismatch will move to whatever
+	// component eventually holds the disclosure key; see follow-up issue.
 	dbPath := t.TempDir() + "/mismatch-test.db"
 	s, err := sdkstore.Open(dbPath)
 	if err != nil {
 		t.Fatalf("open sdk store: %v", err)
 	}
 
-	// status=success + output JSON with isError:true → mismatch.
-	mismatch := makeReceipt("urn:receipt:m1", "chain-m", 1,
+	// status=success + envelope present (legacy mismatch source) → still false.
+	withEnvelope := makeReceipt("urn:receipt:m1", "chain-m", 1,
 		"mcp.tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z", nil)
-	mismatch.CredentialSubject.Action.ParametersDisclosure = map[string]string{
-		"output": `{"content":[{"text":"401 Bad credentials","type":"text"}],"isError":true}`,
-	}
+	withEnvelope.CredentialSubject.Action.ParametersDisclosure = testDisclosureEnvelope(
+		"did:key:test#enc-1", "opaque-ciphertext-m1")
 
-	// status=success + output JSON with isError:false → consistent, no mismatch.
-	clean := makeReceipt("urn:receipt:m2", "chain-m", 2,
+	// status=success, no disclosure → false (control).
+	bare := makeReceipt("urn:receipt:m2", "chain-m", 2,
 		"mcp.tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:01:00Z", nil)
-	clean.CredentialSubject.Action.ParametersDisclosure = map[string]string{
-		"output": `{"content":[{"text":"ok"}],"isError":false}`,
-	}
 
-	// status=success + output JSON without isError key → no mismatch.
-	noFlag := makeReceipt("urn:receipt:m3", "chain-m", 3,
-		"mcp.tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:02:00Z", nil)
-	noFlag.CredentialSubject.Action.ParametersDisclosure = map[string]string{
-		"output": `{"content":[{"text":"ok"}]}`,
-	}
-
-	// status=failure + output JSON with isError:true → consistent, no mismatch.
-	expectedFail := makeReceipt("urn:receipt:m4", "chain-m", 4,
-		"mcp.tool.call", receipt.RiskLow, receipt.StatusFailure, "2026-04-01T10:03:00Z", nil)
-	expectedFail.CredentialSubject.Action.ParametersDisclosure = map[string]string{
-		"output": `{"isError":true}`,
-	}
-
-	// status=success + plain (non-JSON) string output → no mismatch.
-	plain := makeReceipt("urn:receipt:m5", "chain-m", 5,
-		"mcp.tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:04:00Z", nil)
-	plain.CredentialSubject.Action.ParametersDisclosure = map[string]string{
-		"output": "plain text body, not JSON",
-	}
-
-	// status=success + no disclosure at all → no mismatch.
-	bare := makeReceipt("urn:receipt:m6", "chain-m", 6,
-		"mcp.tool.call", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:05:00Z", nil)
-
-	for _, r := range []receipt.AgentReceipt{mismatch, clean, noFlag, expectedFail, plain, bare} {
+	for _, r := range []receipt.AgentReceipt{withEnvelope, bare} {
 		hash, err := receipt.HashReceipt(r)
 		if err != nil {
 			t.Fatalf("hash: %v", err)
@@ -560,31 +523,9 @@ func TestReader_ListReceipts_OutputStatusMismatch(t *testing.T) {
 	if err != nil {
 		t.Fatalf("list: %v", err)
 	}
-
-	byID := map[string]ReceiptRow{}
-	for _, r := range rows {
-		byID[r.ID] = r
-	}
-
-	cases := []struct {
-		id   string
-		want bool
-	}{
-		{"urn:receipt:m1", true},
-		{"urn:receipt:m2", false},
-		{"urn:receipt:m3", false},
-		{"urn:receipt:m4", false},
-		{"urn:receipt:m5", false},
-		{"urn:receipt:m6", false},
-	}
-	for _, tc := range cases {
-		row, ok := byID[tc.id]
-		if !ok {
-			t.Errorf("%s missing from results", tc.id)
-			continue
-		}
-		if row.OutputStatusMismatch != tc.want {
-			t.Errorf("%s: OutputStatusMismatch=%v, want %v", tc.id, row.OutputStatusMismatch, tc.want)
+	for _, row := range rows {
+		if row.OutputStatusMismatch {
+			t.Errorf("%s: OutputStatusMismatch=true, want false under envelope-shape disclosure", row.ID)
 		}
 	}
 }

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"database/sql"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -527,6 +528,89 @@ func TestReader_ListReceipts_OutputStatusMismatch(t *testing.T) {
 		if row.OutputStatusMismatch {
 			t.Errorf("%s: OutputStatusMismatch=true, want false under envelope-shape disclosure", row.ID)
 		}
+	}
+}
+
+// TestReader_ListReceipts_OutputStatusMismatch_LegacyShape pins that the
+// SQL mismatch detector still flags pre-v0.3.0 receipts that physically
+// carry the flat-map disclosure shape on disk. The sdkstore Insert path
+// will not produce these — the typed Go API requires
+// *receipt.DisclosureEnvelope — so we INSERT a raw receipt_json blob
+// directly to simulate a store seeded under an older SDK that has not
+// been re-keyed. The SQL in reader.go is shape-agnostic by design: it
+// looks for .parameters_disclosure.output, and a legacy row still has
+// that key.
+func TestReader_ListReceipts_OutputStatusMismatch_LegacyShape(t *testing.T) {
+	dbPath := t.TempDir() + "/mismatch-legacy.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+	s.Close()
+
+	// Open a raw sqlite handle (read-write) and insert a v0.2.x-shaped
+	// receipt whose parameters_disclosure.output is a JSON-encoded string
+	// containing isError:true. Status is "success" — the exact mismatch
+	// the SQL is meant to flag.
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open raw sqlite: %v", err)
+	}
+	defer db.Close()
+
+	const legacyReceiptJSON = `{
+		"@context":["https://www.w3.org/ns/credentials/v2","https://agentreceipts.ai/context/v1"],
+		"id":"urn:receipt:legacy-1",
+		"type":["VerifiableCredential","AgentReceipt"],
+		"version":"0.2.2",
+		"issuer":{"id":"did:agent:test-agent"},
+		"issuanceDate":"2026-03-01T09:00:00Z",
+		"credentialSubject":{
+			"principal":{"id":"did:user:test-user"},
+			"action":{
+				"id":"act_legacy-1",
+				"type":"mcp.tool.call",
+				"risk_level":"low",
+				"timestamp":"2026-03-01T09:00:00Z",
+				"parameters_disclosure":{
+					"input":"{\"path\":\"/etc/hosts\"}",
+					"output":"{\"isError\":true,\"content\":[{\"type\":\"text\",\"text\":\"denied\"}]}"
+				}
+			},
+			"outcome":{"status":"success"},
+			"chain":{"sequence":1,"previous_receipt_hash":null,"chain_id":"chain-legacy"}
+		},
+		"proof":{"type":"Ed25519Signature2020","proofValue":"u-legacy-1"}
+	}`
+
+	if _, err := db.Exec(
+		`INSERT INTO receipts (id, chain_id, sequence, action_type, risk_level, status, timestamp, issuer_id, receipt_json, receipt_hash)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		"urn:receipt:legacy-1", "chain-legacy", 1, "mcp.tool.call", "low", "success",
+		"2026-03-01T09:00:00Z", "did:agent:test-agent", legacyReceiptJSON, "sha256:legacy",
+	); err != nil {
+		t.Fatalf("insert legacy receipt: %v", err)
+	}
+	db.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	rows, err := reader.ListReceipts(Filter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if !rows[0].OutputStatusMismatch {
+		t.Errorf("legacy mismatch row got OutputStatusMismatch=false, want true (status=success + parameters_disclosure.output.isError=true)")
+	}
+	if !rows[0].HasParametersDisclosure {
+		t.Errorf("legacy row got HasParametersDisclosure=false, want true")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Bump `github.com/agent-receipts/ar/sdk/go` from `v0.9.0` to the stable `v0.11.0`.
- Refactor `internal/store/reader_test.go` so it compiles against the new envelope-shape `Action.ParametersDisclosure` (`*receipt.DisclosureEnvelope` instead of the legacy `map[string]string`).
- Production code in `internal/store/reader.go` builds unchanged; no runtime behaviour rewrite in this PR.

## Why

Phase 6 of the `v0.3.0` release in `agent-receipts/ar` (issue [#280](https://github.com/agent-receipts/ar/issues/280)): the SDK has graduated to `v0.11.0`, and per ADR-0012 `parameters_disclosure` switched from a flat `{input, output}` map to an HPKE-encrypted `DisclosureEnvelope` (`{v, alg, recipients, ct}`). Consumers must move off the alpha.

## Test plan

- [x] `go build ./...` clean locally
- [x] `go vet ./...` clean locally
- [x] `go test ./...` clean locally (all four packages green)
- [ ] CI green on the same commands
- [ ] Lefthook pre-commit hooks (go-vet, go-fmt, go-test) ran on commit

### Test refactor scope

- `TestReader_ListReceipts_ParametersDisclosurePreview` → renamed to `TestReader_ListReceipts_ParametersDisclosurePresence`. The old test exercised the SQL `json_extract(..., '.parameters_disclosure.input/.output')` preview path against a `map[string]string` literal. Under the envelope shape those keys no longer exist on the wire, so the previews are necessarily empty; the rewritten test asserts the `HasParametersDisclosure` indicator still fires when an envelope is attached and that no envelope payload leaks into the preview columns. The long-string SQL-truncation sub-case and the non-primary-keys sub-case were dropped — neither has a v0.3.0 analog.
- `TestReader_ListReceipts_OutputStatusMismatch` reduced from six cases to two. The legacy SQL inspected `parameters_disclosure.output` for an `isError:true` marker (issue #50). The dashboard cannot peek inside an encrypted envelope, so the flag is now always `false` at the list-view layer; the test asserts exactly that under both "envelope present" and "no disclosure" rows.
- A shared `testDisclosureEnvelope(kid, ct)` helper builds a sentinel `*receipt.DisclosureEnvelope` (43-char placeholder `enc`, opaque `ct`) so the assignment sites stay one line and stay aligned with the v1 ciphersuite shape.

## Follow-up

The dashboard's UI rendering of `parameters_disclosure` under the envelope shape is a separate piece of work. The envelope is opaque ciphertext (only the forensic-key holder can decrypt it), so:

- The legacy "show input / output" detail view does not apply as-is.
- The SQL preview path in `reader.go` (`disclosurePreviewMaxLen`, `json_extract` of `.input`/`.output`) still runs but now always yields empty strings — left in place rather than ripped out so the follow-up can decide whether to render envelope metadata (alg, recipient kid count) or wire up a decryption path.
- `OutputStatusMismatch` detection (issue #50) needs to move to whatever component eventually holds the forensic key, since the list-view reader can no longer see inside the payload.

A separate issue should track the rendering UX. This PR is purely the compile/test path.