### PR TITLE
chore(release): bump to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-05-22
+
+### Changed
+
+- **Bump `github.com/agent-receipts/ar/sdk/go` to `v0.11.0`** (#67) — picks up the v0.3.0 envelope-shape `Action.parameters_disclosure` (`*receipt.DisclosureEnvelope` instead of the legacy `map[string]string`). Per [agent-receipts/ar#280](https://github.com/agent-receipts/ar/issues/280) and validated in [agent-receipts/ar#519](https://github.com/agent-receipts/ar/issues/519) Section 5.
+
+### Fixed
+
+- `internal/store/reader_test.go` refactored to compile against the envelope-shape disclosure type and to keep coverage of the SQL `OutputStatusMismatch` detector for both shapes (#67, #68). A new `TestReader_ListReceipts_OutputStatusMismatch_LegacyShape` inserts a raw v0.2.x-shaped `receipt_json` directly into the test DB so the legacy-flat-map mismatch path stays covered after the typed `sdkstore.Insert` switched to enforcing the envelope shape.
+
+### Known follow-up
+
+- The list-view disclosure preview path in `internal/store/reader.go` (`json_extract` of `.input` / `.output`, `disclosurePreviewMaxLen` truncation) is now functionally dead under v0.3.0: the envelope payload is opaque ciphertext, so the SQL extraction always yields empty strings. The detail-view rendering UX for encrypted disclosure (whether to surface envelope metadata, wire up a decryption path, etc.) is deliberately out of scope for this release and tracked separately.
+
 ## [0.2.2] - 2026-05-20
 
 ### Fixed
@@ -102,7 +116,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Server now binds to `localhost` by default; `--host` flag added for custom binding
 
-[Unreleased]: https://github.com/agent-receipts/dashboard/compare/v0.1.6...HEAD
+[Unreleased]: https://github.com/agent-receipts/dashboard/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/agent-receipts/dashboard/compare/v0.2.2...v0.3.0
+[0.2.2]: https://github.com/agent-receipts/dashboard/compare/v0.2.1...v0.2.2
+[0.2.1]: https://github.com/agent-receipts/dashboard/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/agent-receipts/dashboard/compare/v0.1.6...v0.2.0
 [0.1.6]: https://github.com/agent-receipts/dashboard/compare/v0.1.5...v0.1.6
 [0.1.5]: https://github.com/agent-receipts/dashboard/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/agent-receipts/dashboard/compare/v0.1.3...v0.1.4


### PR DESCRIPTION
## What

Cuts the dashboard `v0.3.0` release notes:

- New `[0.3.0] - 2026-05-22` CHANGELOG section covering #67 (sdk/go v0.11.0 bump, envelope-shape `parameters_disclosure`) and #68 (raw-row legacy-mismatch test + double-close cleanup).
- Documents the known follow-up: the list-view disclosure preview path in `internal/store/reader.go` is now functionally dead under v0.3.0 (envelope is opaque ciphertext); a real rendering UX for the encrypted envelope is a separate piece of work.
- Backfills missing `[Unreleased]` / `[0.3.0]` / `[0.2.2]` / `[0.2.1]` / `[0.2.0]` compare links at the bottom of `CHANGELOG.md` — they had stopped being updated after `0.1.6`.

No source changes — goreleaser injects `main.version` via `-X` ldflag from the tag, so there is nothing else to bump in code.

## Why

Phase 6 of the v0.3.0 release in `agent-receipts/ar` (issue [#280](https://github.com/agent-receipts/ar/issues/280)). The dashboard needs a tagged release to refresh the `agent-receipts/homebrew-tap` formula (`dashboard.rb` currently pins `v0.2.2`); main has been on the v0.3.0 SDK since #67/#68 but no end users have it yet.

After this PR merges, push the tag to ship:

```sh
git checkout main && git pull
git tag v0.3.0
git push origin v0.3.0
```

`.github/workflows/release.yml` will run goreleaser → builds linux/macos amd64+arm64 binaries, creates the GitHub Release, and pushes the new formula to the tap.

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] New functionality includes tests (n/a — CHANGELOG-only)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] AGENTS.md updated if project structure changed (no project structure change)
- [ ] Request a Copilot review for automated checks