### PR TITLE
feat: load forensic key from path and auto-probe default location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Forensic key: path input and auto-load** — the "Forensic decryption key" modal now accepts a file path in addition to the file picker and paste field. The path input is pre-filled with the default location (`~/.local/share/agent-receipts/forensic.key`) so most operators can load their key with a single click. Leading `~` is expanded to the user's home directory on the server. Additionally, when the dashboard starts on a loopback address and finds a key file at that default location, it loads the key automatically — no UI step required for a standard single-user install. New endpoint: `POST /api/forensic-key/path`.
+
 ## [0.4.0] - 2026-06-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Forensic key: path input and auto-load** — the "Forensic decryption key" modal now accepts a file path in addition to the file picker and paste field. The path input is pre-filled with the default location (`~/.local/share/agent-receipts/forensic.key`) so most operators can load their key with a single click. Leading `~` is expanded to the user's home directory on the server. Additionally, when the dashboard starts on a loopback address and finds a key file at that default location, it loads the key automatically — no UI step required for a standard single-user install. New endpoint: `POST /api/forensic-key/path`.
+- **Decrypted parameter previews on receipt rows** — when the forensic key is loaded, the hover tooltip on encrypted-disclosure rows now shows the decrypted input/output snippets inline, so the operator no longer has to click into the detail modal to read the parameters. Decrypted snippets are cached in the browser tab only and dropped whenever the forensic key state changes.
+
+### Security
+
+- **CSRF guard on `/api/forensic-key/path`** — the endpoint now requires `Content-Type: application/json`, forcing cross-origin browser POSTs through a CORS preflight rather than letting a hostile page issue a "simple" request that would trigger arbitrary server-side file reads. The existing `POST /api/forensic-key` accepts a raw body for compatibility and is not affected by this change; consider a similar guard there in a follow-up.
 
 ## [0.4.0] - 2026-06-03
 

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -100,6 +100,17 @@ func defaultDBPath() string {
 	return filepath.Join(dh, "agent-receipts", "receipts.db")
 }
 
+// defaultForensicKeyPath returns the conventional path where the daemon writes
+// its X25519 forensic private key. Returns "" if the data home directory cannot
+// be resolved.
+func defaultForensicKeyPath() string {
+	dh := xdgDataHome()
+	if dh == "" {
+		return ""
+	}
+	return filepath.Join(dh, "agent-receipts", "forensic.key")
+}
+
 func main() {
 	if len(os.Args) > 1 {
 		switch os.Args[1] {
@@ -159,10 +170,11 @@ func main() {
 		displayDBPath = abs
 	}
 	srv := server.New(reader, server.Config{
-		PollInterval: *pollInterval,
-		DBPath:       displayDBPath,
-		Version:      resolveVersion(),
-		Host:         *host,
+		PollInterval:    *pollInterval,
+		DBPath:          displayDBPath,
+		Version:         resolveVersion(),
+		Host:            *host,
+		ForensicKeyPath: defaultForensicKeyPath(),
 	})
 	addr := fmt.Sprintf("%s:%d", *host, *port)
 	log.Printf("dashboard listening on http://%s", addr)

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -6,12 +6,15 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/hex"
+	"encoding/json"
 	"encoding/pem"
 	"fmt"
 	"io"
 	"log"
 	"net"
 	"net/http"
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
@@ -100,6 +103,10 @@ type forensicKeyStatus struct {
 	// Available is false when the dashboard is not bound to a loopback address,
 	// in which case loading a key is refused (see forensicAvailable).
 	Available bool `json:"available"`
+	// DefaultPath is the conventional path the server probes at startup for an
+	// X25519 forensic private key. The UI pre-fills its path input with this
+	// value so operators can load the key with a single click.
+	DefaultPath string `json:"default_path,omitempty"`
 }
 
 // disclosureResponse is the JSON returned by the per-receipt disclosure endpoint.
@@ -189,6 +196,7 @@ func (s *Server) handleForensicKeyGet(w http.ResponseWriter, r *http.Request) {
 		Loaded:      loaded,
 		Fingerprint: fp,
 		Available:   s.forensicAvailable(),
+		DefaultPath: s.cfg.ForensicKeyPath,
 	})
 }
 
@@ -229,6 +237,68 @@ func (s *Server) handleForensicKeyLoad(w http.ResponseWriter, r *http.Request) {
 	}
 
 	writeJSON(w, http.StatusOK, forensicKeyStatus{Loaded: true, Fingerprint: fp, Available: true})
+}
+
+// handleForensicKeyLoadPath loads the forensic private key from an absolute
+// path on the server's filesystem. The path is supplied as JSON in the request
+// body and may use a leading ~ for the current user's home directory.
+func (s *Server) handleForensicKeyLoadPath(w http.ResponseWriter, r *http.Request) {
+	if !s.guardForensic(w, r) {
+		return
+	}
+
+	var req struct {
+		Path string `json:"path"`
+	}
+	if err := json.NewDecoder(io.LimitReader(r.Body, 4096)).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	req.Path = strings.TrimSpace(req.Path)
+	if req.Path == "" {
+		writeError(w, http.StatusBadRequest, "path is required")
+		return
+	}
+
+	expanded := expandHomePath(req.Path)
+	data, err := readFileLimited(expanded, maxForensicKeyBody)
+	if err != nil {
+		if isNotExist(err) {
+			writeError(w, http.StatusBadRequest, "key file not found: "+req.Path)
+		} else {
+			writeError(w, http.StatusBadRequest, "could not read key file: "+err.Error())
+		}
+		return
+	}
+	defer zero(data)
+
+	priv, err := parseForensicPrivateKey(data)
+	if err != nil {
+		log.Printf("forensic key load from path rejected: %v", err)
+		writeError(w, http.StatusBadRequest, "invalid forensic key: provide a 32-byte X25519 private key (raw, hex, base64, or PKCS#8 PEM)")
+		return
+	}
+	defer zero(priv)
+
+	fp, err := s.forensic.load(priv)
+	if err != nil {
+		log.Printf("forensic key load from path failed: %v", err)
+		writeError(w, http.StatusBadRequest, "could not derive a forensic key fingerprint from the supplied key")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, forensicKeyStatus{Loaded: true, Fingerprint: fp, Available: true})
+}
+
+// expandHomePath replaces a leading ~ with the current user's home directory.
+func expandHomePath(p string) string {
+	if p == "~" || strings.HasPrefix(p, "~/") || strings.HasPrefix(p, `~\`) {
+		home, err := os.UserHomeDir()
+		if err == nil {
+			return filepath.Join(home, p[1:])
+		}
+	}
+	return p
 }
 
 func (s *Server) handleForensicKeyClear(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"mime"
 	"net"
 	"net/http"
 	"os"
@@ -244,6 +245,17 @@ func (s *Server) handleForensicKeyLoad(w http.ResponseWriter, r *http.Request) {
 // body and may use a leading ~ for the current user's home directory.
 func (s *Server) handleForensicKeyLoadPath(w http.ResponseWriter, r *http.Request) {
 	if !s.guardForensic(w, r) {
+		return
+	}
+
+	// Require Content-Type: application/json so cross-origin browser POSTs
+	// trigger a CORS preflight instead of being treated as "simple" requests.
+	// The existing loopback + Host-header guards block network attackers and
+	// DNS rebinding; this closes the remaining same-browser CSRF gap that
+	// would otherwise let a hostile page drive arbitrary local file reads.
+	ct, _, _ := mime.ParseMediaType(r.Header.Get("Content-Type"))
+	if ct != "application/json" {
+		writeError(w, http.StatusUnsupportedMediaType, "Content-Type must be application/json")
 		return
 	}
 

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -242,7 +242,9 @@ func (s *Server) handleForensicKeyLoad(w http.ResponseWriter, r *http.Request) {
 
 // handleForensicKeyLoadPath loads the forensic private key from an absolute
 // path on the server's filesystem. The path is supplied as JSON in the request
-// body and may use a leading ~ for the current user's home directory.
+// body and may use a leading ~ for the current user's home directory. Relative
+// paths are rejected so a typo like "forensic.key" does not silently resolve
+// against the dashboard's working directory.
 func (s *Server) handleForensicKeyLoadPath(w http.ResponseWriter, r *http.Request) {
 	if !s.guardForensic(w, r) {
 		return
@@ -273,6 +275,10 @@ func (s *Server) handleForensicKeyLoadPath(w http.ResponseWriter, r *http.Reques
 	}
 
 	expanded := expandHomePath(req.Path)
+	if !filepath.IsAbs(expanded) {
+		writeError(w, http.StatusBadRequest, "path must be absolute (or start with ~/)")
+		return
+	}
 	data, err := readFileLimited(expanded, maxForensicKeyBody)
 	if err != nil {
 		if isNotExist(err) {

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -400,12 +401,14 @@ func TestForensicRejectsNonLocalHost(t *testing.T) {
 		r.Host = "evil.example.com" // attacker domain rebound to 127.0.0.1
 		return r
 	}
+	pathBody, _ := json.Marshal(map[string]string{"path": "/some/key"})
 	endpoints := []struct {
 		method, target string
 		body           io.Reader
 	}{
 		{"GET", "/api/forensic-key", nil},
 		{"POST", "/api/forensic-key", bytes.NewReader(priv)},
+		{"POST", "/api/forensic-key/path", bytes.NewReader(pathBody)},
 		{"DELETE", "/api/forensic-key", nil},
 		{"GET", "/api/disclosure/urn:receipt:enc1", nil},
 	}
@@ -424,5 +427,128 @@ func TestForensicRejectsNonLocalHost(t *testing.T) {
 	resp := decodeDisclosure(t, w.Body.Bytes())
 	if resp.State != "decrypted" {
 		t.Fatalf("after rejected rebind requests, state = %q, want decrypted", resp.State)
+	}
+}
+
+func TestForensicKeyLoadPath(t *testing.T) {
+	priv, _, fp := forensicKeyPair(t)
+
+	// Write the raw private key to a temp file.
+	keyFile := t.TempDir() + "/forensic.key"
+	if err := os.WriteFile(keyFile, priv, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	h := srv.Handler()
+
+	body, _ := json.Marshal(map[string]string{"path": keyFile})
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, localReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("load from path: got %d, want 200 (body=%s)", w.Code, w.Body)
+	}
+
+	var st forensicKeyStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !st.Loaded || st.Fingerprint != fp {
+		t.Fatalf("status: loaded=%v fingerprint=%q want loaded=true fingerprint=%q", st.Loaded, st.Fingerprint, fp)
+	}
+}
+
+func TestForensicKeyLoadPathNotFound(t *testing.T) {
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	body, _ := json.Marshal(map[string]string{"path": "/nonexistent/forensic.key"})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", w.Code)
+	}
+}
+
+func TestForensicKeyLoadPathInvalidKey(t *testing.T) {
+	keyFile := t.TempDir() + "/bad.key"
+	if err := os.WriteFile(keyFile, []byte("not a valid key"), 0o600); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	body, _ := json.Marshal(map[string]string{"path": keyFile})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", w.Code)
+	}
+}
+
+func TestForensicKeyLoadPathRejectsNonLocal(t *testing.T) {
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	body, _ := json.Marshal(map[string]string{"path": "/some/key"})
+	r := httptest.NewRequest("POST", "/api/forensic-key/path", bytes.NewReader(body))
+	r.Host = "evil.example.com"
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, r)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403", w.Code)
+	}
+}
+
+func TestForensicKeyLoadPathRejectsNonLoopbackBind(t *testing.T) {
+	srv := seedReceipts(t, Config{Host: "0.0.0.0"})
+	body, _ := json.Marshal(map[string]string{"path": "/some/key"})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403", w.Code)
+	}
+}
+
+func TestForensicStatusIncludesDefaultPath(t *testing.T) {
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyPath: "/some/forensic.key"})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localReq("GET", "/api/forensic-key", nil))
+	var st forensicKeyStatus
+	json.Unmarshal(w.Body.Bytes(), &st)
+	if st.DefaultPath != "/some/forensic.key" {
+		t.Fatalf("default_path = %q, want /some/forensic.key", st.DefaultPath)
+	}
+}
+
+func TestForensicAutoLoadAtStartup(t *testing.T) {
+	priv, _, fp := forensicKeyPair(t)
+
+	keyFile := t.TempDir() + "/forensic.key"
+	if err := os.WriteFile(keyFile, priv, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	// Server with a ForensicKeyPath pointing at our temp file should auto-load.
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyPath: keyFile})
+
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localReq("GET", "/api/forensic-key", nil))
+	var st forensicKeyStatus
+	json.Unmarshal(w.Body.Bytes(), &st)
+	if !st.Loaded || st.Fingerprint != fp {
+		t.Fatalf("auto-load: loaded=%v fingerprint=%q want loaded=true fingerprint=%q", st.Loaded, st.Fingerprint, fp)
+	}
+}
+
+func TestForensicAutoLoadSkipsNonLoopback(t *testing.T) {
+	priv, _, _ := forensicKeyPair(t)
+
+	keyFile := t.TempDir() + "/forensic.key"
+	if err := os.WriteFile(keyFile, priv, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	// A non-loopback bind must not auto-load even when the key file exists.
+	srv := seedReceipts(t, Config{Host: "0.0.0.0", ForensicKeyPath: keyFile})
+
+	loaded, _ := srv.forensic.status()
+	if loaded {
+		t.Fatal("key was auto-loaded on non-loopback bind, should have been skipped")
 	}
 }

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -530,6 +530,18 @@ func TestForensicKeyLoadPathRequiresJSONContentType(t *testing.T) {
 	}
 }
 
+// Relative paths would silently resolve against the dashboard's CWD, so the
+// handler rejects anything that isn't absolute (after ~ expansion).
+func TestForensicKeyLoadPathRejectsRelativePath(t *testing.T) {
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	body, _ := json.Marshal(map[string]string{"path": "forensic.key"})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", w.Code)
+	}
+}
+
 func TestForensicKeyLoadPathRejectsNonLocal(t *testing.T) {
 	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
 	body, _ := json.Marshal(map[string]string{"path": "/some/key"})

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -28,6 +28,14 @@ func localReq(method, target string, body io.Reader) *http.Request {
 	return r
 }
 
+// localJSONReq is like localReq but also sets Content-Type: application/json,
+// matching what /api/forensic-key/path requires of legitimate clients.
+func localJSONReq(method, target string, body io.Reader) *http.Request {
+	r := localReq(method, target, body)
+	r.Header.Set("Content-Type", "application/json")
+	return r
+}
+
 // forensicKeyPair returns a fresh X25519 forensic key pair and its canonical
 // sha256 fingerprint (the value the daemon writes as a recipient kid).
 func forensicKeyPair(t *testing.T) (priv, pub []byte, fingerprint string) {
@@ -444,7 +452,7 @@ func TestForensicKeyLoadPath(t *testing.T) {
 
 	body, _ := json.Marshal(map[string]string{"path": keyFile})
 	w := httptest.NewRecorder()
-	h.ServeHTTP(w, localReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	h.ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
 	if w.Code != http.StatusOK {
 		t.Fatalf("load from path: got %d, want 200 (body=%s)", w.Code, w.Body)
 	}
@@ -462,7 +470,7 @@ func TestForensicKeyLoadPathNotFound(t *testing.T) {
 	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
 	body, _ := json.Marshal(map[string]string{"path": "/nonexistent/forensic.key"})
 	w := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(w, localReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("got %d, want 400", w.Code)
 	}
@@ -477,9 +485,48 @@ func TestForensicKeyLoadPathInvalidKey(t *testing.T) {
 	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
 	body, _ := json.Marshal(map[string]string{"path": keyFile})
 	w := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(w, localReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("got %d, want 400", w.Code)
+	}
+}
+
+// The Content-Type check is the CSRF guard: a cross-origin POST without
+// Content-Type: application/json is "CORS-simple" and would skip preflight,
+// letting a hostile page trigger arbitrary file reads on the loopback API.
+// Reject anything that isn't an explicit application/json content type.
+func TestForensicKeyLoadPathRequiresJSONContentType(t *testing.T) {
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	body := []byte(`{"path":"/some/key"}`)
+
+	cases := []struct {
+		name        string
+		contentType string
+	}{
+		{"missing", ""},
+		{"text/plain", "text/plain"},
+		{"form", "application/x-www-form-urlencoded"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			r := localReq("POST", "/api/forensic-key/path", bytes.NewReader(body))
+			if tc.contentType != "" {
+				r.Header.Set("Content-Type", tc.contentType)
+			}
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, r)
+			if w.Code != http.StatusUnsupportedMediaType {
+				t.Fatalf("Content-Type %q: got %d, want 415", tc.contentType, w.Code)
+			}
+		})
+	}
+
+	// Sanity-check: the helper that adds Content-Type: application/json reaches
+	// the path-validation branch (400) rather than being bounced at 415.
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("with application/json: got %d, want 400 (file not found)", w.Code)
 	}
 }
 
@@ -488,6 +535,7 @@ func TestForensicKeyLoadPathRejectsNonLocal(t *testing.T) {
 	body, _ := json.Marshal(map[string]string{"path": "/some/key"})
 	r := httptest.NewRequest("POST", "/api/forensic-key/path", bytes.NewReader(body))
 	r.Host = "evil.example.com"
+	r.Header.Set("Content-Type", "application/json")
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, r)
 	if w.Code != http.StatusForbidden {
@@ -499,7 +547,7 @@ func TestForensicKeyLoadPathRejectsNonLoopbackBind(t *testing.T) {
 	srv := seedReceipts(t, Config{Host: "0.0.0.0"})
 	body, _ := json.Marshal(map[string]string{"path": "/some/key"})
 	w := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(w, localReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
 	if w.Code != http.StatusForbidden {
 		t.Fatalf("got %d, want 403", w.Code)
 	}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -7,9 +7,12 @@ import (
 	"embed"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
+	"io"
 	"log"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -40,6 +43,11 @@ type Config struct {
 	// forensicAvailable). An empty or all-interfaces bind (""/"0.0.0.0"/"::")
 	// is not loopback and disables forensic operations.
 	Host string
+	// ForensicKeyPath is the default path probed at startup for an X25519
+	// forensic private key. When non-empty and the file exists, the server
+	// loads it automatically so operators with a single-user install do not
+	// need to paste the key into the UI.
+	ForensicKeyPath string
 }
 
 //go:embed static
@@ -53,12 +61,47 @@ type Server struct {
 }
 
 // New creates a new Server backed by the given reader. A zero PollInterval
-// in cfg falls back to DefaultPollInterval.
+// in cfg falls back to DefaultPollInterval. When cfg.ForensicKeyPath names an
+// existing file and the server is bound to loopback, the forensic key is
+// loaded automatically so solo operators need no manual UI step.
 func New(reader *store.Reader, cfg Config) *Server {
 	if cfg.PollInterval <= 0 {
 		cfg.PollInterval = DefaultPollInterval
 	}
-	return &Server{reader: reader, cfg: cfg, forensic: &forensicKeyStore{}}
+	s := &Server{reader: reader, cfg: cfg, forensic: &forensicKeyStore{}}
+	s.tryLoadDefaultForensicKey()
+	return s
+}
+
+// tryLoadDefaultForensicKey probes cfg.ForensicKeyPath at startup and silently
+// loads the key if found. A missing file is a normal condition; any other error
+// or parse failure is logged but never fatal.
+func (s *Server) tryLoadDefaultForensicKey() {
+	if s.cfg.ForensicKeyPath == "" || !s.forensicAvailable() {
+		return
+	}
+	data, err := readFileLimited(s.cfg.ForensicKeyPath, maxForensicKeyBody)
+	if err != nil {
+		if !isNotExist(err) {
+			log.Printf("forensic key: could not read %s: %v", s.cfg.ForensicKeyPath, err)
+		}
+		return
+	}
+	defer zero(data)
+
+	priv, err := parseForensicPrivateKey(data)
+	if err != nil {
+		log.Printf("forensic key: could not parse %s: %v", s.cfg.ForensicKeyPath, err)
+		return
+	}
+	defer zero(priv)
+
+	fp, err := s.forensic.load(priv)
+	if err != nil {
+		log.Printf("forensic key: load failed for %s: %v", s.cfg.ForensicKeyPath, err)
+		return
+	}
+	log.Printf("forensic key loaded from %s (fingerprint %s)", s.cfg.ForensicKeyPath, fp)
 }
 
 // Handler returns the HTTP handler with all routes registered.
@@ -81,6 +124,7 @@ func (s *Server) Handler() http.Handler {
 	// further path segment.
 	mux.HandleFunc("GET /api/forensic-key", s.handleForensicKeyGet)
 	mux.HandleFunc("POST /api/forensic-key", s.handleForensicKeyLoad)
+	mux.HandleFunc("POST /api/forensic-key/path", s.handleForensicKeyLoadPath)
 	mux.HandleFunc("DELETE /api/forensic-key", s.handleForensicKeyClear)
 	mux.HandleFunc("GET /api/disclosure/{id...}", s.handleReceiptDisclosure)
 
@@ -256,6 +300,30 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
 	w.Write(data)
+}
+
+// readFileLimited reads up to limit+1 bytes from path. Returns an error if the
+// file exceeds limit, so callers can reject oversized inputs without reading
+// the whole file into memory first.
+func readFileLimited(path string, limit int64) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	data, err := io.ReadAll(io.LimitReader(f, limit+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(data)) > limit {
+		return nil, fmt.Errorf("file exceeds %d byte limit", limit)
+	}
+	return data, nil
+}
+
+// isNotExist reports whether err is a file-not-found error from the os package.
+func isNotExist(err error) bool {
+	return errors.Is(err, os.ErrNotExist)
 }
 
 func writeJSON(w http.ResponseWriter, status int, v any) {

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1131,29 +1131,60 @@
       return `<button type="button" class="mismatch-indicator" onclick="event.stopPropagation()" aria-label="Status/output mismatch" aria-describedby="${tooltipId}">&#9888;<span class="disclosure-tooltip" id="${tooltipId}" role="tooltip"><span class="label">Status/output mismatch</span><span class="value">Outcome recorded as success, but the disclosed tool output reports isError: true.</span></span></button>`;
     }
 
+    // disclosurePreviewCache holds decrypted input/output snippets keyed by
+    // receipt id, populated by hydrateListDisclosurePreviews after the table
+    // renders. Cleared whenever the forensic key state flips so a cleared key
+    // doesn't leave stale plaintext in tooltips. The cache only persists in
+    // memory for this tab.
+    const disclosurePreviewCache = new Map();
+
     // Renders the parameters_disclosure hover preview marker on rows that
     // carry disclosure data. Click is swallowed so it doesn't double-fire
-    // the row click.
+    // the row click. When the forensic key has decrypted this receipt's
+    // envelope, the cached input/output snippets replace the plaintext-only
+    // preview so the operator does not have to click into the detail modal.
     function disclosureIndicatorHTML(r) {
       if (!r.has_parameters_disclosure) return '';
-      const input  = r.parameters_input_preview  || '';
-      const output = r.parameters_output_preview || '';
-      const parts = [];
-      if (input)  parts.push(`<span class="label">Input</span><span class="value">${escapeHtml(input)}</span>`);
-      if (output) parts.push(`<span class="label">Output</span><span class="value">${escapeHtml(output)}</span>`);
-      const tooltipContent = parts.length > 0
-        ? parts.join('')
-        : '<span class="muted text-xs">Additional disclosure fields present — see detail view</span>';
-      // Sanitize receipt ID for use as DOM id.
       const safeId = r.id.replace(/[^A-Za-z0-9_-]/g, '_');
       const tooltipId = `disclosure-tooltip-${safeId}`;
-      return `<button type="button" class="disclosure-indicator" onclick="event.stopPropagation()" aria-label="View parameters disclosure" aria-describedby="${tooltipId}">&#128203;<span class="disclosure-tooltip" id="${tooltipId}" role="tooltip">${tooltipContent}</span></button>`;
+      return `<button type="button" class="disclosure-indicator" data-receipt-id="${escapeAttr(r.id)}" onclick="event.stopPropagation()" aria-label="View parameters disclosure" aria-describedby="${tooltipId}">&#128203;<span class="disclosure-tooltip" id="${tooltipId}" role="tooltip">${disclosureTooltipInnerHTML(r)}</span></button>`;
+    }
+
+    // disclosureTooltipInnerHTML picks the best available preview source:
+    // a decrypted entry in the cache (when the forensic key is loaded), then
+    // the server-side plaintext preview (for legacy/non-encrypted disclosures),
+    // and finally a generic "see detail view" fallback.
+    function disclosureTooltipInnerHTML(r) {
+      const cached = disclosurePreviewCache.get(r.id);
+      let input  = '', output = '', decrypted = false;
+      if (cached && cached.state === 'decrypted') {
+        input  = cached.input  || '';
+        output = cached.output || '';
+        decrypted = true;
+      } else {
+        input  = r.parameters_input_preview  || '';
+        output = r.parameters_output_preview || '';
+      }
+      const parts = [];
+      if (decrypted) parts.push('<span class="label">🔓 Decrypted</span>');
+      if (input)  parts.push(`<span class="label">Input</span><span class="value">${escapeHtml(input)}</span>`);
+      if (output) parts.push(`<span class="label">Output</span><span class="value">${escapeHtml(output)}</span>`);
+      if (parts.length === (decrypted ? 1 : 0)) {
+        return '<span class="muted text-xs">Additional disclosure fields present — see detail view</span>';
+      }
+      return parts.join('');
     }
 
     function tbodyIdFor(containerId) { return 'tbody-' + containerId; }
 
+    // lastRenderedReceipts records the most recent (receipts, opts) tuple per
+    // container so we can re-render in place after a forensic-key state change
+    // without waiting for the next poll tick or filter change.
+    const lastRenderedReceipts = new Map();
+
     function renderReceiptsTable(receipts, containerId, opts) {
       const container = document.getElementById(containerId);
+      lastRenderedReceipts.set(containerId, { receipts: receipts || [], opts });
       if (!receipts || receipts.length === 0) {
         const filtered = opts && opts.emptyHint;
         container.innerHTML = `
@@ -1190,6 +1221,77 @@
           </div>
         </div>
       `;
+      hydrateListDisclosurePreviews(receipts);
+    }
+
+    // hydrateListDisclosurePreviews fetches /api/disclosure for each visible
+    // row whose disclosure is encrypted (has_parameters_disclosure with no
+    // plaintext preview) and which is not yet in the cache, then patches the
+    // tooltip DOM with the decrypted preview. No-op when the forensic key is
+    // not loaded; the locked rows simply keep their fallback message.
+    async function hydrateListDisclosurePreviews(receipts) {
+      if (!forensicState.loaded || !receipts || receipts.length === 0) return;
+      const todo = receipts.filter(r =>
+        r.has_parameters_disclosure
+        && !r.parameters_input_preview
+        && !r.parameters_output_preview
+        && !disclosurePreviewCache.has(r.id)
+      );
+      if (todo.length === 0) return;
+
+      await Promise.allSettled(todo.map(async r => {
+        try {
+          const resp = await fetchJSON('/api/disclosure/' + encodeURIComponent(r.id));
+          const entry = disclosureCacheEntryFromResponse(resp);
+          if (!entry) return;
+          disclosurePreviewCache.set(r.id, entry);
+          patchDisclosureTooltipFromCache(r);
+        } catch (_) {
+          // Transient errors leave the row with its locked-fallback tooltip;
+          // the next render will retry. Don't poison the cache.
+        }
+      }));
+    }
+
+    // Extract a compact list-preview entry from the disclosure API response.
+    // Returns null for non-decrypted states so the cache only holds usable data.
+    function disclosureCacheEntryFromResponse(resp) {
+      if (!resp || resp.state !== 'decrypted') return null;
+      const p = resp.parameters || {};
+      return {
+        state: 'decrypted',
+        input:  formatDisclosurePreviewValue(p.input),
+        output: formatDisclosurePreviewValue(p.output),
+      };
+    }
+
+    // formatDisclosurePreviewValue mirrors the server's truncation rule for
+    // plaintext previews (ADR-0012, 200 chars) so decrypted rows look like
+    // legacy rows in the tooltip.
+    function formatDisclosurePreviewValue(v) {
+      if (v == null) return '';
+      const s = typeof v === 'string' ? v : JSON.stringify(v);
+      const MAX = 200;
+      return s.length > MAX ? s.slice(0, MAX) + '…' : s;
+    }
+
+    // patchDisclosureTooltipFromCache replaces the tooltip inner HTML for a
+    // single receipt using the current cache state. Safe to call when the
+    // tooltip is not in the DOM (no-ops).
+    function patchDisclosureTooltipFromCache(r) {
+      const safeId = r.id.replace(/[^A-Za-z0-9_-]/g, '_');
+      const tooltip = document.getElementById(`disclosure-tooltip-${safeId}`);
+      if (!tooltip) return;
+      tooltip.innerHTML = disclosureTooltipInnerHTML(r);
+    }
+
+    // rerenderAllReceiptTables re-renders every container that has rendered
+    // receipts since page load. Called when the forensic key state flips so
+    // tooltips reflect the new world without waiting for the next poll.
+    function rerenderAllReceiptTables() {
+      for (const [containerId, snap] of lastRenderedReceipts) {
+        renderReceiptsTable(snap.receipts, containerId, snap.opts);
+      }
     }
 
     // ---------- Chains ----------
@@ -1743,11 +1845,19 @@
     // so funnelling all three through here keeps the client mirror from drifting.
     function applyForensicStatus(st) {
       st = st || {};
+      const wasLoaded = forensicState.loaded;
       forensicState.available = !!st.available;
       forensicState.loaded = !!st.loaded;
       forensicState.fingerprint = st.fingerprint || '';
       if (st.default_path) forensicState.defaultPath = st.default_path;
       renderForensicChip();
+      // Key state flipped: drop any cached plaintext previews and re-render
+      // visible tables so encrypted rows pick up (or lose) their decrypted
+      // preview without waiting for the next poll tick.
+      if (wasLoaded !== forensicState.loaded) {
+        disclosurePreviewCache.clear();
+        rerenderAllReceiptTables();
+      }
     }
 
     async function loadForensicStatus() {

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1736,7 +1736,7 @@
     // happen server-side via /api/forensic-key and /api/disclosure/{id}.
     // available defaults false until the server confirms a loopback bind, so the
     // load form (and any key submission) is never offered before status resolves.
-    const forensicState = { available: false, loaded: false, fingerprint: '' };
+    const forensicState = { available: false, loaded: false, fingerprint: '', defaultPath: '' };
 
     // applyForensicStatus is the single writer of forensicState: every
     // load/clear/status response is the authoritative forensicKeyStatus JSON,
@@ -1746,6 +1746,7 @@
       forensicState.available = !!st.available;
       forensicState.loaded = !!st.loaded;
       forensicState.fingerprint = st.fingerprint || '';
+      if (st.default_path) forensicState.defaultPath = st.default_path;
       renderForensicChip();
     }
 
@@ -1817,11 +1818,22 @@
         return;
       }
 
+      const defaultPath = escapeHtml(forensicState.defaultPath || '');
       body.innerHTML = `
         <p class="text-sm mb-3">Load your X25519 forensic private key to decrypt <code>parameters_disclosure</code> envelopes. The key stays in this dashboard's memory for the session only — it is never persisted or sent elsewhere.</p>
         <div class="space-y-3">
           <div>
-            <label class="muted text-xs" for="forensic-file">Key file (raw 32-byte key from <code>--init-forensic-key</code>)</label>
+            <label class="muted text-xs" for="forensic-path">Key file path</label>
+            <div style="display:flex;gap:0.4rem;align-items:stretch;">
+              <input class="forensic-field" type="text" id="forensic-path" style="flex:1;min-width:0;" value="${defaultPath}" placeholder="~/.local/share/agent-receipts/forensic.key" spellcheck="false" autocomplete="off">
+              <button class="forensic-btn" type="button" onclick="submitForensicKeyPath()" style="white-space:nowrap;flex-shrink:0;">Load from path</button>
+            </div>
+          </div>
+          <div class="muted text-xs" style="display:flex;align-items:center;gap:0.5rem;">
+            <span style="flex:1;border-top:1px solid var(--border);"></span>or<span style="flex:1;border-top:1px solid var(--border);"></span>
+          </div>
+          <div>
+            <label class="muted text-xs" for="forensic-file">Choose file</label>
             <input class="forensic-field" type="file" id="forensic-file">
           </div>
           <div>
@@ -1840,6 +1852,28 @@
       el.hidden = false; el.textContent = msg;
     }
 
+    async function submitForensicKeyPath() {
+      const pathInput = document.getElementById('forensic-path');
+      const path = ((pathInput && pathInput.value) || '').trim();
+      forensicError('');
+      if (!path) { forensicError('Enter a file path.'); return; }
+
+      try {
+        const res = await fetch('/api/forensic-key/path', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ path }),
+        });
+        const data = await res.json().catch(() => ({}));
+        if (!res.ok) { forensicError(data.error || ('HTTP ' + res.status)); return; }
+        applyForensicStatus(data);
+        renderForensicModalBody();
+        refreshOpenReceiptDisclosure();
+      } catch (err) {
+        forensicError(err.message || String(err));
+      }
+    }
+
     async function submitForensicKey() {
       const fileInput = document.getElementById('forensic-file');
       const textInput = document.getElementById('forensic-text');
@@ -1851,7 +1885,7 @@
         body = await file.arrayBuffer();
       } else {
         const text = ((textInput && textInput.value) || '').trim();
-        if (!text) { forensicError('Choose a key file or paste a key.'); return; }
+        if (!text) { forensicError('Choose a file or paste a key.'); return; }
         body = text;
       }
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1224,6 +1224,12 @@
       hydrateListDisclosurePreviews(receipts);
     }
 
+    // disclosureHydrationConcurrency caps how many /api/disclosure requests
+    // are in flight at once. Browsers already bottleneck at ~6 concurrent
+    // connections per origin, but each request triggers a server-side HPKE
+    // decrypt, so we keep the burst small to avoid CPU spikes on long lists.
+    const disclosureHydrationConcurrency = 4;
+
     // hydrateListDisclosurePreviews fetches /api/disclosure for each visible
     // row whose disclosure is encrypted (has_parameters_disclosure with no
     // plaintext preview) and which is not yet in the cache, then patches the
@@ -1239,7 +1245,7 @@
       );
       if (todo.length === 0) return;
 
-      await Promise.allSettled(todo.map(async r => {
+      const fetchOne = async r => {
         try {
           const resp = await fetchJSON('/api/disclosure/' + encodeURIComponent(r.id));
           const entry = disclosureCacheEntryFromResponse(resp);
@@ -1250,7 +1256,12 @@
           // Transient errors leave the row with its locked-fallback tooltip;
           // the next render will retry. Don't poison the cache.
         }
-      }));
+      };
+
+      for (let i = 0; i < todo.length; i += disclosureHydrationConcurrency) {
+        const batch = todo.slice(i, i + disclosureHydrationConcurrency);
+        await Promise.allSettled(batch.map(fetchOne));
+      }
     }
 
     // Extract a compact list-preview entry from the disclosure API response.
@@ -1275,14 +1286,18 @@
       return s.length > MAX ? s.slice(0, MAX) + '…' : s;
     }
 
-    // patchDisclosureTooltipFromCache replaces the tooltip inner HTML for a
-    // single receipt using the current cache state. Safe to call when the
-    // tooltip is not in the DOM (no-ops).
+    // patchDisclosureTooltipFromCache replaces the tooltip inner HTML for
+    // every visible row matching the receipt id. The same receipt can appear
+    // in multiple containers (e.g. recent-receipts and receipts-table), which
+    // produces duplicate DOM ids — so iterate the indicator buttons by data
+    // attribute and patch each child tooltip rather than relying on
+    // getElementById, which would only update the first match.
     function patchDisclosureTooltipFromCache(r) {
-      const safeId = r.id.replace(/[^A-Za-z0-9_-]/g, '_');
-      const tooltip = document.getElementById(`disclosure-tooltip-${safeId}`);
-      if (!tooltip) return;
-      tooltip.innerHTML = disclosureTooltipInnerHTML(r);
+      document.querySelectorAll('.disclosure-indicator').forEach(btn => {
+        if (btn.dataset.receiptId !== r.id) return;
+        const tooltip = btn.querySelector('.disclosure-tooltip');
+        if (tooltip) tooltip.innerHTML = disclosureTooltipInnerHTML(r);
+      });
     }
 
     // rerenderAllReceiptTables re-renders every container that has rendered


### PR DESCRIPTION
## Summary

- Adds a **file-path text input** to the forensic key modal, pre-filled with the XDG default (`~/.local/share/agent-receipts/forensic.key`). Operators can type or paste any path; leading `~` is expanded server-side.
- New `POST /api/forensic-key/path` endpoint reads the file server-side, applying all existing loopback and DNS-rebinding guards, and returns the same `forensicKeyStatus` JSON as the existing load endpoint.
- At startup, when the server is bound to loopback and the default key file exists, it is loaded **automatically** — a standard single-user install needs no UI interaction at all.
- `GET /api/forensic-key` now includes `default_path` in its response so the UI always pre-fills the correct path regardless of platform or `$XDG_DATA_HOME` override.

## Test plan

- [ ] `go test ./...` passes (8 new tests cover path loading, not-found, invalid key, non-local host rejection, non-loopback bind rejection, default path in status response, auto-load at startup, auto-load skipped on non-loopback bind)
- [ ] `go vet ./...` clean
- [ ] Open the modal on a default install: path input pre-filled with default path, "Load from path" loads the key
- [ ] Edit the path to a non-existent file: helpful "key file not found" error
- [ ] If `forensic.key` is present at startup: chip shows 🔓 immediately on page load