### PR TITLE
feat: decrypt HPKE parameter disclosure envelopes in the dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Forensic disclosure decryption** — operators can now load their X25519 forensic private key into the dashboard and view decrypted `parameters_disclosure` envelopes inline in the receipt detail view. A header "Forensic key" control accepts the raw 32-byte key (as written by `agent-receipts-daemon --init-forensic-key`), or a hex / base64 / PKCS#8 PEM paste, and shows the loaded key's `sha256:` fingerprint for verification against the daemon's startup log. Receipts encrypted to that key decrypt automatically; non-matching receipts show a clear "key mismatch" state, and receipts decrypt-fail or lock gracefully without ever blocking the receipt view. This closes the detail-view decryption follow-up deferred in 0.3.0.
   - The private key is held in the dashboard's process memory only — never persisted, never logged — and is zeroed on clear. Decryption reuses the audited SDK `receipt.DecryptDisclosure` (HPKE base mode, `hpke-x25519-hkdf-sha256-aes-256-gcm`).
-  - Forensic key operations are refused unless the dashboard is bound to a loopback address (the default `127.0.0.1`), so a loaded key is never reachable from the network. New endpoints: `GET/POST/DELETE /api/forensic-key` and `GET /api/disclosure/{id}`.
+  - Forensic key operations are refused unless the dashboard is bound to a loopback address (the default `127.0.0.1`), so a loaded key is never reachable from the network. As a second layer, the forensic endpoints also reject requests whose `Host` header is not loopback, blocking DNS-rebinding from a page in the operator's browser. New endpoints: `GET/POST/DELETE /api/forensic-key` and `GET /api/disclosure/{id}`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Forensic disclosure decryption** — operators can now load their X25519 forensic private key into the dashboard and view decrypted `parameters_disclosure` envelopes inline in the receipt detail view. A header "Forensic key" control accepts the raw 32-byte key (as written by `agent-receipts-daemon --init-forensic-key`), or a hex / base64 / PKCS#8 PEM paste, and shows the loaded key's `sha256:` fingerprint for verification against the daemon's startup log. Receipts encrypted to that key decrypt automatically; non-matching receipts show a clear "key mismatch" state, and receipts decrypt-fail or lock gracefully without ever blocking the receipt view. This closes the detail-view decryption follow-up deferred in 0.3.0.
+  - The private key is held in the dashboard's process memory only — never persisted, never logged — and is zeroed on clear. Decryption reuses the audited SDK `receipt.DecryptDisclosure` (HPKE base mode, `hpke-x25519-hkdf-sha256-aes-256-gcm`).
+  - Forensic key operations are refused unless the dashboard is bound to a loopback address (the default `127.0.0.1`), so a loaded key is never reachable from the network. New endpoints: `GET/POST/DELETE /api/forensic-key` and `GET /api/disclosure/{id}`.
+
+### Changed
+
+- **Bump `github.com/agent-receipts/ar/sdk/go` to `v0.15.0`** — picks up the forensic-disclosure helpers (`ForensicPublicFromPrivate`, `ForensicKeyFingerprint`) and HPKE encrypt/decrypt wiring from [agent-receipts/ar#722](https://github.com/agent-receipts/ar/pull/722).
+
 ### Fixed
 
 - **Chain verification false negative** ([agent-receipts/ar#719](https://github.com/agent-receipts/ar/issues/719)) — `/api/chains/{id}/verify` reported valid chains as broken. The recomputed hash linkage round-tripped each receipt through the Go struct (`receipt.HashReceipt`), which drops any forward-compat fields a newer SDK wrote, so it disagreed with the canonical hash the collector stored. Verification now recomputes from the verbatim `receipt_json` wire bytes via `receipt.HashRawReceipt`, matching `agent-receipts verify` and any auditor reading the raw bytes. `store.GetChain` now returns the raw bytes alongside the parsed receipt.

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -162,6 +162,7 @@ func main() {
 		PollInterval: *pollInterval,
 		DBPath:       displayDBPath,
 		Version:      resolveVersion(),
+		Host:         *host,
 	})
 	addr := fmt.Sprintf("%s:%d", *host, *port)
 	log.Printf("dashboard listening on http://%s", addr)

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/dashboard
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.13.0
+	github.com/agent-receipts/ar/sdk/go v0.15.0
 	modernc.org/sqlite v1.51.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.13.0 h1:o/JDXuJrWuyyXuiei/TmC7p/8KRVsufNWS9SIPFhPJ8=
-github.com/agent-receipts/ar/sdk/go v0.13.0/go.mod h1:O4UZo83wzTJw08TsaxjEKjgmsSUq4bjYmSMQxDJTJZA=
+github.com/agent-receipts/ar/sdk/go v0.15.0 h1:kMix5RHLn1dhdvPr5CrajluoUHEQVMW4xxKNLQ/PVDs=
+github.com/agent-receipts/ar/sdk/go v0.15.0/go.mod h1:beOZmNsSk/I9KrU46xJcegIFN3Fo0bdXo8luHhUmeuc=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -1,0 +1,315 @@
+package server
+
+import (
+	"bytes"
+	"crypto/ecdh"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"log"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+)
+
+// maxForensicKeyBody bounds the request body accepted by the key-load endpoint.
+// A raw X25519 key is 32 bytes; a PKCS#8 PEM wrapper is a few hundred. 8 KiB is
+// comfortably above any legitimate input and caps abuse.
+const maxForensicKeyBody = 8 << 10
+
+// forensicKeyStore holds the operator's X25519 forensic private key in process
+// memory only. Per the parameter-disclosure threat model the key is never
+// persisted, never logged, and is zeroed when cleared or replaced. All access
+// is guarded by mu so concurrent HTTP handlers stay safe.
+type forensicKeyStore struct {
+	mu          sync.RWMutex
+	privateKey  []byte // 32-byte raw X25519 private key; nil when unloaded
+	fingerprint string // sha256:<hex> of the derived public key; "" when unloaded
+}
+
+// load derives the public key and fingerprint from priv, then stores a private
+// copy. The previously held key (if any) is zeroed first. Returns the canonical
+// sha256 fingerprint the operator can verify against the daemon's startup log.
+func (f *forensicKeyStore) load(priv []byte) (string, error) {
+	pub, err := receipt.ForensicPublicFromPrivate(priv)
+	if err != nil {
+		return "", err
+	}
+	fp, err := receipt.ForensicKeyFingerprint(pub)
+	if err != nil {
+		return "", err
+	}
+
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	zero(f.privateKey)
+	f.privateKey = append([]byte(nil), priv...)
+	f.fingerprint = fp
+	return fp, nil
+}
+
+// clear zeroes and forgets the loaded key. Safe to call when nothing is loaded.
+func (f *forensicKeyStore) clear() {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	zero(f.privateKey)
+	f.privateKey = nil
+	f.fingerprint = ""
+}
+
+// status reports whether a key is loaded and its fingerprint.
+func (f *forensicKeyStore) status() (loaded bool, fingerprint string) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	return f.privateKey != nil, f.fingerprint
+}
+
+// current returns a copy of the loaded private key and its fingerprint, or
+// (nil, "") when no key is loaded. The caller owns the returned slice and MUST
+// zero it after use so the plaintext key does not linger.
+func (f *forensicKeyStore) current() (priv []byte, fingerprint string) {
+	f.mu.RLock()
+	defer f.mu.RUnlock()
+	if f.privateKey == nil {
+		return nil, ""
+	}
+	return append([]byte(nil), f.privateKey...), f.fingerprint
+}
+
+// zero overwrites b with zeros. A no-op for nil/empty slices.
+func zero(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
+}
+
+// forensicKeyStatus is the JSON returned by the key status and load endpoints.
+type forensicKeyStatus struct {
+	// Loaded is true when a forensic private key is held in memory.
+	Loaded bool `json:"loaded"`
+	// Fingerprint is the sha256:<hex> fingerprint of the loaded key's public
+	// half, omitted when no key is loaded.
+	Fingerprint string `json:"fingerprint,omitempty"`
+	// Available is false when the dashboard is not bound to a loopback address,
+	// in which case loading a key is refused (see forensicAvailable).
+	Available bool `json:"available"`
+}
+
+// disclosureResponse is the JSON returned by the per-receipt disclosure endpoint.
+type disclosureResponse struct {
+	// State is one of: none, locked, mismatch, decrypted, failed.
+	State string `json:"state"`
+	// Alg echoes the envelope ciphersuite tag for display, when present.
+	Alg string `json:"alg,omitempty"`
+	// Kids are the recipient fingerprints the envelope was encrypted to.
+	Kids []string `json:"kids,omitempty"`
+	// Fingerprint is the loaded key's fingerprint, included for the mismatch
+	// state so the UI can show "expected <kid> vs loaded <fingerprint>".
+	Fingerprint string `json:"fingerprint,omitempty"`
+	// Parameters is the recovered plaintext, present only in the decrypted state.
+	Parameters map[string]any `json:"parameters,omitempty"`
+}
+
+// isLoopbackHost reports whether the dashboard's bind host keeps the HTTP
+// surface on the local machine. The empty string (the zero Config used in
+// tests) is treated as loopback; an explicit 0.0.0.0 / :: bind is not.
+func isLoopbackHost(host string) bool {
+	switch host {
+	case "", "localhost":
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+// forensicAvailable reports whether forensic key operations are permitted. The
+// loaded private key can decrypt every matching disclosure, so it must never be
+// reachable from the network: we refuse to hold a key unless the dashboard is
+// bound to a loopback address.
+func (s *Server) forensicAvailable() bool {
+	return isLoopbackHost(s.cfg.Host)
+}
+
+func (s *Server) handleForensicKeyGet(w http.ResponseWriter, r *http.Request) {
+	loaded, fp := s.forensic.status()
+	writeJSON(w, http.StatusOK, forensicKeyStatus{
+		Loaded:      loaded,
+		Fingerprint: fp,
+		Available:   s.forensicAvailable(),
+	})
+}
+
+func (s *Server) handleForensicKeyLoad(w http.ResponseWriter, r *http.Request) {
+	if !s.forensicAvailable() {
+		writeError(w, http.StatusForbidden, "forensic decryption is only available when the dashboard is bound to a loopback address")
+		return
+	}
+
+	body, err := io.ReadAll(io.LimitReader(r.Body, maxForensicKeyBody+1))
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "could not read request body")
+		return
+	}
+	if len(body) > maxForensicKeyBody {
+		writeError(w, http.StatusRequestEntityTooLarge, "forensic key payload is too large")
+		return
+	}
+
+	priv, err := parseForensicPrivateKey(body)
+	if err != nil {
+		// The error is deliberately generic and the key material is never
+		// logged — only the parse outcome.
+		log.Printf("forensic key load rejected: %v", err)
+		writeError(w, http.StatusBadRequest, "invalid forensic key: provide a 32-byte X25519 private key (raw, hex, base64, or PKCS#8 PEM)")
+		return
+	}
+	defer zero(priv)
+
+	fp, err := s.forensic.load(priv)
+	if err != nil {
+		log.Printf("forensic key load failed: %v", err)
+		writeError(w, http.StatusBadRequest, "could not derive a forensic key fingerprint from the supplied key")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, forensicKeyStatus{Loaded: true, Fingerprint: fp, Available: true})
+}
+
+func (s *Server) handleForensicKeyClear(w http.ResponseWriter, r *http.Request) {
+	s.forensic.clear()
+	writeJSON(w, http.StatusOK, forensicKeyStatus{Loaded: false, Available: s.forensicAvailable()})
+}
+
+// handleReceiptDisclosure reports the decryption state of a single receipt's
+// parameters_disclosure envelope using the loaded forensic key. It never blocks
+// the receipt view: every outcome — including a missing key, a key mismatch, or
+// a decryption failure — is a 200 with a state field the UI renders inline.
+func (s *Server) handleReceiptDisclosure(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	if !strings.HasPrefix(id, "urn:") {
+		id = "urn:" + id
+	}
+
+	ar, err := s.reader.GetByID(id)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "query failed")
+		log.Printf("disclosure lookup error: %v", err)
+		return
+	}
+	if ar == nil {
+		writeError(w, http.StatusNotFound, "receipt not found")
+		return
+	}
+
+	// Plaintext must never be cached by the webview or an intermediary.
+	w.Header().Set("Cache-Control", "no-store")
+
+	env := ar.CredentialSubject.Action.ParametersDisclosure
+	if env == nil {
+		writeJSON(w, http.StatusOK, disclosureResponse{State: "none"})
+		return
+	}
+
+	kids := recipientKIDs(env)
+
+	priv, fp := s.forensic.current()
+	if priv == nil {
+		writeJSON(w, http.StatusOK, disclosureResponse{State: "locked", Alg: env.Alg, Kids: kids})
+		return
+	}
+	defer zero(priv)
+
+	if !containsString(kids, fp) {
+		writeJSON(w, http.StatusOK, disclosureResponse{State: "mismatch", Alg: env.Alg, Kids: kids, Fingerprint: fp})
+		return
+	}
+
+	params, err := receipt.DecryptDisclosure(env, priv)
+	if err != nil {
+		// Log the failure but never the key or plaintext.
+		log.Printf("disclosure decrypt failed for %s: %v", id, err)
+		writeJSON(w, http.StatusOK, disclosureResponse{State: "failed", Alg: env.Alg, Kids: kids, Fingerprint: fp})
+		return
+	}
+
+	writeJSON(w, http.StatusOK, disclosureResponse{
+		State:       "decrypted",
+		Alg:         env.Alg,
+		Kids:        kids,
+		Fingerprint: fp,
+		Parameters:  params,
+	})
+}
+
+// recipientKIDs extracts the recipient fingerprints from an envelope.
+func recipientKIDs(env *receipt.DisclosureEnvelope) []string {
+	kids := make([]string, 0, len(env.Recipients))
+	for _, rcpt := range env.Recipients {
+		kids = append(kids, rcpt.KID)
+	}
+	return kids
+}
+
+func containsString(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}
+
+// parseForensicPrivateKey accepts the forensic private key in any of the forms a
+// solo operator is likely to hand it over:
+//
+//   - the raw 32-byte key exactly as `--init-forensic-key` writes it (file upload),
+//   - hex (64 chars),
+//   - base64 (standard or URL alphabet, padded or unpadded),
+//   - a PKCS#8 PEM wrapper around an X25519 key.
+//
+// It returns the raw 32-byte key. The raw-length check comes first so a binary
+// upload is never reinterpreted as text.
+func parseForensicPrivateKey(raw []byte) ([]byte, error) {
+	if len(raw) == 32 {
+		return append([]byte(nil), raw...), nil
+	}
+
+	trimmed := bytes.TrimSpace(raw)
+
+	if block, _ := pem.Decode(trimmed); block != nil {
+		key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+		if err != nil {
+			return nil, fmt.Errorf("parse PKCS#8 PEM: %w", err)
+		}
+		xkey, ok := key.(*ecdh.PrivateKey)
+		if !ok || xkey.Curve() != ecdh.X25519() {
+			return nil, fmt.Errorf("PEM key is not an X25519 private key")
+		}
+		return xkey.Bytes(), nil
+	}
+
+	s := string(trimmed)
+
+	if len(s) == 64 {
+		if b, err := hex.DecodeString(s); err == nil && len(b) == 32 {
+			return b, nil
+		}
+	}
+
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding, base64.RawStdEncoding,
+		base64.URLEncoding, base64.RawURLEncoding,
+	} {
+		if b, err := enc.DecodeString(s); err == nil && len(b) == 32 {
+			return b, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unrecognised key encoding or wrong length")
+}

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"net"
 	"net/http"
+	"slices"
 	"strings"
 	"sync"
 
@@ -116,12 +117,13 @@ type disclosureResponse struct {
 	Parameters map[string]any `json:"parameters,omitempty"`
 }
 
-// isLoopbackHost reports whether the dashboard's bind host keeps the HTTP
-// surface on the local machine. The empty string (the zero Config used in
-// tests) is treated as loopback; an explicit 0.0.0.0 / :: bind is not.
+// isLoopbackHost reports whether host names a loopback address. An empty or
+// unspecified host (e.g. "" or "0.0.0.0"/"::", which bind every interface) is
+// NOT loopback: callers use this to decide whether the HTTP surface is reachable
+// only from the local machine, and an all-interfaces bind is reachable from the
+// network.
 func isLoopbackHost(host string) bool {
-	switch host {
-	case "", "localhost":
+	if host == "localhost" {
 		return true
 	}
 	ip := net.ParseIP(host)
@@ -136,7 +138,52 @@ func (s *Server) forensicAvailable() bool {
 	return isLoopbackHost(s.cfg.Host)
 }
 
+// requestHostIsLocal reports whether the request's Host header names a loopback
+// address. Forensic endpoints reject non-local Host values as a defense against
+// DNS-rebinding, where a remote page resolves its own domain to 127.0.0.1 to
+// reach this loopback-bound server from the operator's browser as if it were
+// same-origin. The bind gate (forensicAvailable) and this per-request Host
+// check are complementary: the former keeps the socket off the network, the
+// latter blocks rebinding when the socket is on loopback.
+func requestHostIsLocal(r *http.Request) bool {
+	host := r.Host
+	if h, _, err := net.SplitHostPort(host); err == nil {
+		host = h
+	}
+	// Strip IPv6 brackets left when there was no port (e.g. "[::1]").
+	host = strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	return isLoopbackHost(host)
+}
+
+// rejectNonLocalHost writes a 403 and returns true when the request's Host
+// header does not name loopback (the DNS-rebinding guard shared by every
+// forensic endpoint). Returns false when the request may proceed.
+func (s *Server) rejectNonLocalHost(w http.ResponseWriter, r *http.Request) bool {
+	if requestHostIsLocal(r) {
+		return false
+	}
+	writeError(w, http.StatusForbidden, "forensic endpoints are restricted to local (loopback) access")
+	return true
+}
+
+// guardForensic enforces both the Host-header check and the bind gate for
+// endpoints that load or use a forensic key. It returns true when the request
+// may proceed; on rejection it has already written the response.
+func (s *Server) guardForensic(w http.ResponseWriter, r *http.Request) bool {
+	if s.rejectNonLocalHost(w, r) {
+		return false
+	}
+	if !s.forensicAvailable() {
+		writeError(w, http.StatusForbidden, "forensic decryption is only available when the dashboard is bound to a loopback address")
+		return false
+	}
+	return true
+}
+
 func (s *Server) handleForensicKeyGet(w http.ResponseWriter, r *http.Request) {
+	if s.rejectNonLocalHost(w, r) {
+		return
+	}
 	loaded, fp := s.forensic.status()
 	writeJSON(w, http.StatusOK, forensicKeyStatus{
 		Loaded:      loaded,
@@ -146,8 +193,7 @@ func (s *Server) handleForensicKeyGet(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleForensicKeyLoad(w http.ResponseWriter, r *http.Request) {
-	if !s.forensicAvailable() {
-		writeError(w, http.StatusForbidden, "forensic decryption is only available when the dashboard is bound to a loopback address")
+	if !s.guardForensic(w, r) {
 		return
 	}
 
@@ -182,6 +228,9 @@ func (s *Server) handleForensicKeyLoad(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleForensicKeyClear(w http.ResponseWriter, r *http.Request) {
+	if s.rejectNonLocalHost(w, r) {
+		return
+	}
 	s.forensic.clear()
 	writeJSON(w, http.StatusOK, forensicKeyStatus{Loaded: false, Available: s.forensicAvailable()})
 }
@@ -191,6 +240,10 @@ func (s *Server) handleForensicKeyClear(w http.ResponseWriter, r *http.Request) 
 // the receipt view: every outcome — including a missing key, a key mismatch, or
 // a decryption failure — is a 200 with a state field the UI renders inline.
 func (s *Server) handleReceiptDisclosure(w http.ResponseWriter, r *http.Request) {
+	if s.rejectNonLocalHost(w, r) {
+		return
+	}
+
 	id := r.PathValue("id")
 	if !strings.HasPrefix(id, "urn:") {
 		id = "urn:" + id
@@ -225,7 +278,7 @@ func (s *Server) handleReceiptDisclosure(w http.ResponseWriter, r *http.Request)
 	}
 	defer zero(priv)
 
-	if !containsString(kids, fp) {
+	if !slices.Contains(kids, fp) {
 		writeJSON(w, http.StatusOK, disclosureResponse{State: "mismatch", Alg: env.Alg, Kids: kids, Fingerprint: fp})
 		return
 	}
@@ -256,24 +309,16 @@ func recipientKIDs(env *receipt.DisclosureEnvelope) []string {
 	return kids
 }
 
-func containsString(haystack []string, needle string) bool {
-	for _, s := range haystack {
-		if s == needle {
-			return true
-		}
-	}
-	return false
-}
-
 // parseForensicPrivateKey accepts the forensic private key in any of the forms a
 // solo operator is likely to hand it over:
 //
-//   - the raw 32-byte key exactly as `--init-forensic-key` writes it (file upload),
+//   - the raw 32-byte key as `--init-forensic-key` writes it (file upload),
+//     optionally with surrounding whitespace such as an editor-appended newline,
 //   - hex (64 chars),
 //   - base64 (standard or URL alphabet, padded or unpadded),
 //   - a PKCS#8 PEM wrapper around an X25519 key.
 //
-// It returns the raw 32-byte key. The raw-length check comes first so a binary
+// It returns the raw 32-byte key. The exact-32-byte check comes first so a binary
 // upload is never reinterpreted as text.
 func parseForensicPrivateKey(raw []byte) ([]byte, error) {
 	if len(raw) == 32 {
@@ -292,6 +337,14 @@ func parseForensicPrivateKey(raw []byte) ([]byte, error) {
 			return nil, fmt.Errorf("PEM key is not an X25519 private key")
 		}
 		return xkey.Bytes(), nil
+	}
+
+	// A raw key file commonly arrives with a trailing newline, so the exact-32
+	// check above misses it. If trimming leaves exactly 32 bytes, treat it as
+	// raw: no text encoding of a 32-byte X25519 key is 32 characters long
+	// (hex is 64, base64 is 43/44), so this is unambiguous.
+	if len(trimmed) == 32 {
+		return append([]byte(nil), trimmed...), nil
 	}
 
 	s := string(trimmed)

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -278,16 +278,22 @@ func (s *Server) handleReceiptDisclosure(w http.ResponseWriter, r *http.Request)
 	}
 	defer zero(priv)
 
-	if !slices.Contains(kids, fp) {
-		writeJSON(w, http.StatusOK, disclosureResponse{State: "mismatch", Alg: env.Alg, Kids: kids, Fingerprint: fp})
-		return
-	}
-
+	// Attempt decryption regardless of the kid value. The kid is
+	// non-authoritative metadata that DecryptDisclosure ignores; an emitter may
+	// legitimately write it in a non-canonical form (e.g. a did:key URL) while
+	// our key is still the correct recipient. Only after a failure do we use the
+	// kid to classify it: if the envelope names our key the ciphertext is
+	// corrupt/tampered (failed); otherwise our key is for a different recipient
+	// (mismatch).
 	params, err := receipt.DecryptDisclosure(env, priv)
 	if err != nil {
-		// Log the failure but never the key or plaintext.
-		log.Printf("disclosure decrypt failed for %s: %v", id, err)
-		writeJSON(w, http.StatusOK, disclosureResponse{State: "failed", Alg: env.Alg, Kids: kids, Fingerprint: fp})
+		if slices.Contains(kids, fp) {
+			// Log the failure but never the key or plaintext.
+			log.Printf("disclosure decrypt failed for %s: %v", id, err)
+			writeJSON(w, http.StatusOK, disclosureResponse{State: "failed", Alg: env.Alg, Kids: kids, Fingerprint: fp})
+			return
+		}
+		writeJSON(w, http.StatusOK, disclosureResponse{State: "mismatch", Alg: env.Alg, Kids: kids, Fingerprint: fp})
 		return
 	}
 

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -202,6 +202,10 @@ func (s *Server) handleForensicKeyLoad(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusBadRequest, "could not read request body")
 		return
 	}
+	// A raw-file upload puts the private key bytes in body; zero it once we're
+	// done so the only retained copy is the one held (and later cleared) by the
+	// key store, keeping the key's in-memory lifetime minimal.
+	defer zero(body)
 	if len(body) > maxForensicKeyBody {
 		writeError(w, http.StatusRequestEntityTooLarge, "forensic key payload is too large")
 		return

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -16,6 +17,15 @@ import (
 	sdkstore "github.com/agent-receipts/ar/sdk/go/store"
 	"github.com/agent-receipts/dashboard/internal/store"
 )
+
+// localReq builds a request whose Host header names loopback, matching what a
+// browser on 127.0.0.1 sends. httptest.NewRequest defaults Host to
+// "example.com", which the forensic endpoints reject as a DNS-rebinding guard.
+func localReq(method, target string, body io.Reader) *http.Request {
+	r := httptest.NewRequest(method, target, body)
+	r.Host = "127.0.0.1:8080"
+	return r
+}
 
 // forensicKeyPair returns a fresh X25519 forensic key pair and its canonical
 // sha256 fingerprint (the value the daemon writes as a recipient kid).
@@ -100,6 +110,8 @@ func TestParseForensicPrivateKey(t *testing.T) {
 		in   []byte
 	}{
 		{"raw", priv},
+		{"raw with trailing newline", append(append([]byte(nil), priv...), '\n')},
+		{"raw with trailing crlf", append(append([]byte(nil), priv...), '\r', '\n')},
 		{"hex", []byte(hex.EncodeToString(priv))},
 		{"hex with whitespace", []byte("  " + hex.EncodeToString(priv) + "\n")},
 		{"base64 std", []byte(base64.StdEncoding.EncodeToString(priv))},
@@ -137,12 +149,12 @@ func TestParseForensicPrivateKey(t *testing.T) {
 
 func TestForensicKeyLoadStatusClear(t *testing.T) {
 	priv, _, fp := forensicKeyPair(t)
-	srv := seedReceipts(t, Config{})
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
 	h := srv.Handler()
 
 	// Load.
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	h.ServeHTTP(w, localReq("POST", "/api/forensic-key", bytes.NewReader(priv)))
 	if w.Code != http.StatusOK {
 		t.Fatalf("load: got %d, want 200 (body=%s)", w.Code, w.Body)
 	}
@@ -156,7 +168,7 @@ func TestForensicKeyLoadStatusClear(t *testing.T) {
 
 	// Status reflects the loaded key.
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("GET", "/api/forensic-key", nil))
+	h.ServeHTTP(w, localReq("GET", "/api/forensic-key", nil))
 	st = forensicKeyStatus{}
 	json.Unmarshal(w.Body.Bytes(), &st)
 	if !st.Loaded || st.Fingerprint != fp || !st.Available {
@@ -165,12 +177,12 @@ func TestForensicKeyLoadStatusClear(t *testing.T) {
 
 	// Clear.
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("DELETE", "/api/forensic-key", nil))
+	h.ServeHTTP(w, localReq("DELETE", "/api/forensic-key", nil))
 	if w.Code != http.StatusOK {
 		t.Fatalf("clear: got %d", w.Code)
 	}
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("GET", "/api/forensic-key", nil))
+	h.ServeHTTP(w, localReq("GET", "/api/forensic-key", nil))
 	st = forensicKeyStatus{}
 	json.Unmarshal(w.Body.Bytes(), &st)
 	if st.Loaded || st.Fingerprint != "" {
@@ -179,9 +191,9 @@ func TestForensicKeyLoadStatusClear(t *testing.T) {
 }
 
 func TestForensicKeyLoadRejectsBadKey(t *testing.T) {
-	srv := seedReceipts(t, Config{})
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
 	w := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader([]byte("nonsense"))))
+	srv.Handler().ServeHTTP(w, localReq("POST", "/api/forensic-key", bytes.NewReader([]byte("nonsense"))))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("got %d, want 400", w.Code)
 	}
@@ -190,18 +202,18 @@ func TestForensicKeyLoadRejectsBadKey(t *testing.T) {
 func TestDisclosureDecryptsWithMatchingKey(t *testing.T) {
 	priv, pub, fp := forensicKeyPair(t)
 	params := map[string]any{"command": "rm -rf /tmp/scratch", "cwd": "/home/op"}
-	srv := seedReceipts(t, Config{}, encReceipt(t, "urn:receipt:enc1", pub, fp, params))
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"}, encReceipt(t, "urn:receipt:enc1", pub, fp, params))
 	h := srv.Handler()
 
 	// Load the key, then decrypt.
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	h.ServeHTTP(w, localReq("POST", "/api/forensic-key", bytes.NewReader(priv)))
 	if w.Code != http.StatusOK {
 		t.Fatalf("load: %d", w.Code)
 	}
 
 	w = httptest.NewRecorder()
-	req := httptest.NewRequest("GET", "/api/disclosure/"+"urn:receipt:enc1", nil)
+	req := localReq("GET", "/api/disclosure/"+"urn:receipt:enc1", nil)
 	h.ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Fatalf("disclosure: %d", w.Code)
@@ -220,10 +232,10 @@ func TestDisclosureDecryptsWithMatchingKey(t *testing.T) {
 
 func TestDisclosureLockedWithoutKey(t *testing.T) {
 	_, pub, fp := forensicKeyPair(t)
-	srv := seedReceipts(t, Config{}, encReceipt(t, "urn:receipt:enc1", pub, fp, map[string]any{"command": "ls"}))
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"}, encReceipt(t, "urn:receipt:enc1", pub, fp, map[string]any{"command": "ls"}))
 
 	w := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(w, httptest.NewRequest("GET", "/api/disclosure/urn:receipt:enc1", nil))
+	srv.Handler().ServeHTTP(w, localReq("GET", "/api/disclosure/urn:receipt:enc1", nil))
 	resp := decodeDisclosure(t, w.Body.Bytes())
 	if resp.State != "locked" {
 		t.Fatalf("state = %q, want locked", resp.State)
@@ -236,17 +248,17 @@ func TestDisclosureLockedWithoutKey(t *testing.T) {
 func TestDisclosureMismatchWithWrongKey(t *testing.T) {
 	_, pub, fp := forensicKeyPair(t)
 	wrongPriv, _, _ := forensicKeyPair(t)
-	srv := seedReceipts(t, Config{}, encReceipt(t, "urn:receipt:enc1", pub, fp, map[string]any{"command": "ls"}))
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"}, encReceipt(t, "urn:receipt:enc1", pub, fp, map[string]any{"command": "ls"}))
 	h := srv.Handler()
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader(wrongPriv)))
+	h.ServeHTTP(w, localReq("POST", "/api/forensic-key", bytes.NewReader(wrongPriv)))
 	if w.Code != http.StatusOK {
 		t.Fatalf("load: %d", w.Code)
 	}
 
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("GET", "/api/disclosure/urn:receipt:enc1", nil))
+	h.ServeHTTP(w, localReq("GET", "/api/disclosure/urn:receipt:enc1", nil))
 	resp := decodeDisclosure(t, w.Body.Bytes())
 	if resp.State != "mismatch" {
 		t.Fatalf("state = %q, want mismatch", resp.State)
@@ -267,17 +279,17 @@ func TestDisclosureFailedWithTamperedCiphertext(t *testing.T) {
 	ctBytes[0] ^= 0xff
 	env.CT = base64.RawURLEncoding.EncodeToString(ctBytes)
 
-	srv := seedReceipts(t, Config{}, r)
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"}, r)
 	h := srv.Handler()
 
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	h.ServeHTTP(w, localReq("POST", "/api/forensic-key", bytes.NewReader(priv)))
 	if w.Code != http.StatusOK {
 		t.Fatalf("load: %d", w.Code)
 	}
 
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("GET", "/api/disclosure/urn:receipt:enc1", nil))
+	h.ServeHTTP(w, localReq("GET", "/api/disclosure/urn:receipt:enc1", nil))
 	resp := decodeDisclosure(t, w.Body.Bytes())
 	if resp.State != "failed" {
 		t.Fatalf("state = %q, want failed", resp.State)
@@ -287,10 +299,10 @@ func TestDisclosureFailedWithTamperedCiphertext(t *testing.T) {
 func TestDisclosureNoneForPlainReceipt(t *testing.T) {
 	// A receipt with no parameters_disclosure reports state "none".
 	r := makeReceipt("urn:receipt:plain1", "chain-plain", 1, "filesystem.file.read", receipt.RiskLow, receipt.StatusSuccess, "2026-05-01T10:00:00Z", nil)
-	srv := seedReceipts(t, Config{}, r)
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"}, r)
 
 	w := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(w, httptest.NewRequest("GET", "/api/disclosure/urn:receipt:plain1", nil))
+	srv.Handler().ServeHTTP(w, localReq("GET", "/api/disclosure/urn:receipt:plain1", nil))
 	resp := decodeDisclosure(t, w.Body.Bytes())
 	if resp.State != "none" {
 		t.Fatalf("state = %q, want none", resp.State)
@@ -304,7 +316,7 @@ func TestForensicDisabledOnNonLoopbackBind(t *testing.T) {
 
 	// Status reports unavailable.
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("GET", "/api/forensic-key", nil))
+	h.ServeHTTP(w, localReq("GET", "/api/forensic-key", nil))
 	var st forensicKeyStatus
 	json.Unmarshal(w.Body.Bytes(), &st)
 	if st.Available {
@@ -313,8 +325,76 @@ func TestForensicDisabledOnNonLoopbackBind(t *testing.T) {
 
 	// Loading a key is refused.
 	w = httptest.NewRecorder()
-	h.ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	h.ServeHTTP(w, localReq("POST", "/api/forensic-key", bytes.NewReader(priv)))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("load on non-loopback: got %d, want 403", w.Code)
+	}
+}
+
+// An empty bind host binds all interfaces, so it must NOT count as loopback —
+// otherwise the forensic key would be loadable over the network (regression
+// guard for the "" fail-open).
+func TestForensicDisabledOnEmptyHostBind(t *testing.T) {
+	priv, _, _ := forensicKeyPair(t)
+	srv := seedReceipts(t, Config{Host: ""})
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localReq("GET", "/api/forensic-key", nil))
+	var st forensicKeyStatus
+	json.Unmarshal(w.Body.Bytes(), &st)
+	if st.Available {
+		t.Fatalf("expected Available=false on empty (all-interfaces) bind")
+	}
+
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localReq("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("load on empty bind: got %d, want 403", w.Code)
+	}
+}
+
+// Requests whose Host header is not loopback are rejected even when the bind is
+// loopback — a DNS-rebinding guard. Covers all forensic endpoints.
+func TestForensicRejectsNonLocalHost(t *testing.T) {
+	priv, pub, fp := forensicKeyPair(t)
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"}, encReceipt(t, "urn:receipt:enc1", pub, fp, map[string]any{"command": "ls"}))
+	h := srv.Handler()
+
+	// Load a key via a legitimate local request first.
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, localReq("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("local load: %d", w.Code)
+	}
+
+	rebind := func(method, target string, body io.Reader) *http.Request {
+		r := httptest.NewRequest(method, target, body)
+		r.Host = "evil.example.com" // attacker domain rebound to 127.0.0.1
+		return r
+	}
+	endpoints := []struct {
+		method, target string
+		body           io.Reader
+	}{
+		{"GET", "/api/forensic-key", nil},
+		{"POST", "/api/forensic-key", bytes.NewReader(priv)},
+		{"DELETE", "/api/forensic-key", nil},
+		{"GET", "/api/disclosure/urn:receipt:enc1", nil},
+	}
+	for _, ep := range endpoints {
+		w := httptest.NewRecorder()
+		h.ServeHTTP(w, rebind(ep.method, ep.target, ep.body))
+		if w.Code != http.StatusForbidden {
+			t.Fatalf("%s %s with foreign Host: got %d, want 403", ep.method, ep.target, w.Code)
+		}
+	}
+
+	// The key was not cleared by the rejected DELETE, and a local request still
+	// decrypts — i.e. the foreign-Host requests had no effect on state.
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, localReq("GET", "/api/disclosure/urn:receipt:enc1", nil))
+	resp := decodeDisclosure(t, w.Body.Bytes())
+	if resp.State != "decrypted" {
+		t.Fatalf("after rejected rebind requests, state = %q, want decrypted", resp.State)
 	}
 }

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -1,0 +1,320 @@
+package server
+
+import (
+	"bytes"
+	"crypto/ecdh"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"encoding/json"
+	"encoding/pem"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/agent-receipts/ar/sdk/go/receipt"
+	sdkstore "github.com/agent-receipts/ar/sdk/go/store"
+	"github.com/agent-receipts/dashboard/internal/store"
+)
+
+// forensicKeyPair returns a fresh X25519 forensic key pair and its canonical
+// sha256 fingerprint (the value the daemon writes as a recipient kid).
+func forensicKeyPair(t *testing.T) (priv, pub []byte, fingerprint string) {
+	t.Helper()
+	kp, err := receipt.GenerateForensicKeyPair()
+	if err != nil {
+		t.Fatalf("generate forensic key pair: %v", err)
+	}
+	fp, err := receipt.ForensicKeyFingerprint(kp.PublicKey)
+	if err != nil {
+		t.Fatalf("fingerprint: %v", err)
+	}
+	return kp.PrivateKey, kp.PublicKey, fp
+}
+
+// encReceipt builds a receipt whose parameters_disclosure is an HPKE envelope
+// encrypted to pub/kid.
+func encReceipt(t *testing.T, id string, pub []byte, kid string, params map[string]any) receipt.AgentReceipt {
+	t.Helper()
+	env, err := receipt.EncryptDisclosure(params, pub, kid)
+	if err != nil {
+		t.Fatalf("encrypt disclosure: %v", err)
+	}
+	r := makeReceipt(id, "chain-enc", 1, "system.command.execute", receipt.RiskHigh, receipt.StatusSuccess, "2026-05-01T10:00:00Z", nil)
+	r.CredentialSubject.Action.ParametersDisclosure = env
+	return r
+}
+
+// seedReceipts writes the given receipts to a fresh read-only store and returns
+// a Server reading from it.
+func seedReceipts(t *testing.T, cfg Config, recs ...receipt.AgentReceipt) *Server {
+	t.Helper()
+	dbPath := t.TempDir() + "/forensic.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+	for _, r := range recs {
+		h, _ := receipt.HashReceipt(r)
+		if err := s.Insert(r, h); err != nil {
+			s.Close()
+			t.Fatalf("insert %s: %v", r.ID, err)
+		}
+	}
+	s.Close()
+
+	reader, err := store.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { reader.Close() })
+	return New(reader, cfg)
+}
+
+func decodeDisclosure(t *testing.T, body []byte) disclosureResponse {
+	t.Helper()
+	var resp disclosureResponse
+	if err := json.Unmarshal(body, &resp); err != nil {
+		t.Fatalf("decode disclosure response: %v (body=%s)", err, body)
+	}
+	return resp
+}
+
+func TestParseForensicPrivateKey(t *testing.T) {
+	priv, _, _ := forensicKeyPair(t)
+
+	pemKey := func() []byte {
+		ek, err := ecdh.X25519().NewPrivateKey(priv)
+		if err != nil {
+			t.Fatalf("ecdh key: %v", err)
+		}
+		der, err := x509.MarshalPKCS8PrivateKey(ek)
+		if err != nil {
+			t.Fatalf("marshal pkcs8: %v", err)
+		}
+		return pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	}()
+
+	cases := []struct {
+		name string
+		in   []byte
+	}{
+		{"raw", priv},
+		{"hex", []byte(hex.EncodeToString(priv))},
+		{"hex with whitespace", []byte("  " + hex.EncodeToString(priv) + "\n")},
+		{"base64 std", []byte(base64.StdEncoding.EncodeToString(priv))},
+		{"base64 rawurl", []byte(base64.RawURLEncoding.EncodeToString(priv))},
+		{"pem pkcs8", pemKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseForensicPrivateKey(tc.in)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if !bytes.Equal(got, priv) {
+				t.Fatalf("parsed key mismatch")
+			}
+		})
+	}
+
+	bad := []struct {
+		name string
+		in   []byte
+	}{
+		{"too short", priv[:31]},
+		{"garbage text", []byte("not-a-key")},
+		{"empty", []byte("")},
+	}
+	for _, tc := range bad {
+		t.Run("reject/"+tc.name, func(t *testing.T) {
+			if _, err := parseForensicPrivateKey(tc.in); err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+		})
+	}
+}
+
+func TestForensicKeyLoadStatusClear(t *testing.T) {
+	priv, _, fp := forensicKeyPair(t)
+	srv := seedReceipts(t, Config{})
+	h := srv.Handler()
+
+	// Load.
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("load: got %d, want 200 (body=%s)", w.Code, w.Body)
+	}
+	var st forensicKeyStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil {
+		t.Fatalf("decode load: %v", err)
+	}
+	if !st.Loaded || st.Fingerprint != fp {
+		t.Fatalf("load status: loaded=%v fingerprint=%q want loaded=true fingerprint=%q", st.Loaded, st.Fingerprint, fp)
+	}
+
+	// Status reflects the loaded key.
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/api/forensic-key", nil))
+	st = forensicKeyStatus{}
+	json.Unmarshal(w.Body.Bytes(), &st)
+	if !st.Loaded || st.Fingerprint != fp || !st.Available {
+		t.Fatalf("status after load: %+v", st)
+	}
+
+	// Clear.
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("DELETE", "/api/forensic-key", nil))
+	if w.Code != http.StatusOK {
+		t.Fatalf("clear: got %d", w.Code)
+	}
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/api/forensic-key", nil))
+	st = forensicKeyStatus{}
+	json.Unmarshal(w.Body.Bytes(), &st)
+	if st.Loaded || st.Fingerprint != "" {
+		t.Fatalf("status after clear: %+v", st)
+	}
+}
+
+func TestForensicKeyLoadRejectsBadKey(t *testing.T) {
+	srv := seedReceipts(t, Config{})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader([]byte("nonsense"))))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", w.Code)
+	}
+}
+
+func TestDisclosureDecryptsWithMatchingKey(t *testing.T) {
+	priv, pub, fp := forensicKeyPair(t)
+	params := map[string]any{"command": "rm -rf /tmp/scratch", "cwd": "/home/op"}
+	srv := seedReceipts(t, Config{}, encReceipt(t, "urn:receipt:enc1", pub, fp, params))
+	h := srv.Handler()
+
+	// Load the key, then decrypt.
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("load: %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	req := httptest.NewRequest("GET", "/api/disclosure/"+"urn:receipt:enc1", nil)
+	h.ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("disclosure: %d", w.Code)
+	}
+	if cc := w.Header().Get("Cache-Control"); cc != "no-store" {
+		t.Errorf("Cache-Control = %q, want no-store", cc)
+	}
+	resp := decodeDisclosure(t, w.Body.Bytes())
+	if resp.State != "decrypted" {
+		t.Fatalf("state = %q, want decrypted", resp.State)
+	}
+	if resp.Parameters["command"] != "rm -rf /tmp/scratch" || resp.Parameters["cwd"] != "/home/op" {
+		t.Fatalf("decrypted params mismatch: %+v", resp.Parameters)
+	}
+}
+
+func TestDisclosureLockedWithoutKey(t *testing.T) {
+	_, pub, fp := forensicKeyPair(t)
+	srv := seedReceipts(t, Config{}, encReceipt(t, "urn:receipt:enc1", pub, fp, map[string]any{"command": "ls"}))
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, httptest.NewRequest("GET", "/api/disclosure/urn:receipt:enc1", nil))
+	resp := decodeDisclosure(t, w.Body.Bytes())
+	if resp.State != "locked" {
+		t.Fatalf("state = %q, want locked", resp.State)
+	}
+	if len(resp.Kids) != 1 || resp.Kids[0] != fp {
+		t.Fatalf("kids = %v, want [%s]", resp.Kids, fp)
+	}
+}
+
+func TestDisclosureMismatchWithWrongKey(t *testing.T) {
+	_, pub, fp := forensicKeyPair(t)
+	wrongPriv, _, _ := forensicKeyPair(t)
+	srv := seedReceipts(t, Config{}, encReceipt(t, "urn:receipt:enc1", pub, fp, map[string]any{"command": "ls"}))
+	h := srv.Handler()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader(wrongPriv)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("load: %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/api/disclosure/urn:receipt:enc1", nil))
+	resp := decodeDisclosure(t, w.Body.Bytes())
+	if resp.State != "mismatch" {
+		t.Fatalf("state = %q, want mismatch", resp.State)
+	}
+}
+
+func TestDisclosureFailedWithTamperedCiphertext(t *testing.T) {
+	priv, pub, fp := forensicKeyPair(t)
+	r := encReceipt(t, "urn:receipt:enc1", pub, fp, map[string]any{"command": "ls"})
+
+	// Corrupt the AEAD ciphertext while keeping it valid base64url, so the
+	// envelope still parses but the AEAD open fails.
+	env := r.CredentialSubject.Action.ParametersDisclosure
+	ctBytes, err := base64.RawURLEncoding.DecodeString(env.CT)
+	if err != nil {
+		t.Fatalf("decode ct: %v", err)
+	}
+	ctBytes[0] ^= 0xff
+	env.CT = base64.RawURLEncoding.EncodeToString(ctBytes)
+
+	srv := seedReceipts(t, Config{}, r)
+	h := srv.Handler()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("load: %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/api/disclosure/urn:receipt:enc1", nil))
+	resp := decodeDisclosure(t, w.Body.Bytes())
+	if resp.State != "failed" {
+		t.Fatalf("state = %q, want failed", resp.State)
+	}
+}
+
+func TestDisclosureNoneForPlainReceipt(t *testing.T) {
+	// A receipt with no parameters_disclosure reports state "none".
+	r := makeReceipt("urn:receipt:plain1", "chain-plain", 1, "filesystem.file.read", receipt.RiskLow, receipt.StatusSuccess, "2026-05-01T10:00:00Z", nil)
+	srv := seedReceipts(t, Config{}, r)
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, httptest.NewRequest("GET", "/api/disclosure/urn:receipt:plain1", nil))
+	resp := decodeDisclosure(t, w.Body.Bytes())
+	if resp.State != "none" {
+		t.Fatalf("state = %q, want none", resp.State)
+	}
+}
+
+func TestForensicDisabledOnNonLoopbackBind(t *testing.T) {
+	priv, _, _ := forensicKeyPair(t)
+	srv := seedReceipts(t, Config{Host: "0.0.0.0"})
+	h := srv.Handler()
+
+	// Status reports unavailable.
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("GET", "/api/forensic-key", nil))
+	var st forensicKeyStatus
+	json.Unmarshal(w.Body.Bytes(), &st)
+	if st.Available {
+		t.Fatalf("expected Available=false on 0.0.0.0 bind")
+	}
+
+	// Loading a key is refused.
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, httptest.NewRequest("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("load on non-loopback: got %d, want 403", w.Code)
+	}
+}

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -230,6 +230,34 @@ func TestDisclosureDecryptsWithMatchingKey(t *testing.T) {
 	}
 }
 
+// A correct key must decrypt even when the envelope's kid is written in a
+// non-canonical form (e.g. a did:key URL) that does not equal our sha256
+// fingerprint — the kid is non-authoritative and DecryptDisclosure ignores it.
+func TestDisclosureDecryptsWithNonCanonicalKid(t *testing.T) {
+	priv, pub, _ := forensicKeyPair(t)
+	params := map[string]any{"command": "whoami"}
+	// Encrypt to the right public key but stamp a did:key-style kid.
+	r := encReceipt(t, "urn:receipt:enc1", pub, "did:key:z6MkExampleForensicRecipientKeyId", params)
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"}, r)
+	h := srv.Handler()
+
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, localReq("POST", "/api/forensic-key", bytes.NewReader(priv)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("load: %d", w.Code)
+	}
+
+	w = httptest.NewRecorder()
+	h.ServeHTTP(w, localReq("GET", "/api/disclosure/urn:receipt:enc1", nil))
+	resp := decodeDisclosure(t, w.Body.Bytes())
+	if resp.State != "decrypted" {
+		t.Fatalf("state = %q, want decrypted (kid form must not block a correct key)", resp.State)
+	}
+	if resp.Parameters["command"] != "whoami" {
+		t.Fatalf("decrypted params mismatch: %+v", resp.Parameters)
+	}
+}
+
 func TestDisclosureLockedWithoutKey(t *testing.T) {
 	_, pub, fp := forensicKeyPair(t)
 	srv := seedReceipts(t, Config{Host: "127.0.0.1"}, encReceipt(t, "urn:receipt:enc1", pub, fp, map[string]any{"command": "ls"}))

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -37,7 +37,8 @@ type Config struct {
 	// Host is the address the server is bound to. It gates forensic key
 	// operations: the loaded private key can decrypt every matching
 	// disclosure, so a key is only accepted when the bind is loopback (see
-	// forensicAvailable). The empty value is treated as loopback.
+	// forensicAvailable). An empty or all-interfaces bind (""/"0.0.0.0"/"::")
+	// is not loopback and disables forensic operations.
 	Host string
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -34,6 +34,11 @@ type Config struct {
 	DBPath string
 	// Version is the dashboard build version, shown in the header footer.
 	Version string
+	// Host is the address the server is bound to. It gates forensic key
+	// operations: the loaded private key can decrypt every matching
+	// disclosure, so a key is only accepted when the bind is loopback (see
+	// forensicAvailable). The empty value is treated as loopback.
+	Host string
 }
 
 //go:embed static
@@ -41,8 +46,9 @@ var staticFS embed.FS
 
 // Server is the dashboard HTTP server.
 type Server struct {
-	reader *store.Reader
-	cfg    Config
+	reader   *store.Reader
+	cfg      Config
+	forensic *forensicKeyStore
 }
 
 // New creates a new Server backed by the given reader. A zero PollInterval
@@ -51,7 +57,7 @@ func New(reader *store.Reader, cfg Config) *Server {
 	if cfg.PollInterval <= 0 {
 		cfg.PollInterval = DefaultPollInterval
 	}
-	return &Server{reader: reader, cfg: cfg}
+	return &Server{reader: reader, cfg: cfg, forensic: &forensicKeyStore{}}
 }
 
 // Handler returns the HTTP handler with all routes registered.
@@ -66,6 +72,16 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/receipts/{id...}", s.handleReceiptDetail)
 	mux.HandleFunc("GET /api/chains", s.handleChains)
 	mux.HandleFunc("GET /api/chains/{chainID}/verify", s.handleChainVerify)
+
+	// Forensic disclosure: load/clear the operator's X25519 private key (held
+	// in memory only) and decrypt a receipt's parameters_disclosure envelope
+	// inline. The decrypt route lives under its own prefix because the receipt
+	// detail route uses a trailing {id...} wildcard, which cannot carry a
+	// further path segment.
+	mux.HandleFunc("GET /api/forensic-key", s.handleForensicKeyGet)
+	mux.HandleFunc("POST /api/forensic-key", s.handleForensicKeyLoad)
+	mux.HandleFunc("DELETE /api/forensic-key", s.handleForensicKeyClear)
+	mux.HandleFunc("GET /api/disclosure/{id...}", s.handleReceiptDisclosure)
 
 	// Static files + index.
 	mux.HandleFunc("GET /", s.handleIndex)

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1752,6 +1752,11 @@
     async function loadForensicStatus() {
       try {
         applyForensicStatus(await fetchJSON('/api/forensic-key'));
+        // The server may already hold a key from a prior session (the key lives
+        // in server memory, not the browser). If a receipt was opened before
+        // this resolved, re-hydrate it so a matching receipt decrypts rather
+        // than staying stuck in the locked state.
+        refreshOpenReceiptDisclosure();
       } catch (err) {
         console.warn('forensic status:', err);
         renderForensicChip();
@@ -1775,11 +1780,15 @@
       }
     }
 
-    // Abbreviate a sha256:<hex> fingerprint for compact display.
+    // Abbreviate a recipient identifier for compact display. A sha256:<hex>
+    // fingerprint keeps its prefix and shows the first 10 hex chars; any other
+    // form (e.g. a did:key URL) is truncated as-is so it isn't mislabelled.
     function shortFingerprint(fp) {
       if (!fp) return '';
-      const hex = fp.startsWith('sha256:') ? fp.slice(7) : fp;
-      return 'sha256:' + hex.slice(0, 10) + '…';
+      if (fp.startsWith('sha256:')) {
+        return 'sha256:' + fp.slice(7, 17) + '…';
+      }
+      return fp.length > 24 ? fp.slice(0, 24) + '…' : fp;
     }
 
     function openForensic() {

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -450,6 +450,49 @@
       border-left: 3px solid var(--risk-medium); border-radius: var(--radius);
       padding: 8px 12px; font-size: 0.8rem; color: var(--text);
     }
+
+    /* ---------- Forensic key (header chip + panel) ---------- */
+    .forensic-chip {
+      display: inline-flex; align-items: center; gap: 6px;
+      background: var(--surface); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 3px 8px; cursor: pointer;
+      color: var(--muted); font-size: 0.75rem; font-family: var(--font-mono);
+    }
+    .forensic-chip:hover { border-color: var(--border-strong); color: var(--text); }
+    .forensic-chip:focus { outline: 2px solid var(--accent); outline-offset: 2px; }
+    .forensic-chip.loaded { color: var(--status-success); border-color: rgba(63,185,80,0.4); }
+    .forensic-field {
+      width: 100%; background: var(--surface-sunken); border: 1px solid var(--border);
+      border-radius: var(--radius); padding: 6px 8px; resize: vertical;
+      font-family: var(--font-mono); font-size: 0.75rem; color: var(--text);
+    }
+    .forensic-btn {
+      font-size: 0.75rem; padding: 5px 12px; border: 1px solid var(--border);
+      border-radius: var(--radius); background: var(--surface); color: var(--text); cursor: pointer;
+    }
+    .forensic-btn:hover { border-color: var(--border-strong); }
+    .forensic-btn.danger { color: var(--status-failure); border-color: rgba(248,81,73,0.4); }
+
+    /* ---------- Parameters disclosure: decryption panel ---------- */
+    .decrypt-panel {
+      border: 1px solid var(--border); border-radius: var(--radius);
+      padding: 10px 12px; font-size: 0.8rem;
+    }
+    .decrypt-panel .decrypt-head {
+      display: flex; align-items: center; gap: 8px; font-weight: 500; margin-bottom: 6px;
+    }
+    .decrypt-panel.locked    { background: var(--surface-sunken); border-color: var(--border); }
+    .decrypt-panel.locked    .decrypt-head { color: var(--muted); }
+    .decrypt-panel.mismatch,
+    .decrypt-panel.failed    { background: rgba(248,81,73,0.06); border-color: rgba(248,81,73,0.35); }
+    .decrypt-panel.mismatch  .decrypt-head,
+    .decrypt-panel.failed    .decrypt-head { color: var(--status-failure); }
+    .decrypt-panel.decrypted {
+      background: rgba(63,185,80,0.06); border-color: rgba(63,185,80,0.35);
+      border-left: 3px solid var(--status-success);
+    }
+    .decrypt-panel.decrypted .decrypt-head { color: var(--status-success); }
+    .decrypt-meta { color: var(--muted); font-size: 0.7rem; font-family: var(--font-mono); word-break: break-all; }
     .mismatch-banner .label { color: var(--risk-medium); font-weight: 600; margin-right: 6px; }
     .outcome-error-banner {
       background: rgba(248,81,73,0.08); border: 1px solid rgba(248,81,73,0.35);
@@ -521,6 +564,9 @@
       </div>
 
       <div class="header-actions">
+        <button class="forensic-chip" id="forensic-chip" type="button" onclick="openForensic()" aria-haspopup="dialog" title="Forensic decryption key">
+          <span id="forensic-chip-label">🔒 Forensic key</span>
+        </button>
         <button class="icon-btn" id="btn-shortcuts" type="button" aria-label="Keyboard shortcuts (?)" title="Keyboard shortcuts (?)">?</button>
         <span class="ctx-item" id="ctx-version">
           <span class="ctx-label">v</span>
@@ -675,6 +721,17 @@
           <div class="shortcut-row"><span class="shortcut-desc">Go to Chains</span><span class="shortcut-keys"><span class="kbd">g</span><span class="kbd">c</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Clear all filters</span><span class="shortcut-keys"><span class="kbd">c</span></span></div>
         </div>
+      </div>
+    </div>
+
+    <!-- Forensic decryption key modal -->
+    <div id="forensic-modal" class="modal-backdrop" hidden>
+      <div class="modal-panel" role="dialog" aria-labelledby="forensic-modal-title" aria-modal="true" style="max-width: 520px;">
+        <div class="modal-head">
+          <h2 class="modal-title" id="forensic-modal-title">Forensic decryption key</h2>
+          <button class="icon-btn" type="button" onclick="closeForensic()" aria-label="Close">×</button>
+        </div>
+        <div class="modal-body" id="forensic-modal-body"></div>
       </div>
     </div>
   </main>
@@ -1225,6 +1282,7 @@
         document.getElementById('modal-title').textContent = receipt.id;
         document.getElementById('modal-content').innerHTML = renderReceiptDetail(receipt);
         openModal('receipt-modal');
+        hydrateDisclosure(receipt);
       } catch (err) {
         showError('Failed to load receipt: ' + err.message);
       }
@@ -1286,7 +1344,7 @@
 
           ${authorizationSectionHTML(subj.authorization)}
 
-          ${parametersDisclosureHTML(subj.action.parameters_disclosure)}
+          ${disclosureSectionHTML(subj.action.parameters_disclosure)}
 
           ${outcomeDetailsHTML(subj.outcome)}
 
@@ -1530,6 +1588,119 @@
       el.setAttribute('aria-expanded', expanded ? 'true' : 'false');
     }
 
+    // ---------- Parameters disclosure: HPKE decryption ----------
+    // An HPKE envelope (parameters_disclosure with a recipients array and a ct
+    // field) is encrypted to a forensic key. We render a placeholder and decrypt
+    // it server-side via /api/disclosure/{id} using the loaded private key.
+    // Older receipts carry a plaintext {input, output, …} disclosure instead —
+    // those keep their existing rendering.
+    function isHpkeEnvelope(d) {
+      return d && typeof d === 'object' && Array.isArray(d.recipients) && typeof d.ct === 'string';
+    }
+
+    function disclosureSectionHTML(d) {
+      if (!d || typeof d !== 'object') return '';
+      if (isHpkeEnvelope(d)) {
+        // Filled by hydrateDisclosure once the receipt modal opens.
+        return `
+          <div>
+            <div class="muted text-xs mb-1">Parameters disclosure</div>
+            <div id="disclosure-panel">
+              <div class="decrypt-panel locked">
+                <div class="decrypt-head">🔒 Encrypted parameters</div>
+                <div class="muted text-xs">Checking…</div>
+              </div>
+            </div>
+          </div>`;
+      }
+      // Legacy operator-disclosed plaintext ({input, output, …}).
+      return parametersDisclosureHTML(d);
+    }
+
+    async function hydrateDisclosure(receipt) {
+      const subj = receipt && receipt.credentialSubject;
+      const d = subj && subj.action && subj.action.parameters_disclosure;
+      if (!isHpkeEnvelope(d)) return;
+      if (!document.getElementById('disclosure-panel')) return;
+      try {
+        const resp = await fetchJSON('/api/disclosure/' + encodeURIComponent(receipt.id));
+        // Bail if the operator switched to a different receipt while in flight.
+        if (!currentReceipt || currentReceipt.id !== receipt.id) return;
+        const panel = document.getElementById('disclosure-panel');
+        if (panel) panel.innerHTML = renderDisclosurePanel(resp);
+      } catch (err) {
+        const panel = document.getElementById('disclosure-panel');
+        if (panel) panel.innerHTML = renderDisclosurePanelError(err.message);
+      }
+    }
+
+    function renderDisclosurePanel(resp) {
+      const state = resp && resp.state;
+      const kids = (resp && resp.kids) || [];
+      const kidLine = kids.length
+        ? `<div class="decrypt-meta" title="${escapeAttr(kids.join(', '))}">recipient: ${escapeHtml(kids.map(shortFingerprint).join(', '))}</div>`
+        : '';
+
+      if (state === 'decrypted') {
+        const params = resp.parameters || {};
+        const keys = Object.keys(params);
+        const blocks = keys.length
+          ? keys.map(k => disclosureBlockHTML(k, formatDisclosureValue(params[k]))).join('')
+          : '<div class="muted text-xs">(empty parameters object)</div>';
+        return `
+          <div class="decrypt-panel decrypted">
+            <div class="decrypt-head">🔓 Decrypted parameters</div>
+            <div class="space-y-3">${blocks}</div>
+            ${kidLine}
+          </div>`;
+      }
+
+      if (state === 'mismatch') {
+        return `
+          <div class="decrypt-panel mismatch">
+            <div class="decrypt-head">🔑 Decryption key mismatch</div>
+            <div class="text-xs">The loaded key does not match this receipt's recipient.</div>
+            <div class="decrypt-meta">loaded: ${escapeHtml(shortFingerprint(resp.fingerprint))}</div>
+            ${kidLine}
+          </div>`;
+      }
+
+      if (state === 'failed') {
+        return `
+          <div class="decrypt-panel failed">
+            <div class="decrypt-head">⚠ Decryption failed</div>
+            <div class="text-xs">The envelope could not be decrypted with the loaded key.</div>
+            ${kidLine}
+          </div>`;
+      }
+
+      if (state === 'none') return '';
+
+      // locked (default): no key loaded.
+      return `
+        <div class="decrypt-panel locked">
+          <div class="decrypt-head">🔒 Encrypted parameters</div>
+          <div class="text-xs muted">Decryption key not loaded.
+            <button class="toggle" type="button" onclick="openForensic()">Load forensic key</button>
+          </div>
+          ${kidLine}
+        </div>`;
+    }
+
+    function renderDisclosurePanelError(msg) {
+      return `
+        <div class="decrypt-panel failed">
+          <div class="decrypt-head">⚠ Disclosure unavailable</div>
+          <div class="text-xs">${escapeHtml(msg || 'Could not check disclosure state.')}</div>
+        </div>`;
+    }
+
+    function formatDisclosureValue(v) {
+      if (v === null || v === undefined) return '';
+      if (typeof v === 'string') return v;
+      try { return JSON.stringify(v, null, 2); } catch (_) { return String(v); }
+    }
+
     // ---------- Modal helpers ----------
     let lastFocusedBeforeModal = null;
     function openModal(id) {
@@ -1554,12 +1725,157 @@
     function closeShortcuts()  { closeModalById('shortcuts-modal'); }
 
     function isModalOpen() {
-      return ['receipt-modal','chain-modal','shortcuts-modal'].some(id => !document.getElementById(id).hidden);
+      return ['receipt-modal','chain-modal','shortcuts-modal','forensic-modal'].some(id => !document.getElementById(id).hidden);
     }
     function closeAnyOpenModal() {
+      if (!document.getElementById('forensic-modal').hidden) closeForensic();
       if (!document.getElementById('shortcuts-modal').hidden) closeShortcuts();
       if (!document.getElementById('chain-modal').hidden) closeChainModal();
       if (!document.getElementById('receipt-modal').hidden) closeModal();
+    }
+
+    // ---------- Forensic decryption key ----------
+    // The operator's X25519 private key is held in the dashboard process memory
+    // only (never persisted). This client tracks the loaded status and drives
+    // the load/clear UI; key parsing, fingerprinting, and HPKE decryption all
+    // happen server-side via /api/forensic-key and /api/disclosure/{id}.
+    const forensicState = { available: true, loaded: false, fingerprint: '' };
+
+    async function loadForensicStatus() {
+      try {
+        const st = await fetchJSON('/api/forensic-key');
+        forensicState.available = !!st.available;
+        forensicState.loaded = !!st.loaded;
+        forensicState.fingerprint = st.fingerprint || '';
+      } catch (err) {
+        console.warn('forensic status:', err);
+      }
+      renderForensicChip();
+    }
+
+    function renderForensicChip() {
+      const chip = document.getElementById('forensic-chip');
+      const label = document.getElementById('forensic-chip-label');
+      if (!chip || !label) return;
+      if (forensicState.loaded) {
+        chip.classList.add('loaded');
+        label.textContent = '🔓 ' + shortFingerprint(forensicState.fingerprint);
+        chip.title = 'Forensic key loaded: ' + forensicState.fingerprint;
+      } else {
+        chip.classList.remove('loaded');
+        label.textContent = '🔒 Forensic key';
+        chip.title = forensicState.available
+          ? 'Load a forensic decryption key'
+          : 'Forensic decryption unavailable (not bound to loopback)';
+      }
+    }
+
+    // Abbreviate a sha256:<hex> fingerprint for compact display.
+    function shortFingerprint(fp) {
+      if (!fp) return '';
+      const hex = fp.startsWith('sha256:') ? fp.slice(7) : fp;
+      return 'sha256:' + hex.slice(0, 10) + '…';
+    }
+
+    function openForensic() {
+      renderForensicModalBody();
+      openModal('forensic-modal');
+    }
+    function closeForensic() { closeModalById('forensic-modal'); }
+
+    function renderForensicModalBody() {
+      const body = document.getElementById('forensic-modal-body');
+      if (!body) return;
+
+      if (!forensicState.available) {
+        body.innerHTML = `
+          <p class="text-sm muted">Forensic decryption is disabled because the dashboard is not bound to a loopback address. Restart with <code>-host 127.0.0.1</code> to enable it.</p>`;
+        return;
+      }
+
+      if (forensicState.loaded) {
+        body.innerHTML = `
+          <p class="text-sm mb-3">A forensic key is loaded for this session. Matching receipts decrypt automatically in the detail view.</p>
+          <div class="muted text-xs mb-1">Loaded key fingerprint</div>
+          <div class="decrypt-meta mb-3">${escapeHtml(forensicState.fingerprint)}</div>
+          <p class="muted text-xs mb-3">Verify this matches the fingerprint the daemon logged at startup. The key is held in memory only and is never written to disk.</p>
+          <button class="forensic-btn danger" type="button" onclick="clearForensicKey()">Clear key</button>`;
+        return;
+      }
+
+      body.innerHTML = `
+        <p class="text-sm mb-3">Load your X25519 forensic private key to decrypt <code>parameters_disclosure</code> envelopes. The key stays in this dashboard's memory for the session only — it is never persisted or sent elsewhere.</p>
+        <div class="space-y-3">
+          <div>
+            <label class="muted text-xs" for="forensic-file">Key file (raw 32-byte key from <code>--init-forensic-key</code>)</label>
+            <input class="forensic-field" type="file" id="forensic-file">
+          </div>
+          <div>
+            <label class="muted text-xs" for="forensic-text">…or paste hex / base64 / PKCS#8 PEM</label>
+            <textarea class="forensic-field" id="forensic-text" rows="3" placeholder="hex, base64, or -----BEGIN PRIVATE KEY-----"></textarea>
+          </div>
+          <div id="forensic-error" class="text-xs" style="color:var(--status-failure);" hidden></div>
+          <button class="forensic-btn" type="button" onclick="submitForensicKey()">Load key</button>
+        </div>`;
+    }
+
+    function forensicError(msg) {
+      const el = document.getElementById('forensic-error');
+      if (!el) return;
+      if (!msg) { el.hidden = true; el.textContent = ''; return; }
+      el.hidden = false; el.textContent = msg;
+    }
+
+    async function submitForensicKey() {
+      const fileInput = document.getElementById('forensic-file');
+      const textInput = document.getElementById('forensic-text');
+      forensicError('');
+
+      let body;
+      const file = fileInput && fileInput.files && fileInput.files[0];
+      if (file) {
+        body = await file.arrayBuffer();
+      } else {
+        const text = ((textInput && textInput.value) || '').trim();
+        if (!text) { forensicError('Choose a key file or paste a key.'); return; }
+        body = text;
+      }
+
+      try {
+        const res = await fetch('/api/forensic-key', { method: 'POST', body });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) { forensicError(data.error || ('HTTP ' + res.status)); return; }
+        forensicState.loaded = !!data.loaded;
+        forensicState.fingerprint = data.fingerprint || '';
+        forensicState.available = true;
+        renderForensicChip();
+        renderForensicModalBody();
+        refreshOpenReceiptDisclosure();
+      } catch (err) {
+        forensicError(err.message || String(err));
+      }
+    }
+
+    async function clearForensicKey() {
+      try {
+        await fetch('/api/forensic-key', { method: 'DELETE' });
+      } catch (err) {
+        console.warn('forensic clear:', err);
+      }
+      forensicState.loaded = false;
+      forensicState.fingerprint = '';
+      renderForensicChip();
+      renderForensicModalBody();
+      refreshOpenReceiptDisclosure();
+    }
+
+    // Re-run disclosure hydration for the open receipt modal after the key
+    // changes, so a just-loaded key decrypts inline (or a cleared key re-locks)
+    // without the operator reopening the receipt.
+    function refreshOpenReceiptDisclosure() {
+      if (!document.getElementById('receipt-modal').hidden && currentReceipt) {
+        hydrateDisclosure(currentReceipt);
+      }
     }
 
     // ---------- Chain detail ----------
@@ -1970,7 +2286,7 @@
     document.getElementById('btn-shortcuts').addEventListener('click', showShortcuts);
 
     // Close modals on backdrop click.
-    ['receipt-modal','chain-modal','shortcuts-modal'].forEach(id => {
+    ['receipt-modal','chain-modal','shortcuts-modal','forensic-modal'].forEach(id => {
       document.getElementById(id).addEventListener('click', e => {
         if (e.target === e.currentTarget) closeModalById(id);
       });
@@ -1978,6 +2294,7 @@
 
     // ---------- Boot ----------
     loadPollConfig().then(loadOverview);
+    loadForensicStatus();
   </script>
 </body>
 </html>

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1540,32 +1540,6 @@
     }
 
     // ---------- Parameters disclosure (modal body) ----------
-    const DISCLOSURE_PRIMARY_KEYS = ['input', 'output'];
-    function parametersDisclosureHTML(disclosure) {
-      if (!disclosure || typeof disclosure !== 'object') return '';
-      const keys = Object.keys(disclosure);
-      if (keys.length === 0) return '';
-
-      const primary = DISCLOSURE_PRIMARY_KEYS
-        .filter(k => disclosure[k] != null && String(disclosure[k]) !== '')
-        .map(k => disclosureBlockHTML(k.charAt(0).toUpperCase() + k.slice(1), String(disclosure[k])));
-      const others = keys
-        .filter(k => !DISCLOSURE_PRIMARY_KEYS.includes(k))
-        .map(k => disclosureBlockHTML(k, String(disclosure[k])));
-
-      if (primary.length === 0 && others.length === 0) return '';
-
-      return `
-        <div>
-          <div class="muted text-xs mb-1">Parameters disclosure</div>
-          <div class="space-y-3">
-            ${primary.join('')}
-            ${others.join('')}
-          </div>
-        </div>
-      `;
-    }
-
     // Approximate threshold above which a disclosure block collapses behind
     // a toggle. JS uses character count, CSS uses height, so they won't
     // perfectly align across all fonts and screen sizes.
@@ -1598,23 +1572,27 @@
       return d && typeof d === 'object' && Array.isArray(d.recipients) && typeof d.ct === 'string';
     }
 
+    // Only HPKE envelopes are rendered here. The pre-v0.3.0 plaintext
+    // {input, output} disclosure no longer survives the round-trip through the
+    // SDK's typed *DisclosureEnvelope (which carries only v/alg/recipients/ct),
+    // so there is nothing legacy to render in the detail view.
     function disclosureSectionHTML(d) {
-      if (!d || typeof d !== 'object') return '';
-      if (isHpkeEnvelope(d)) {
-        // Filled by hydrateDisclosure once the receipt modal opens.
-        return `
-          <div>
-            <div class="muted text-xs mb-1">Parameters disclosure</div>
-            <div id="disclosure-panel">
-              <div class="decrypt-panel locked">
-                <div class="decrypt-head">🔒 Encrypted parameters</div>
-                <div class="muted text-xs">Checking…</div>
-              </div>
+      if (!isHpkeEnvelope(d)) return '';
+      // The panel body is filled by hydrateDisclosure once the modal opens.
+      return `
+        <div>
+          <div class="muted text-xs mb-1">Parameters disclosure</div>
+          <div id="disclosure-panel">
+            <div class="decrypt-panel locked">
+              <div class="decrypt-head">🔒 Encrypted parameters</div>
+              <div class="muted text-xs">Checking…</div>
             </div>
-          </div>`;
-      }
-      // Legacy operator-disclosed plaintext ({input, output, …}).
-      return parametersDisclosureHTML(d);
+          </div>
+        </div>`;
+    }
+
+    function envelopeKids(d) {
+      return (d.recipients || []).map(r => r && r.kid).filter(Boolean);
     }
 
     async function hydrateDisclosure(receipt) {
@@ -1622,6 +1600,14 @@
       const d = subj && subj.action && subj.action.parameters_disclosure;
       if (!isHpkeEnvelope(d)) return;
       if (!document.getElementById('disclosure-panel')) return;
+      // No key loaded: the locked state is fully derivable from the envelope the
+      // client already holds, so render it without a server round-trip. Only
+      // decryption needs the server (it alone holds the private key), which also
+      // keeps recovered plaintext confined to the dedicated /api/disclosure route.
+      if (!forensicState.loaded) {
+        setDisclosurePanel(receipt.id, renderDisclosurePanel({ state: 'locked', alg: d.alg, kids: envelopeKids(d) }));
+        return;
+      }
       try {
         const resp = await fetchJSON('/api/disclosure/' + encodeURIComponent(receipt.id));
         setDisclosurePanel(receipt.id, renderDisclosurePanel(resp));

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1565,9 +1565,9 @@
     // ---------- Parameters disclosure: HPKE decryption ----------
     // An HPKE envelope (parameters_disclosure with a recipients array and a ct
     // field) is encrypted to a forensic key. We render a placeholder and decrypt
-    // it server-side via /api/disclosure/{id} using the loaded private key.
-    // Older receipts carry a plaintext {input, output, …} disclosure instead —
-    // those keep their existing rendering.
+    // it server-side via /api/disclosure/{id} using the loaded private key. This
+    // is the only disclosure shape the detail view renders; see
+    // disclosureSectionHTML for why legacy plaintext disclosures do not appear.
     function isHpkeEnvelope(d) {
       return d && typeof d === 'object' && Array.isArray(d.recipients) && typeof d.ct === 'string';
     }
@@ -1870,10 +1870,16 @@
     async function clearForensicKey() {
       try {
         const res = await fetch('/api/forensic-key', { method: 'DELETE' });
-        applyForensicStatus(await res.json().catch(() => ({ available: forensicState.available })));
+        if (res.ok) {
+          applyForensicStatus(await res.json().catch(() => ({ available: forensicState.available })));
+        } else {
+          // The clear was rejected (e.g. 403): never assume the key is gone —
+          // re-sync from the authoritative status so the UI matches the server.
+          await loadForensicStatus();
+        }
       } catch (err) {
         console.warn('forensic clear:', err);
-        applyForensicStatus({ available: forensicState.available });
+        await loadForensicStatus();
       }
       renderForensicModalBody();
       refreshOpenReceiptDisclosure();

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1624,14 +1624,19 @@
       if (!document.getElementById('disclosure-panel')) return;
       try {
         const resp = await fetchJSON('/api/disclosure/' + encodeURIComponent(receipt.id));
-        // Bail if the operator switched to a different receipt while in flight.
-        if (!currentReceipt || currentReceipt.id !== receipt.id) return;
-        const panel = document.getElementById('disclosure-panel');
-        if (panel) panel.innerHTML = renderDisclosurePanel(resp);
+        setDisclosurePanel(receipt.id, renderDisclosurePanel(resp));
       } catch (err) {
-        const panel = document.getElementById('disclosure-panel');
-        if (panel) panel.innerHTML = renderDisclosurePanelError(err.message);
+        setDisclosurePanel(receipt.id, renderDisclosurePanelError(err.message));
       }
+    }
+
+    // Write into the open receipt's disclosure panel, but only if that receipt
+    // is still the one on screen — the operator may have switched receipts while
+    // the request was in flight (the panel id is shared across detail opens).
+    function setDisclosurePanel(receiptId, html) {
+      if (!currentReceipt || currentReceipt.id !== receiptId) return;
+      const panel = document.getElementById('disclosure-panel');
+      if (panel) panel.innerHTML = html;
     }
 
     function renderDisclosurePanel(resp) {
@@ -1674,7 +1679,11 @@
           </div>`;
       }
 
-      if (state === 'none') return '';
+      // 'none' should not occur here (the panel only renders for HPKE
+      // envelopes), but guard against an orphaned header if it ever does.
+      if (state === 'none') {
+        return '<div class="muted text-xs">No parameters disclosure recorded.</div>';
+      }
 
       // locked (default): no key loaded.
       return `
@@ -1739,18 +1748,28 @@
     // only (never persisted). This client tracks the loaded status and drives
     // the load/clear UI; key parsing, fingerprinting, and HPKE decryption all
     // happen server-side via /api/forensic-key and /api/disclosure/{id}.
-    const forensicState = { available: true, loaded: false, fingerprint: '' };
+    // available defaults false until the server confirms a loopback bind, so the
+    // load form (and any key submission) is never offered before status resolves.
+    const forensicState = { available: false, loaded: false, fingerprint: '' };
+
+    // applyForensicStatus is the single writer of forensicState: every
+    // load/clear/status response is the authoritative forensicKeyStatus JSON,
+    // so funnelling all three through here keeps the client mirror from drifting.
+    function applyForensicStatus(st) {
+      st = st || {};
+      forensicState.available = !!st.available;
+      forensicState.loaded = !!st.loaded;
+      forensicState.fingerprint = st.fingerprint || '';
+      renderForensicChip();
+    }
 
     async function loadForensicStatus() {
       try {
-        const st = await fetchJSON('/api/forensic-key');
-        forensicState.available = !!st.available;
-        forensicState.loaded = !!st.loaded;
-        forensicState.fingerprint = st.fingerprint || '';
+        applyForensicStatus(await fetchJSON('/api/forensic-key'));
       } catch (err) {
         console.warn('forensic status:', err);
+        renderForensicChip();
       }
-      renderForensicChip();
     }
 
     function renderForensicChip() {
@@ -1845,10 +1864,7 @@
         const res = await fetch('/api/forensic-key', { method: 'POST', body });
         const data = await res.json().catch(() => ({}));
         if (!res.ok) { forensicError(data.error || ('HTTP ' + res.status)); return; }
-        forensicState.loaded = !!data.loaded;
-        forensicState.fingerprint = data.fingerprint || '';
-        forensicState.available = true;
-        renderForensicChip();
+        applyForensicStatus(data);
         renderForensicModalBody();
         refreshOpenReceiptDisclosure();
       } catch (err) {
@@ -1858,13 +1874,12 @@
 
     async function clearForensicKey() {
       try {
-        await fetch('/api/forensic-key', { method: 'DELETE' });
+        const res = await fetch('/api/forensic-key', { method: 'DELETE' });
+        applyForensicStatus(await res.json().catch(() => ({ available: forensicState.available })));
       } catch (err) {
         console.warn('forensic clear:', err);
+        applyForensicStatus({ available: forensicState.available });
       }
-      forensicState.loaded = false;
-      forensicState.fingerprint = '';
-      renderForensicChip();
       renderForensicModalBody();
       refreshOpenReceiptDisclosure();
     }


### PR DESCRIPTION
## What

Adds forensic-disclosure decryption to the dashboard. An operator can load their X25519 forensic private key for the session and view decrypted `parameters_disclosure` envelopes inline in the receipt detail view. This closes the detail-view decryption follow-up deferred in 0.3.0.

Decryption is **server-side, local, and transient**: the key is held in the dashboard's process memory only and reuses the SDK's audited `receipt.DecryptDisclosure` (HPKE base mode, `hpke-x25519-hkdf-sha256-aes-256-gcm`) rather than re-implementing HPKE in the webview.

## How it works

- **Key management** — header "Forensic key" control loads the key (raw 32-byte file as written by `--init-forensic-key`, or a hex / base64 / PKCS#8 PEM paste), shows its `sha256:` fingerprint for verification against the daemon's startup log, and clears it.
- **Inline decryption** — receipts encrypted to the loaded key decrypt automatically in the detail view; non-matching show a clear "key mismatch" state; missing-key/decrypt-failure states degrade gracefully and never block the receipt view.
- **New endpoints** — `GET/POST/DELETE /api/forensic-key` and `GET /api/disclosure/{id}`.
- **SDK bump** — `github.com/agent-receipts/ar/sdk/go` `v0.13.0` → `v0.15.0` for the forensic helpers + HPKE wiring from agent-receipts/ar#722.

## Security model

- The private key is never persisted, never logged, and is zeroed on clear/replace.
- **Bind gate** — forensic operations are refused unless the dashboard is bound to a loopback address (an empty/`0.0.0.0`/`::` bind is treated as non-loopback and disables them).
- **DNS-rebinding gate** — forensic endpoints also reject requests whose `Host` header is not loopback, so a rebound remote page in the operator's browser can't reach the key/plaintext over the loopback socket.
- Decrypted plaintext is confined to the dedicated `/api/disclosure/{id}` route (`Cache-Control: no-store`); the general receipt endpoint never carries plaintext. The locked state is rendered client-side from the envelope, so the no-key case makes no server call.
- The `kid` is treated as non-authoritative: decryption is attempted whenever a key is loaded (a `did:key`-style `kid` won't block a key that can actually decrypt); the `kid` only classifies a *failure* as tamper-vs-mismatch.

## Tests

`go test ./...` green. Server-side coverage for: key parsing (raw / raw+newline / hex / base64 / PKCS#8 PEM / rejects), load/status/clear, decrypt with a matching key, decrypt with a non-canonical `kid`, locked / mismatch / failed / none states, the empty-host and non-loopback bind gates, and the `Host`-header rebinding guard across all forensic endpoints.

## Notes

- Dependencies satisfied: agent-receipts/ar#722 (daemon HPKE wiring) and #723 (SDK docs) are merged.
- The receipts **list** view still shows the generic disclosure indicator for encrypted rows (distinguishing HPKE from legacy in the list would require a reader.go SQL change); the detail view is the decryption UX. Possible follow-up.
- `CHANGELOG.md` updated under `[Unreleased]`.

## Commits

1. `feat`: the decryption feature.
2. `fix`: harden gating + key parsing (loopback fail-open on empty host, DNS-rebinding `Host` check, trailing-newline raw keys, cleanups) — from self-review.
3. `fix`: decrypt regardless of `kid` form, render locked state offline, drop dead legacy disclosure paths — from self-review.