### PR TITLE
test(store): drop double-close on raw sqlite handle in legacy-shape test

### DIFF
--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -556,7 +556,8 @@ func TestReader_ListReceipts_OutputStatusMismatch_LegacyShape(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open raw sqlite: %v", err)
 	}
-	defer db.Close()
+	// No defer: the writer must be closed before OpenReadOnly so the
+	// reader sees a quiesced file. Single explicit Close below.
 
 	const legacyReceiptJSON = `{
 		"@context":["https://www.w3.org/ns/credentials/v2","https://agentreceipts.ai/context/v1"],
@@ -591,7 +592,9 @@ func TestReader_ListReceipts_OutputStatusMismatch_LegacyShape(t *testing.T) {
 	); err != nil {
 		t.Fatalf("insert legacy receipt: %v", err)
 	}
-	db.Close()
+	if err := db.Close(); err != nil {
+		t.Fatalf("close raw sqlite: %v", err)
+	}
 
 	reader, err := OpenReadOnly(dbPath)
 	if err != nil {

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -556,8 +556,13 @@ func TestReader_ListReceipts_OutputStatusMismatch_LegacyShape(t *testing.T) {
 	if err != nil {
 		t.Fatalf("open raw sqlite: %v", err)
 	}
-	// No defer: the writer must be closed before OpenReadOnly so the
-	// reader sees a quiesced file. Single explicit Close below.
+	// Failure-path safety net: if any t.Fatalf below short-circuits the
+	// explicit Close, t.Cleanup still releases the handle. database/sql's
+	// DB.Close is idempotent (sets a `closed` flag, subsequent calls return
+	// nil), so this is a no-op on the happy path. The explicit Close before
+	// OpenReadOnly is the load-bearing one — it surfaces errors and quiesces
+	// the file before the reader opens it.
+	t.Cleanup(func() { _ = db.Close() })
 
 	const legacyReceiptJSON = `{
 		"@context":["https://www.w3.org/ns/credentials/v2","https://agentreceipts.ai/context/v1"],


### PR DESCRIPTION
## Summary

Removes the `defer db.Close()` paired with the explicit `db.Close()` that landed in #67's `TestReader_ListReceipts_OutputStatusMismatch_LegacyShape`. Switches the explicit close to an error-checked form so an inner-Close failure surfaces instead of being silently masked by the deferred one.

## Why

Copilot review on #67 flagged the double-close after the fix-push but before I had a chance to address it; I merged on CI-green and missed the second-pass review. This is the follow-up.

The explicit close is the load-bearing one — the writer must be quiesced before `OpenReadOnly` opens the file in read-only mode. The defer was redundant safety that just hid Close errors.

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./internal/store/ -run LegacyShape -v` — `TestReader_ListReceipts_OutputStatusMismatch_LegacyShape` passes
- [x] `go test ./...` — all four packages green