### PR TITLE
Fix chain verification false negative with forward-compat fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Chain verification false negative** ([agent-receipts/ar#719](https://github.com/agent-receipts/ar/issues/719)) — `/api/chains/{id}/verify` reported valid chains as broken. The recomputed hash linkage round-tripped each receipt through the Go struct (`receipt.HashReceipt`), which drops any forward-compat fields a newer SDK wrote, so it disagreed with the canonical hash the collector stored. Verification now recomputes from the verbatim `receipt_json` wire bytes via `receipt.HashRawReceipt`, matching `agent-receipts verify` and any auditor reading the raw bytes. `store.GetChain` now returns the raw bytes alongside the parsed receipt.
+
 ## [0.3.0] - 2026-05-22
 
 ### Changed

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -358,6 +358,90 @@ func TestChainVerifyEndpoint(t *testing.T) {
 	}
 }
 
+// TestChainVerifyEndpoint_ForwardCompatChain is the end-to-end regression for
+// issue #719. A collector persists receipts via InsertRaw, keeping the verbatim
+// wire bytes (which may carry fields a newer SDK added) and storing the hash
+// computed over those bytes. The verify endpoint must read those raw bytes back
+// and recompute the same hash — reporting the chain as valid, not broken.
+func TestChainVerifyEndpoint_ForwardCompatChain(t *testing.T) {
+	dbPath := t.TempDir() + "/fc-receipts.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	// rawWithFutureField marshals r and splices in a top-level field the
+	// AgentReceipt struct does not know about, then returns the bytes and
+	// their canonical (raw) hash.
+	rawWithFutureField := func(r receipt.AgentReceipt) ([]byte, string) {
+		var generic map[string]any
+		b, mErr := json.Marshal(r)
+		if mErr != nil {
+			t.Fatalf("marshal: %v", mErr)
+		}
+		if uErr := json.Unmarshal(b, &generic); uErr != nil {
+			t.Fatalf("unmarshal: %v", uErr)
+		}
+		generic["_future_field"] = "v2"
+		raw, mErr := json.Marshal(generic)
+		if mErr != nil {
+			t.Fatalf("marshal enriched: %v", mErr)
+		}
+		h, hErr := receipt.HashRawReceipt(raw)
+		if hErr != nil {
+			t.Fatalf("hash raw: %v", hErr)
+		}
+		return raw, h
+	}
+
+	r1 := makeReceipt("urn:receipt:f01", "fc-chain", 1, "filesystem.file.read", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z", nil)
+	raw1, hash1 := rawWithFutureField(r1)
+	r2 := makeReceipt("urn:receipt:f02", "fc-chain", 2, "filesystem.file.modify", receipt.RiskMedium, receipt.StatusSuccess, "2026-04-01T10:01:00Z", &hash1)
+	raw2, hash2 := rawWithFutureField(r2)
+	r3 := makeReceipt("urn:receipt:f03", "fc-chain", 3, "communication.email.send", receipt.RiskHigh, receipt.StatusSuccess, "2026-04-01T10:02:00Z", &hash2)
+	raw3, hash3 := rawWithFutureField(r3)
+
+	for _, rec := range []struct {
+		r   receipt.AgentReceipt
+		raw []byte
+		h   string
+	}{{r1, raw1, hash1}, {r2, raw2, hash2}, {r3, raw3, hash3}} {
+		if err := s.InsertRaw(rec.r, rec.raw, rec.h); err != nil {
+			t.Fatalf("insert raw: %v", err)
+		}
+	}
+	s.Close()
+
+	reader, err := store.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { reader.Close() })
+	srv := New(reader, Config{})
+
+	req := httptest.NewRequest("GET", "/api/chains/fc-chain/verify", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200", w.Code)
+	}
+	var result struct {
+		Valid    bool `json:"valid"`
+		Length   int  `json:"length"`
+		BrokenAt int  `json:"broken_at"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &result); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !result.Valid {
+		t.Errorf("forward-compat chain should be valid, broken at %d", result.BrokenAt)
+	}
+	if result.Length != 3 {
+		t.Errorf("got length %d, want 3", result.Length)
+	}
+}
+
 func TestChainVerifyEndpoint_EmptyChain(t *testing.T) {
 	srv := setupServer(t)
 	req := httptest.NewRequest("GET", "/api/chains/nonexistent/verify", nil)

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -289,15 +289,18 @@ func (r *Reader) GetChain(chainID string) ([]ChainReceipt, error) {
 
 	var out []ChainReceipt
 	for rows.Next() {
-		var rJSON string
-		if err := rows.Scan(&rJSON); err != nil {
+		// Scan into []byte (not string): database/sql hands *[]byte a fresh
+		// copy owned by the caller, so we reuse the one allocation for both
+		// Unmarshal and the retained Raw bytes instead of copying twice.
+		var rawJSON []byte
+		if err := rows.Scan(&rawJSON); err != nil {
 			return nil, err
 		}
 		var ar receipt.AgentReceipt
-		if err := json.Unmarshal([]byte(rJSON), &ar); err != nil {
+		if err := json.Unmarshal(rawJSON, &ar); err != nil {
 			return nil, fmt.Errorf("corrupt receipt in chain %s: %w", chainID, err)
 		}
-		out = append(out, ChainReceipt{Receipt: ar, Raw: []byte(rJSON)})
+		out = append(out, ChainReceipt{Receipt: ar, Raw: rawJSON})
 	}
 	return out, rows.Err()
 }

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -58,12 +58,24 @@ type ReceiptRow struct {
 // in list rows. The modal still shows the full value via the detail endpoint.
 const disclosurePreviewMaxLen = 200
 
+// ChainReceipt pairs a parsed receipt with the verbatim JSON bytes stored in
+// the receipt_json column. Chain verification recomputes the canonical hash
+// from Raw via receipt.HashRawReceipt — the same hash form the collector and
+// an auditor use — rather than round-tripping through the Go struct. The
+// struct path (receipt.HashReceipt) silently drops any forward-compat fields a
+// newer SDK wrote, yielding a hash that disagrees with the stored one and a
+// false "broken chain" report (issue #719).
+type ChainReceipt struct {
+	Receipt receipt.AgentReceipt
+	Raw     []byte
+}
+
 // ChainSummary holds aggregate information about a receipt chain.
 type ChainSummary struct {
 	ChainID        string `json:"chain_id"`
 	ReceiptCount   int    `json:"receipt_count"`
 	FirstTimestamp string `json:"first_timestamp"`
-	LastTimestamp   string `json:"last_timestamp"`
+	LastTimestamp  string `json:"last_timestamp"`
 }
 
 // Stats holds aggregate statistics for the store.
@@ -262,8 +274,10 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 	return out, rows.Err()
 }
 
-// GetChain retrieves all receipts in a chain, ordered by sequence.
-func (r *Reader) GetChain(chainID string) ([]receipt.AgentReceipt, error) {
+// GetChain retrieves all receipts in a chain, ordered by sequence. Each result
+// carries both the parsed receipt and the verbatim receipt_json bytes so chain
+// verification can recompute hashes from the wire form (see ChainReceipt).
+func (r *Reader) GetChain(chainID string) ([]ChainReceipt, error) {
 	rows, err := r.db.Query(
 		"SELECT receipt_json FROM receipts WHERE chain_id = ? ORDER BY sequence ASC",
 		chainID,
@@ -273,7 +287,7 @@ func (r *Reader) GetChain(chainID string) ([]receipt.AgentReceipt, error) {
 	}
 	defer rows.Close()
 
-	var out []receipt.AgentReceipt
+	var out []ChainReceipt
 	for rows.Next() {
 		var rJSON string
 		if err := rows.Scan(&rJSON); err != nil {
@@ -283,7 +297,7 @@ func (r *Reader) GetChain(chainID string) ([]receipt.AgentReceipt, error) {
 		if err := json.Unmarshal([]byte(rJSON), &ar); err != nil {
 			return nil, fmt.Errorf("corrupt receipt in chain %s: %w", chainID, err)
 		}
-		out = append(out, ar)
+		out = append(out, ChainReceipt{Receipt: ar, Raw: []byte(rJSON)})
 	}
 	return out, rows.Err()
 }

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -60,8 +60,8 @@ const disclosurePreviewMaxLen = 200
 
 // ChainReceipt pairs a parsed receipt with the verbatim JSON bytes stored in
 // the receipt_json column. Chain verification recomputes the canonical hash
-// from Raw via receipt.HashRawReceipt — the same hash form the collector and
-// an auditor use — rather than round-tripping through the Go struct. The
+// from Raw via receipt.HashRawReceipt — the same hash form that the collector
+// and an auditor use — rather than round-tripping through the Go struct. The
 // struct path (receipt.HashReceipt) silently drops any forward-compat fields a
 // newer SDK wrote, yielding a hash that disagrees with the stored one and a
 // false "broken chain" report (issue #719).

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -639,10 +639,16 @@ func TestReader_GetChain(t *testing.T) {
 	}
 	// Should be ordered by sequence.
 	for i := 1; i < len(receipts); i++ {
-		prev := receipts[i-1].CredentialSubject.Chain.Sequence
-		curr := receipts[i].CredentialSubject.Chain.Sequence
+		prev := receipts[i-1].Receipt.CredentialSubject.Chain.Sequence
+		curr := receipts[i].Receipt.CredentialSubject.Chain.Sequence
 		if curr <= prev {
 			t.Errorf("receipts not ordered: seq %d after seq %d", curr, prev)
+		}
+	}
+	// Each result must carry the verbatim wire bytes used for hash recompute.
+	for i, cr := range receipts {
+		if len(cr.Raw) == 0 {
+			t.Errorf("receipt %d: missing raw JSON bytes", i)
 		}
 	}
 }

--- a/internal/verify/chain.go
+++ b/internal/verify/chain.go
@@ -7,6 +7,8 @@ import (
 	"log"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
+
+	"github.com/agent-receipts/dashboard/internal/store"
 )
 
 // LinkVerification holds the result for a single receipt in a chain.
@@ -32,7 +34,13 @@ type ChainLinkResult struct {
 // When publicKeyPEM is non-empty, each receipt's Ed25519 signature is also
 // verified using the ar SDK; SignatureValid will be set per receipt.
 // When publicKeyPEM is empty, signature checks are skipped (SignatureValid is nil).
-func VerifyChainLinks(receipts []receipt.AgentReceipt, publicKeyPEM string) ChainLinkResult {
+//
+// Hash linkage is recomputed from each receipt's verbatim wire bytes
+// (receipt.HashRawReceipt), which is the canonical hash form the collector
+// stored and an auditor would reproduce. Hashing the re-marshalled Go struct
+// instead (receipt.HashReceipt) drops any forward-compat fields a newer SDK
+// emitted, making a valid chain look broken — issue #719.
+func VerifyChainLinks(receipts []store.ChainReceipt, publicKeyPEM string) ChainLinkResult {
 	if len(receipts) == 0 {
 		return ChainLinkResult{Valid: true, Length: 0, BrokenAt: -1}
 	}
@@ -40,14 +48,15 @@ func VerifyChainLinks(receipts []receipt.AgentReceipt, publicKeyPEM string) Chai
 	results := make([]LinkVerification, 0, len(receipts))
 	brokenAt := -1
 
-	for i, r := range receipts {
+	for i, cr := range receipts {
+		r := cr.Receipt
 		chain := r.CredentialSubject.Chain
 
 		hashValid := true
 		if i == 0 {
 			hashValid = chain.PreviousReceiptHash == nil
 		} else {
-			prevHash, err := receipt.HashReceipt(receipts[i-1])
+			prevHash, err := receipt.HashRawReceipt(receipts[i-1].Raw)
 			if err != nil {
 				hashValid = false
 			} else {
@@ -59,7 +68,7 @@ func VerifyChainLinks(receipts []receipt.AgentReceipt, publicKeyPEM string) Chai
 		if i == 0 {
 			seqValid = chain.Sequence >= 1
 		} else {
-			seqValid = chain.Sequence == receipts[i-1].CredentialSubject.Chain.Sequence+1
+			seqValid = chain.Sequence == receipts[i-1].Receipt.CredentialSubject.Chain.Sequence+1
 		}
 
 		lv := LinkVerification{

--- a/internal/verify/chain.go
+++ b/internal/verify/chain.go
@@ -36,8 +36,8 @@ type ChainLinkResult struct {
 // When publicKeyPEM is empty, signature checks are skipped (SignatureValid is nil).
 //
 // Hash linkage is recomputed from each receipt's verbatim wire bytes
-// (receipt.HashRawReceipt), which is the canonical hash form the collector
-// stored and an auditor would reproduce. Hashing the re-marshalled Go struct
+// (receipt.HashRawReceipt), which is the canonical hash form that the
+// collector stored and an auditor would reproduce. Hashing the re-marshalled Go struct
 // instead (receipt.HashReceipt) drops any forward-compat fields a newer SDK
 // emitted, making a valid chain look broken — issue #719.
 func VerifyChainLinks(receipts []store.ChainReceipt, publicKeyPEM string) ChainLinkResult {

--- a/internal/verify/chain.go
+++ b/internal/verify/chain.go
@@ -58,6 +58,9 @@ func VerifyChainLinks(receipts []store.ChainReceipt, publicKeyPEM string) ChainL
 		} else {
 			prevHash, err := receipt.HashRawReceipt(receipts[i-1].Raw)
 			if err != nil {
+				// A hashing failure is not a chain break; log it so the
+				// operator can tell an internal error apart from real tampering.
+				log.Printf("chain hash recompute error for receipt %s: %v", receipts[i-1].Receipt.ID, err)
 				hashValid = false
 			} else {
 				hashValid = chain.PreviousReceiptHash != nil && *chain.PreviousReceiptHash == prevHash

--- a/internal/verify/chain_test.go
+++ b/internal/verify/chain_test.go
@@ -1,9 +1,12 @@
 package verify
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
+
+	"github.com/agent-receipts/dashboard/internal/store"
 )
 
 func makeReceipt(id, chainID string, seq int, prevHash *string) receipt.AgentReceipt {
@@ -38,6 +41,28 @@ func makeReceipt(id, chainID string, seq int, prevHash *string) receipt.AgentRec
 
 func strPtr(s string) *string { return &s }
 
+// chainReceipt pairs a receipt with the verbatim wire bytes the store would
+// hold, mirroring store.GetChain. Verification recomputes hashes from Raw.
+func chainReceipt(t *testing.T, r receipt.AgentReceipt) store.ChainReceipt {
+	t.Helper()
+	raw, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+	return store.ChainReceipt{Receipt: r, Raw: raw}
+}
+
+// rawHash returns the canonical hash of a chain receipt's wire bytes — the
+// value a producer would store in the next receipt's previous_receipt_hash.
+func rawHash(t *testing.T, cr store.ChainReceipt) string {
+	t.Helper()
+	h, err := receipt.HashRawReceipt(cr.Raw)
+	if err != nil {
+		t.Fatalf("hash raw receipt: %v", err)
+	}
+	return h
+}
+
 func TestVerifyChainLinks_Empty(t *testing.T) {
 	result := VerifyChainLinks(nil, "")
 	if !result.Valid {
@@ -49,8 +74,8 @@ func TestVerifyChainLinks_Empty(t *testing.T) {
 }
 
 func TestVerifyChainLinks_SingleReceipt(t *testing.T) {
-	r := makeReceipt("urn:receipt:001", "chain-1", 1, nil)
-	result := VerifyChainLinks([]receipt.AgentReceipt{r}, "")
+	cr := chainReceipt(t, makeReceipt("urn:receipt:001", "chain-1", 1, nil))
+	result := VerifyChainLinks([]store.ChainReceipt{cr}, "")
 	if !result.Valid {
 		t.Errorf("single receipt should be valid, broken at %d", result.BrokenAt)
 	}
@@ -69,19 +94,13 @@ func TestVerifyChainLinks_SingleReceipt(t *testing.T) {
 }
 
 func TestVerifyChainLinks_ValidChain(t *testing.T) {
-	r1 := makeReceipt("urn:receipt:001", "chain-1", 1, nil)
-	hash1, err := receipt.HashReceipt(r1)
-	if err != nil {
-		t.Fatalf("hash: %v", err)
-	}
-	r2 := makeReceipt("urn:receipt:002", "chain-1", 2, &hash1)
-	hash2, err := receipt.HashReceipt(r2)
-	if err != nil {
-		t.Fatalf("hash: %v", err)
-	}
-	r3 := makeReceipt("urn:receipt:003", "chain-1", 3, &hash2)
+	cr1 := chainReceipt(t, makeReceipt("urn:receipt:001", "chain-1", 1, nil))
+	hash1 := rawHash(t, cr1)
+	cr2 := chainReceipt(t, makeReceipt("urn:receipt:002", "chain-1", 2, &hash1))
+	hash2 := rawHash(t, cr2)
+	cr3 := chainReceipt(t, makeReceipt("urn:receipt:003", "chain-1", 3, &hash2))
 
-	result := VerifyChainLinks([]receipt.AgentReceipt{r1, r2, r3}, "")
+	result := VerifyChainLinks([]store.ChainReceipt{cr1, cr2, cr3}, "")
 	if !result.Valid {
 		t.Errorf("chain should be valid, broken at %d", result.BrokenAt)
 	}
@@ -98,11 +117,64 @@ func TestVerifyChainLinks_ValidChain(t *testing.T) {
 	}
 }
 
-func TestVerifyChainLinks_BrokenHash(t *testing.T) {
-	r1 := makeReceipt("urn:receipt:001", "chain-1", 1, nil)
-	r2 := makeReceipt("urn:receipt:002", "chain-1", 2, strPtr("sha256:wrong"))
+// TestVerifyChainLinks_ForwardCompatFields is the regression test for issue
+// #719. A chain whose stored hashes were computed over wire bytes carrying a
+// field the Go struct does not know about must still verify as valid: the
+// recompute must hash the raw bytes, not a re-marshal of the struct.
+func TestVerifyChainLinks_ForwardCompatFields(t *testing.T) {
+	// Build chain receipts whose Raw bytes carry a forward-compat top-level
+	// field the AgentReceipt struct drops on Unmarshal.
+	withFutureField := func(t *testing.T, r receipt.AgentReceipt) store.ChainReceipt {
+		t.Helper()
+		var generic map[string]any
+		raw, err := json.Marshal(r)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+		if err := json.Unmarshal(raw, &generic); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+		generic["_future_field"] = "v2"
+		enriched, err := json.Marshal(generic)
+		if err != nil {
+			t.Fatalf("marshal enriched: %v", err)
+		}
+		return store.ChainReceipt{Receipt: r, Raw: enriched}
+	}
 
-	result := VerifyChainLinks([]receipt.AgentReceipt{r1, r2}, "")
+	cr1 := withFutureField(t, makeReceipt("urn:receipt:001", "default", 1, nil))
+	hash1 := rawHash(t, cr1)
+	cr2 := withFutureField(t, makeReceipt("urn:receipt:002", "default", 2, &hash1))
+	hash2 := rawHash(t, cr2)
+	cr3 := withFutureField(t, makeReceipt("urn:receipt:003", "default", 3, &hash2))
+
+	result := VerifyChainLinks([]store.ChainReceipt{cr1, cr2, cr3}, "")
+	if !result.Valid {
+		t.Fatalf("chain with forward-compat fields should be valid, broken at %d", result.BrokenAt)
+	}
+	for i, rv := range result.Receipts {
+		if !rv.HashLinkValid {
+			t.Errorf("receipt %d: hash link should be valid", i)
+		}
+	}
+
+	// Sanity check: hashing the re-marshalled struct (the old behaviour)
+	// would drop _future_field and disagree, proving the test exercises the
+	// real divergence rather than a no-op.
+	structHash, err := receipt.HashReceipt(cr1.Receipt)
+	if err != nil {
+		t.Fatalf("hash receipt: %v", err)
+	}
+	if structHash == hash1 {
+		t.Fatal("expected struct hash to differ from raw hash with forward-compat field present")
+	}
+}
+
+func TestVerifyChainLinks_BrokenHash(t *testing.T) {
+	cr1 := chainReceipt(t, makeReceipt("urn:receipt:001", "chain-1", 1, nil))
+	cr2 := chainReceipt(t, makeReceipt("urn:receipt:002", "chain-1", 2, strPtr("sha256:wrong")))
+
+	result := VerifyChainLinks([]store.ChainReceipt{cr1, cr2}, "")
 	if result.Valid {
 		t.Error("chain with wrong hash should be invalid")
 	}
@@ -115,11 +187,11 @@ func TestVerifyChainLinks_BrokenHash(t *testing.T) {
 }
 
 func TestVerifyChainLinks_BrokenSequence(t *testing.T) {
-	r1 := makeReceipt("urn:receipt:001", "chain-1", 1, nil)
-	hash1, _ := receipt.HashReceipt(r1)
-	r2 := makeReceipt("urn:receipt:002", "chain-1", 5, &hash1) // gap in sequence
+	cr1 := chainReceipt(t, makeReceipt("urn:receipt:001", "chain-1", 1, nil))
+	hash1 := rawHash(t, cr1)
+	cr2 := chainReceipt(t, makeReceipt("urn:receipt:002", "chain-1", 5, &hash1)) // gap in sequence
 
-	result := VerifyChainLinks([]receipt.AgentReceipt{r1, r2}, "")
+	result := VerifyChainLinks([]store.ChainReceipt{cr1, cr2}, "")
 	if result.Valid {
 		t.Error("chain with sequence gap should be invalid")
 	}
@@ -136,9 +208,9 @@ func TestVerifyChainLinks_BrokenSequence(t *testing.T) {
 }
 
 func TestVerifyChainLinks_FirstReceiptNonNilPrevHash(t *testing.T) {
-	r1 := makeReceipt("urn:receipt:001", "chain-1", 1, strPtr("sha256:shouldbenull"))
+	cr1 := chainReceipt(t, makeReceipt("urn:receipt:001", "chain-1", 1, strPtr("sha256:shouldbenull")))
 
-	result := VerifyChainLinks([]receipt.AgentReceipt{r1}, "")
+	result := VerifyChainLinks([]store.ChainReceipt{cr1}, "")
 	if result.Valid {
 		t.Error("first receipt with non-nil prev hash should be invalid")
 	}
@@ -180,7 +252,7 @@ func TestVerifyChainLinks_SignatureValid(t *testing.T) {
 		t.Fatalf("sign: %v", err)
 	}
 
-	result := VerifyChainLinks([]receipt.AgentReceipt{signed}, kp.PublicKey)
+	result := VerifyChainLinks([]store.ChainReceipt{chainReceipt(t, signed)}, kp.PublicKey)
 	if len(result.Receipts) != 1 {
 		t.Fatalf("got %d results, want 1", len(result.Receipts))
 	}
@@ -227,7 +299,7 @@ func TestVerifyChainLinks_SignatureInvalid(t *testing.T) {
 		t.Fatalf("sign: %v", err)
 	}
 
-	result := VerifyChainLinks([]receipt.AgentReceipt{signed}, wrongKP.PublicKey)
+	result := VerifyChainLinks([]store.ChainReceipt{chainReceipt(t, signed)}, wrongKP.PublicKey)
 	if len(result.Receipts) != 1 {
 		t.Fatalf("got %d results, want 1", len(result.Receipts))
 	}
@@ -241,8 +313,8 @@ func TestVerifyChainLinks_SignatureInvalid(t *testing.T) {
 }
 
 func TestVerifyChainLinks_NoPublicKey_SignatureNotChecked(t *testing.T) {
-	r1 := makeReceipt("urn:receipt:001", "chain-1", 1, nil)
-	result := VerifyChainLinks([]receipt.AgentReceipt{r1}, "")
+	cr := chainReceipt(t, makeReceipt("urn:receipt:001", "chain-1", 1, nil))
+	result := VerifyChainLinks([]store.ChainReceipt{cr}, "")
 	if result.Receipts[0].SignatureValid != nil {
 		t.Error("SignatureValid should be nil when no public key provided")
 	}


### PR DESCRIPTION
## What

Fix chain verification to correctly validate chains containing receipts with forward-compatible fields. The `/api/chains/{id}/verify` endpoint now recomputes hash linkage from the verbatim wire bytes (`receipt.HashRawReceipt`) instead of re-marshalling the Go struct (`receipt.HashReceipt`), which was silently dropping unknown fields and causing valid chains to be reported as broken.

## Why

When a newer SDK version adds fields to receipts, collectors persist the full wire bytes via `InsertRaw` and store the canonical hash computed over those bytes. The dashboard&#39;s verification was round-tripping receipts through the Go struct, which doesn&#39;t know about the new fields, causing the recomputed hash to disagree with the stored hash and falsely reporting the chain as broken (issue #719).

The fix ensures verification uses the same hash computation as the collector and auditors: `receipt.HashRawReceipt` over the original JSON bytes.

## Changes

- **`internal/store/reader.go`**: Added `ChainReceipt` type to pair parsed receipts with their verbatim wire bytes. Updated `GetChain()` to return `[]ChainReceipt` instead of `[]receipt.AgentReceipt`, preserving the raw JSON for hash recomputation.

- **`internal/verify/chain.go`**: Updated `VerifyChainLinks()` to accept `[]store.ChainReceipt` and use `receipt.HashRawReceipt()` on the raw bytes instead of `receipt.HashReceipt()` on the struct. Added logging for hash recomputation errors to distinguish internal failures from tampering.

- **Tests**: Updated all chain verification tests to use the new `ChainReceipt` type. Added `TestVerifyChainLinks_ForwardCompatFields` regression test that verifies chains with unknown top-level fields validate correctly. Added `TestChainVerifyEndpoint_ForwardCompatChain` end-to-end test using the SDK store&#39;s `InsertRaw` API.

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] New functionality includes tests (regression tests for issue #719)
- [x] Commit messages follow Conventional Commits
- [x] CHANGELOG.md updated