### PR TITLE
docs: Mark ADR 0001 as superseded by issue #38

### DIFF
--- a/docs/adr/0001-wails-desktop-wrapper.md
+++ b/docs/adr/0001-wails-desktop-wrapper.md
@@ -1,7 +1,8 @@
 # ADR 0001: Wails as Desktop Wrapper
 
-**Status:** Accepted  
-**Date:** 2026-04-24
+**Status:** Superseded  
+**Date:** 2026-04-24  
+**Superseded:** 2026-06-05 — see [issue #38](https://github.com/agent-receipts/dashboard/issues/38)
 
 ## Context
 


### PR DESCRIPTION
## What

Updated ADR 0001 (Wails as Desktop Wrapper) to mark its status as "Superseded" and added a reference to the superseding decision with a link to issue #38.

## Why

This ADR is no longer the current decision for the desktop wrapper approach. Marking it as superseded with a clear reference to the replacement decision improves documentation clarity and helps future developers understand the decision history.

## Checklist

- [ ] `go test ./...` passes
- [ ] `go vet ./...` passes
- [ ] No real keys or secrets in the diff
- [ ] New functionality includes tests
- [ ] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] AGENTS.md updated if project structure changed
- [ ] Request a Copilot review for automated checks