### PR TITLE
feat: add top actions by failure rate table and endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Top actions by failure rate** — a new `GET /api/stats/actions` endpoint returns per-action-type failure statistics (total, success, failure counts, and failure rate), filtered to action types with at least 5 receipts. An optional `range` query parameter (Go duration string, e.g. `24h`) restricts the window. Results are sorted by failure rate descending. A new **Actions** tab renders the full sortable table with clickable column headers and a "Show all" toggle; clicking a row pre-filters the Receipts view to that action type's failures. The Overview tab gains a new "Top actions by failure rate" summary card showing the top 5 action types as horizontal bars, with a "View all →" link to the Actions tab.
+
 ## [0.5.1] - 2026-06-03
 
 ### Fixed

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -112,6 +112,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/health", s.handleHealth)
 	mux.HandleFunc("GET /api/config", s.handleConfig)
 	mux.HandleFunc("GET /api/stats", s.handleStats)
+	mux.HandleFunc("GET /api/stats/actions", s.handleActionStats)
 	mux.HandleFunc("GET /api/receipts", s.handleReceipts)
 	mux.HandleFunc("GET /api/receipts/{id...}", s.handleReceiptDetail)
 	mux.HandleFunc("GET /api/chains", s.handleChains)
@@ -165,6 +166,32 @@ func (s *Server) handleStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	writeJSON(w, http.StatusOK, stats)
+}
+
+func (s *Server) handleActionStats(w http.ResponseWriter, r *http.Request) {
+	var since *string
+	if rangeStr := r.URL.Query().Get("range"); rangeStr != "" {
+		d, err := time.ParseDuration(rangeStr)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "range must be a valid Go duration (e.g. 24h, 7d)")
+			return
+		}
+		t := time.Now().UTC().Add(-d).Format(time.RFC3339)
+		since = &t
+	}
+
+	stats, err := s.reader.ActionStats(since)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "action stats query failed")
+		log.Printf("action stats error: %v", err)
+		return
+	}
+
+	// Return an empty slice rather than null in JSON.
+	if stats == nil {
+		stats = []store.ActionStat{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"actions": stats})
 }
 
 func (s *Server) handleReceipts(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -172,8 +172,8 @@ func (s *Server) handleActionStats(w http.ResponseWriter, r *http.Request) {
 	var since *string
 	if rangeStr := r.URL.Query().Get("range"); rangeStr != "" {
 		d, err := time.ParseDuration(rangeStr)
-		if err != nil {
-			writeError(w, http.StatusBadRequest, "range must be a valid Go duration (e.g. 24h, 7d)")
+		if err != nil || d <= 0 {
+			writeError(w, http.StatusBadRequest, "range must be a positive Go duration (e.g. 24h)")
 			return
 		}
 		t := time.Now().UTC().Add(-d).Format(time.RFC3339)

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -2,6 +2,7 @@ package server
 
 import (
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -465,6 +466,148 @@ func TestChainVerifyEndpoint_EmptyChain(t *testing.T) {
 	}
 	if result.Length != 0 {
 		t.Errorf("got length %d, want 0", result.Length)
+	}
+}
+
+func TestActionStatsEndpoint(t *testing.T) {
+	// seedTestDB seeds 3 receipts: filesystem.file.read (success), filesystem.file.modify
+	// (success), communication.email.send (failure). None of these action types has >= 5
+	// receipts, so the endpoint should return an empty actions list.
+	srv := setupServer(t)
+
+	t.Run("200 with empty actions (all types below minimum threshold)", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/stats/actions", nil)
+		w := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Fatalf("got status %d, want 200", w.Code)
+		}
+
+		var resp struct {
+			Actions []store.ActionStat `json:"actions"`
+		}
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		// All 3 action types have only 1 receipt each — all excluded by HAVING >= 5.
+		if resp.Actions == nil {
+			t.Error("actions must be [] not null")
+		}
+		if len(resp.Actions) != 0 {
+			t.Errorf("got %d actions, want 0 (all below 5-receipt threshold)", len(resp.Actions))
+		}
+	})
+
+	t.Run("400 on invalid range param", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/stats/actions?range=notaduration", nil)
+		w := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("got status %d, want 400", w.Code)
+		}
+
+		var resp map[string]string
+		if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+			t.Fatalf("decode error body: %v", err)
+		}
+		if resp["error"] == "" {
+			t.Error("expected error message in response body")
+		}
+	})
+
+	t.Run("200 with valid range param", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/api/stats/actions?range=24h", nil)
+		w := httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+
+		if w.Code != http.StatusOK {
+			t.Errorf("got status %d, want 200", w.Code)
+		}
+	})
+}
+
+func TestActionStatsEndpoint_WithSufficientData(t *testing.T) {
+	// Seed a database with enough receipts (>=5) for one action type so that the
+	// endpoint returns populated action stats.
+	dbPath := t.TempDir() + "/action-stats-server-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	// Insert 5 receipts for "cmd.exec" (3 failure, 2 success) and 2 for "file.read"
+	// (below threshold).
+	for i := 0; i < 3; i++ {
+		r := makeReceipt(
+			fmt.Sprintf("urn:receipt:exec-fail-%d", i), "chain-cmd", i+1,
+			"cmd.exec", receipt.RiskHigh, receipt.StatusFailure,
+			fmt.Sprintf("2026-05-01T10:%02d:00Z", i), nil,
+		)
+		h, _ := receipt.HashReceipt(r)
+		if err := s.Insert(r, h); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		r := makeReceipt(
+			fmt.Sprintf("urn:receipt:exec-ok-%d", i), "chain-cmd", i+4,
+			"cmd.exec", receipt.RiskHigh, receipt.StatusSuccess,
+			fmt.Sprintf("2026-05-01T11:%02d:00Z", i), nil,
+		)
+		h, _ := receipt.HashReceipt(r)
+		if err := s.Insert(r, h); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	for i := 0; i < 2; i++ {
+		r := makeReceipt(
+			fmt.Sprintf("urn:receipt:file-%d", i), "chain-file", i+1,
+			"file.read", receipt.RiskLow, receipt.StatusSuccess,
+			fmt.Sprintf("2026-05-01T12:%02d:00Z", i), nil,
+		)
+		h, _ := receipt.HashReceipt(r)
+		if err := s.Insert(r, h); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	s.Close()
+
+	reader, err := store.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { reader.Close() })
+	srv := New(reader, Config{})
+
+	req := httptest.NewRequest("GET", "/api/stats/actions", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200", w.Code)
+	}
+
+	var resp struct {
+		Actions []store.ActionStat `json:"actions"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Only cmd.exec (5 receipts) must appear; file.read (2) must be excluded.
+	if len(resp.Actions) != 1 {
+		t.Fatalf("got %d actions, want 1", len(resp.Actions))
+	}
+	if resp.Actions[0].ActionType != "cmd.exec" {
+		t.Errorf("got action_type %q, want cmd.exec", resp.Actions[0].ActionType)
+	}
+	if resp.Actions[0].Total != 5 {
+		t.Errorf("got total %d, want 5", resp.Actions[0].Total)
+	}
+	if resp.Actions[0].Failure != 3 {
+		t.Errorf("got failure %d, want 3", resp.Actions[0].Failure)
 	}
 }
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1063,6 +1063,9 @@
         actionsSortAsc = false;
         actionsShowAll = false;
         renderActionsTable();
+        // Wire keyboard row navigation (j/k/Enter) for the Actions table,
+        // mirroring the receipts/chains views.
+        nav.setSelector('#actions-table-container tbody tr');
       } catch (err) {
         showError('Failed to load actions: ' + err.message);
         document.getElementById('actions-table-container').innerHTML =
@@ -1105,6 +1108,7 @@
             <div class="empty-title">No action data</div>
             <div class="empty-hint">Action types appear here once they have at least 5 receipts.</div>
           </div>`;
+        nav.refresh();
         return;
       }
 
@@ -1157,6 +1161,9 @@
           </div>
           ${showAllToggle}
         </div>`;
+      // Re-renders (sort / show-all) replace the table DOM, so refresh the
+      // keyboard-nav row list to keep j/k/Enter targeting the current rows.
+      nav.refresh();
     }
 
     function toggleActionsSort(key) {

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1015,8 +1015,8 @@
     }
 
     // Render up to 5 action types as horizontal bars in the Overview summary card.
-    // Bar width is proportional to failure_rate (0–100%). Row click navigates to
-    // the Actions tab, mirroring the "View all →" button.
+    // failure_rate is a 0–1 ratio; the bar width and label render it as a percent.
+    // Each row navigates to the Actions tab (mouse + keyboard), mirroring "View all →".
     function renderTopActionsChart(actions) {
       const el = document.getElementById('top-actions-chart');
       if (!el) return;
@@ -1025,13 +1025,15 @@
         el.innerHTML = '<div class="muted text-sm">No data — action types with fewer than 5 receipts are excluded.</div>';
         return;
       }
-      el.innerHTML = top5.map(a => `
-        <div class="bar-row" style="cursor:pointer;" onclick="showView('actions')" title="${escapeAttr(a.action_type)} — ${a.failure_rate.toFixed(1)}% failure rate">
+      el.innerHTML = top5.map(a => {
+        const pct = (a.failure_rate * 100);
+        return `
+        <div class="bar-row" style="cursor:pointer;" role="button" tabindex="0" onclick="showView('actions')" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();showView('actions')}" title="${escapeAttr(a.action_type)} — ${pct.toFixed(1)}% failure rate" aria-label="${escapeAttr(a.action_type)}, ${pct.toFixed(1)}% failure rate. View all actions.">
           <span class="bar-label" style="width:160px;min-width:160px;" title="${escapeAttr(a.action_type)}"><span class="badge badge-failure" style="max-width:156px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:inline-block;vertical-align:middle;">${escapeHtml(a.action_type)}</span></span>
-          <div class="bar-track"><div class="bar-fill bar-failure" style="width:${Math.min(a.failure_rate, 100)}%"></div></div>
-          <span class="bar-count">${a.failure_rate.toFixed(1)}%</span>
-        </div>
-      `).join('');
+          <div class="bar-track"><div class="bar-fill bar-failure" style="width:${Math.min(pct, 100)}%"></div></div>
+          <span class="bar-count">${pct.toFixed(1)}%</span>
+        </div>`;
+      }).join('');
     }
 
     // ---------- Actions tab ----------
@@ -1118,14 +1120,17 @@
       function thHTML(key, label) {
         const active = actionsSortKey === key;
         const arrow = active ? (actionsSortAsc ? ' ↑' : ' ↓') : '';
-        return `<th style="cursor:pointer;user-select:none;" onclick="toggleActionsSort('${key}')">${escapeHtml(label)}${arrow}</th>`;
+        const ariaSort = active ? (actionsSortAsc ? 'ascending' : 'descending') : 'none';
+        // Sort control is a real <button> so it is keyboard-focusable and
+        // operable with Enter/Space, not just mouse click on the <th>.
+        return `<th style="user-select:none;" aria-sort="${ariaSort}"><button type="button" onclick="toggleActionsSort('${key}')" style="background:none;border:none;color:inherit;font:inherit;cursor:pointer;padding:0;">${escapeHtml(label)}${arrow}</button></th>`;
       }
 
       const rows = visible.map(a => {
-        const pct = Math.min(a.failure_rate, 100);
+        const pct = Math.min(a.failure_rate * 100, 100); // failure_rate is a 0–1 ratio
         const rateBar = `<div style="display:inline-flex;align-items:center;gap:8px;width:100%;">
           <div class="bar-track" style="flex:1;"><div class="bar-fill bar-failure" style="width:${pct}%"></div></div>
-          <span style="width:40px;text-align:right;font-size:0.8rem;color:var(--muted);font-variant-numeric:tabular-nums;">${a.failure_rate.toFixed(1)}%</span>
+          <span style="width:40px;text-align:right;font-size:0.8rem;color:var(--muted);font-variant-numeric:tabular-nums;">${(a.failure_rate * 100).toFixed(1)}%</span>
         </div>`;
         return `
           <tr style="cursor:pointer;" data-action="${escapeAttr(a.action_type)}" onclick="filterToActionFailures(this.dataset.action)" title="Click to view failure receipts for ${escapeAttr(a.action_type)}">

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -585,6 +585,7 @@
     <nav class="tab-bar">
       <button class="tab active" onclick="showView('overview')" id="tab-overview">Overview</button>
       <button class="tab" onclick="showView('receipts')" id="tab-receipts">Receipts</button>
+      <button class="tab" onclick="showView('actions')" id="tab-actions">Actions</button>
       <button class="tab" onclick="showView('chains')" id="tab-chains">Chains</button>
     </nav>
   </header>
@@ -615,6 +616,14 @@
           <h3 class="text-sm font-medium muted mb-3">Action distribution</h3>
           <div id="action-chart" class="space-y-2"></div>
         </div>
+      </div>
+
+      <div class="card p-4 mb-6">
+        <div class="flex items-center justify-between mb-3">
+          <h3 class="text-sm font-medium muted">Top actions by failure rate</h3>
+          <button class="text-xs accent" onclick="showView('actions')" style="background:none;border:none;cursor:pointer;">View all →</button>
+        </div>
+        <div id="top-actions-chart"></div>
       </div>
 
       <div class="card p-4">
@@ -664,6 +673,11 @@
       </div>
 
       <div id="receipts-table"></div>
+    </div>
+
+    <!-- Actions view -->
+    <div id="view-actions" class="hidden">
+      <div id="actions-table-container"></div>
     </div>
 
     <!-- Chains view -->
@@ -825,7 +839,8 @@
       stopPolling();
       if (view === 'overview') loadOverview();
       if (view === 'receipts') loadReceipts();
-      if (view === 'chains') loadChains();
+      if (view === 'actions')  loadActions();
+      if (view === 'chains')   loadChains();
     }
 
     // ---------- Header context ----------
@@ -857,6 +872,7 @@
       const gen = ++poller.generation;
       renderStatsSkeleton();
       renderRecentSkeleton();
+      renderTopActionsSkeleton();
       try {
         const stats = await fetchJSON('/api/stats');
         if (gen !== poller.generation) return;
@@ -872,6 +888,18 @@
         // Wire keyboard nav after startPolling so the j/k/Enter row list is
         // initialised even though stopPolling() cleared activeView above.
         nav.setSelector('#recent-receipts tbody tr');
+
+        // The summary card is non-essential: load it after core overview is
+        // wired and isolate failures so a stats/actions error can't take down
+        // recent-receipts polling or keyboard nav.
+        try {
+          const actionData = await fetchJSON('/api/stats/actions');
+          if (gen !== poller.generation) return;
+          renderTopActionsChart(actionData.actions || []);
+        } catch (err) {
+          console.warn('top actions summary:', err);
+          renderTopActionsChart([]);
+        }
       } catch (err) {
         showError('Failed to load overview: ' + err.message);
       }
@@ -986,6 +1014,169 @@
       showView('receipts');
     }
 
+    // Render up to 5 action types as horizontal bars in the Overview summary card.
+    // Bar width is proportional to failure_rate (0–100%). Row click navigates to
+    // the Actions tab, mirroring the "View all →" button.
+    function renderTopActionsChart(actions) {
+      const el = document.getElementById('top-actions-chart');
+      if (!el) return;
+      const top5 = (actions || []).slice(0, 5);
+      if (top5.length === 0) {
+        el.innerHTML = '<div class="muted text-sm">No data — action types with fewer than 5 receipts are excluded.</div>';
+        return;
+      }
+      el.innerHTML = top5.map(a => `
+        <div class="bar-row" style="cursor:pointer;" onclick="showView('actions')" title="${escapeAttr(a.action_type)} — ${a.failure_rate.toFixed(1)}% failure rate">
+          <span class="bar-label" style="width:160px;min-width:160px;" title="${escapeAttr(a.action_type)}"><span class="badge badge-failure" style="max-width:156px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;display:inline-block;vertical-align:middle;">${escapeHtml(a.action_type)}</span></span>
+          <div class="bar-track"><div class="bar-fill bar-failure" style="width:${Math.min(a.failure_rate, 100)}%"></div></div>
+          <span class="bar-count">${a.failure_rate.toFixed(1)}%</span>
+        </div>
+      `).join('');
+    }
+
+    // ---------- Actions tab ----------
+    // Client-side sort state for the Actions table.
+    let actionsData = [];
+    let actionsSortKey = 'failure_rate';
+    let actionsSortAsc = false; // default: failure_rate DESC
+    let actionsShowAll = false;
+    const ACTIONS_PAGE_SIZE = 10;
+
+    async function loadActions() {
+      const gen = ++poller.generation;
+      document.getElementById('actions-table-container').innerHTML = `
+        <div class="receipts-table-wrap">
+          <div class="receipts-table-scroll">
+            <table class="receipts">
+              <thead><tr>
+                <th>Action type</th><th>Total</th><th>Failures</th><th>Failure rate</th>
+              </tr></thead>
+              <tbody>${skeletonActionRows(6)}</tbody>
+            </table>
+          </div>
+        </div>`;
+      try {
+        const data = await fetchJSON('/api/stats/actions');
+        if (gen !== poller.generation) return;
+        actionsData = data.actions || [];
+        actionsSortKey = 'failure_rate';
+        actionsSortAsc = false;
+        actionsShowAll = false;
+        renderActionsTable();
+      } catch (err) {
+        showError('Failed to load actions: ' + err.message);
+        document.getElementById('actions-table-container').innerHTML =
+          '<div class="empty-state"><div class="empty-title">Could not load actions</div><div class="empty-hint">' + escapeHtml(err.message) + '</div></div>';
+      }
+    }
+
+    function skeletonActionRows(n) {
+      return Array(n).fill(0).map(() => `
+        <tr>
+          <td style="padding:8px 12px;"><span class="skeleton skeleton-line" style="width:70%"></span></td>
+          <td style="padding:8px 12px;"><span class="skeleton skeleton-line" style="width:40%"></span></td>
+          <td style="padding:8px 12px;"><span class="skeleton skeleton-line" style="width:40%"></span></td>
+          <td style="padding:8px 12px;"><span class="skeleton" style="width:80px;height:8px;border-radius:9999px;display:inline-block;"></span></td>
+        </tr>
+      `).join('');
+    }
+
+    function sortedActions() {
+      const copy = actionsData.slice();
+      copy.sort((a, b) => {
+        let va = a[actionsSortKey], vb = b[actionsSortKey];
+        if (typeof va === 'string') va = va.toLowerCase();
+        if (typeof vb === 'string') vb = vb.toLowerCase();
+        if (va < vb) return actionsSortAsc ? -1 : 1;
+        if (va > vb) return actionsSortAsc ? 1 : -1;
+        return 0;
+      });
+      return copy;
+    }
+
+    function renderActionsTable() {
+      const container = document.getElementById('actions-table-container');
+      if (!container) return;
+
+      const sorted = sortedActions();
+      if (sorted.length === 0) {
+        container.innerHTML = `
+          <div class="empty-state">
+            <div class="empty-title">No action data</div>
+            <div class="empty-hint">Action types appear here once they have at least 5 receipts.</div>
+          </div>`;
+        return;
+      }
+
+      const visible = actionsShowAll ? sorted : sorted.slice(0, ACTIONS_PAGE_SIZE);
+      const hiddenCount = sorted.length - visible.length;
+
+      function thHTML(key, label) {
+        const active = actionsSortKey === key;
+        const arrow = active ? (actionsSortAsc ? ' ↑' : ' ↓') : '';
+        return `<th style="cursor:pointer;user-select:none;" onclick="toggleActionsSort('${key}')">${escapeHtml(label)}${arrow}</th>`;
+      }
+
+      const rows = visible.map(a => {
+        const pct = Math.min(a.failure_rate, 100);
+        const rateBar = `<div style="display:inline-flex;align-items:center;gap:8px;width:100%;">
+          <div class="bar-track" style="flex:1;"><div class="bar-fill bar-failure" style="width:${pct}%"></div></div>
+          <span style="width:40px;text-align:right;font-size:0.8rem;color:var(--muted);font-variant-numeric:tabular-nums;">${a.failure_rate.toFixed(1)}%</span>
+        </div>`;
+        return `
+          <tr style="cursor:pointer;" data-action="${escapeAttr(a.action_type)}" onclick="filterToActionFailures(this.dataset.action)" title="Click to view failure receipts for ${escapeAttr(a.action_type)}">
+            <td class="font-mono text-xs">${escapeHtml(a.action_type)}</td>
+            <td class="muted" style="font-variant-numeric:tabular-nums;">${a.total}</td>
+            <td class="muted" style="font-variant-numeric:tabular-nums;">${a.failure}</td>
+            <td style="min-width:160px;">${rateBar}</td>
+          </tr>`;
+      }).join('');
+
+      const showAllToggle = hiddenCount > 0
+        ? `<div style="padding:10px 12px;text-align:center;border-top:1px solid var(--border);">
+            <button type="button" class="chip-clear-all" onclick="actionsShowAll=true;renderActionsTable()">Show all ${sorted.length} action types</button>
+          </div>`
+        : (actionsShowAll && sorted.length > ACTIONS_PAGE_SIZE
+            ? `<div style="padding:10px 12px;text-align:center;border-top:1px solid var(--border);">
+                <button type="button" class="chip-clear-all" onclick="actionsShowAll=false;renderActionsTable()">Show fewer</button>
+              </div>`
+            : '');
+
+      container.innerHTML = `
+        <div class="receipts-table-wrap">
+          <div class="receipts-table-scroll">
+            <table class="receipts">
+              <thead><tr>
+                ${thHTML('action_type','Action type')}
+                ${thHTML('total','Total')}
+                ${thHTML('failure','Failures')}
+                ${thHTML('failure_rate','Failure rate')}
+              </tr></thead>
+              <tbody>${rows}</tbody>
+            </table>
+          </div>
+          ${showAllToggle}
+        </div>`;
+    }
+
+    function toggleActionsSort(key) {
+      if (actionsSortKey === key) {
+        actionsSortAsc = !actionsSortAsc;
+      } else {
+        actionsSortKey = key;
+        // Default direction: numeric desc, alpha asc.
+        actionsSortAsc = (key === 'action_type');
+      }
+      renderActionsTable();
+    }
+
+    // Row click: pre-fill action type + status=failure filter and jump to Receipts.
+    function filterToActionFailures(actionType) {
+      document.getElementById('filter-action').value = actionType;
+      document.getElementById('filter-status').value = 'failure';
+      showView('receipts');
+    }
+
     function renderStatsSkeleton() {
       document.getElementById('stats-cards').innerHTML = Array(4).fill(0).map(() => `
         <div class="card stat-card">
@@ -1001,6 +1192,11 @@
 
     function renderRecentSkeleton() {
       document.getElementById('recent-receipts').innerHTML = skeletonRows(6);
+    }
+
+    function renderTopActionsSkeleton() {
+      const el = document.getElementById('top-actions-chart');
+      if (el) el.innerHTML = skeletonBars(3);
     }
 
     function skeletonBars(n) {

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -370,10 +370,12 @@ func (r *Reader) Stats() (Stats, error) {
 
 // ActionStat holds aggregate statistics for a single action type.
 type ActionStat struct {
-	ActionType  string  `json:"action_type"`
-	Total       int     `json:"total"`
-	Success     int     `json:"success"`
-	Failure     int     `json:"failure"`
+	ActionType string `json:"action_type"`
+	Total      int    `json:"total"`
+	Success    int    `json:"success"`
+	Failure    int    `json:"failure"`
+	// FailureRate is the fraction of receipts that failed, in [0,1] (e.g. 0.05
+	// is 5%). Matches the ratio convention used by ServerStats.
 	FailureRate float64 `json:"failure_rate"`
 }
 
@@ -420,7 +422,7 @@ func (r *Reader) ActionStats(since *string) ([]ActionStat, error) {
 			return nil, err
 		}
 		if s.Total > 0 {
-			s.FailureRate = float64(s.Failure) / float64(s.Total) * 100
+			s.FailureRate = float64(s.Failure) / float64(s.Total)
 		}
 		out = append(out, s)
 	}

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -365,6 +366,80 @@ func (r *Reader) Stats() (Stats, error) {
 	}
 
 	return st, nil
+}
+
+// ActionStat holds aggregate statistics for a single action type.
+type ActionStat struct {
+	ActionType  string  `json:"action_type"`
+	Total       int     `json:"total"`
+	Success     int     `json:"success"`
+	Failure     int     `json:"failure"`
+	FailureRate float64 `json:"failure_rate"`
+}
+
+// ActionStats returns per-action-type failure rate statistics. Action types
+// with fewer than 5 receipts are excluded (HAVING COUNT(*) >= 5). Results are
+// sorted by failure_rate DESC, then total DESC, then action_type ASC for a
+// deterministic ordering. An optional since timestamp (ISO-8601, inclusive)
+// restricts the query to receipts at or after that time; nil means all-time.
+func (r *Reader) ActionStats(since *string) ([]ActionStat, error) {
+	var conds []string
+	var args []any
+
+	if since != nil {
+		conds = append(conds, "timestamp >= ?")
+		args = append(args, *since)
+	}
+
+	where := ""
+	if len(conds) > 0 {
+		where = "WHERE " + strings.Join(conds, " AND ")
+	}
+
+	query := fmt.Sprintf(`
+		SELECT action_type,
+		       COUNT(*) AS total,
+		       SUM(CASE WHEN status = 'success' THEN 1 ELSE 0 END) AS success_count,
+		       SUM(CASE WHEN status = 'failure' THEN 1 ELSE 0 END) AS failure_count
+		FROM receipts
+		%s
+		GROUP BY action_type
+		HAVING COUNT(*) >= 5
+	`, where)
+
+	rows, err := r.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var out []ActionStat
+	for rows.Next() {
+		var s ActionStat
+		if err := rows.Scan(&s.ActionType, &s.Total, &s.Success, &s.Failure); err != nil {
+			return nil, err
+		}
+		if s.Total > 0 {
+			s.FailureRate = float64(s.Failure) / float64(s.Total) * 100
+		}
+		out = append(out, s)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Sort: failure_rate DESC, total DESC, action_type ASC (deterministic).
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].FailureRate != out[j].FailureRate {
+			return out[i].FailureRate > out[j].FailureRate
+		}
+		if out[i].Total != out[j].Total {
+			return out[i].Total > out[j].Total
+		}
+		return out[i].ActionType < out[j].ActionType
+	})
+
+	return out, nil
 }
 
 // Close closes the database connection.

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -916,8 +916,8 @@ func TestActionStats(t *testing.T) {
 	if first.Success != 2 {
 		t.Errorf("cmd.exec success: got %d, want 2", first.Success)
 	}
-	wantRate := 4.0 / 6.0 * 100
-	if first.FailureRate < wantRate-0.001 || first.FailureRate > wantRate+0.001 {
+	wantRate := 4.0 / 6.0 // failure_rate is a 0–1 ratio
+	if first.FailureRate < wantRate-0.0001 || first.FailureRate > wantRate+0.0001 {
 		t.Errorf("cmd.exec failure_rate: got %.4f, want %.4f", first.FailureRate, wantRate)
 	}
 

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"fmt"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -817,6 +818,140 @@ func seedEmptyDB(t *testing.T) string {
 	}
 	s.Close()
 	return dbPath
+}
+
+func TestActionStats(t *testing.T) {
+	// Seed: three action types —
+	//   "cmd.exec":    6 receipts (4 failure, 2 success) → 66.7% failure rate
+	//   "file.read":   5 receipts (0 failure, 5 success) → 0% failure rate, all-success
+	//   "tiny.action": 3 receipts (3 failure)            → excluded (< 5)
+	dbPath := t.TempDir() + "/action-stats-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	var recs []receipt.AgentReceipt
+
+	// "cmd.exec": 4 failures + 2 successes (6 total)
+	for i := range 4 {
+		ts := fmt.Sprintf("2026-05-01T10:%02d:00Z", i)
+		recs = append(recs, makeReceipt(
+			fmt.Sprintf("urn:receipt:cmd-fail-%d", i), "chain-cmd", i+1,
+			"cmd.exec", receipt.RiskHigh, receipt.StatusFailure, ts, nil,
+		))
+	}
+	for i := range 2 {
+		ts := fmt.Sprintf("2026-05-01T11:%02d:00Z", i)
+		recs = append(recs, makeReceipt(
+			fmt.Sprintf("urn:receipt:cmd-ok-%d", i), "chain-cmd", i+5,
+			"cmd.exec", receipt.RiskHigh, receipt.StatusSuccess, ts, nil,
+		))
+	}
+
+	// "file.read": 5 successes (0 failures)
+	for i := range 5 {
+		ts := fmt.Sprintf("2026-05-01T12:%02d:00Z", i)
+		recs = append(recs, makeReceipt(
+			fmt.Sprintf("urn:receipt:file-%d", i), "chain-file", i+1,
+			"file.read", receipt.RiskLow, receipt.StatusSuccess, ts, nil,
+		))
+	}
+
+	// "tiny.action": 3 receipts — must be EXCLUDED by HAVING COUNT(*) >= 5
+	for i := range 3 {
+		ts := fmt.Sprintf("2026-05-01T13:%02d:00Z", i)
+		recs = append(recs, makeReceipt(
+			fmt.Sprintf("urn:receipt:tiny-%d", i), "chain-tiny", i+1,
+			"tiny.action", receipt.RiskLow, receipt.StatusFailure, ts, nil,
+		))
+	}
+
+	for _, r := range recs {
+		hash, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatalf("hash: %v", err)
+		}
+		if err := s.Insert(r, hash); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	s.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	// All-time query.
+	stats, err := reader.ActionStats(nil)
+	if err != nil {
+		t.Fatalf("ActionStats: %v", err)
+	}
+
+	// Only "cmd.exec" and "file.read" must be present (tiny.action excluded).
+	if len(stats) != 2 {
+		t.Fatalf("got %d entries, want 2 (tiny.action must be excluded)", len(stats))
+	}
+
+	// Verify exclusion of tiny.action.
+	for _, s := range stats {
+		if s.ActionType == "tiny.action" {
+			t.Errorf("tiny.action (total=3) should be excluded by HAVING COUNT(*) >= 5")
+		}
+	}
+
+	// First entry must be cmd.exec (highest failure rate).
+	first := stats[0]
+	if first.ActionType != "cmd.exec" {
+		t.Errorf("first action: got %q, want cmd.exec", first.ActionType)
+	}
+	if first.Total != 6 {
+		t.Errorf("cmd.exec total: got %d, want 6", first.Total)
+	}
+	if first.Failure != 4 {
+		t.Errorf("cmd.exec failure: got %d, want 4", first.Failure)
+	}
+	if first.Success != 2 {
+		t.Errorf("cmd.exec success: got %d, want 2", first.Success)
+	}
+	wantRate := 4.0 / 6.0 * 100
+	if first.FailureRate < wantRate-0.001 || first.FailureRate > wantRate+0.001 {
+		t.Errorf("cmd.exec failure_rate: got %.4f, want %.4f", first.FailureRate, wantRate)
+	}
+
+	// Second entry must be file.read (0% failure rate).
+	second := stats[1]
+	if second.ActionType != "file.read" {
+		t.Errorf("second action: got %q, want file.read", second.ActionType)
+	}
+	if second.Total != 5 {
+		t.Errorf("file.read total: got %d, want 5", second.Total)
+	}
+	if second.Failure != 0 {
+		t.Errorf("file.read failure: got %d, want 0", second.Failure)
+	}
+	if second.FailureRate != 0 {
+		t.Errorf("file.read failure_rate: got %f, want 0", second.FailureRate)
+	}
+
+	// Test since filter: only include receipts from 2026-05-01T11:00:00Z onward.
+	// cmd.exec: 2 successes in that window (the 4 failures are before 11:00).
+	// file.read: 5 receipts (12:xx) — still included, still 5 total.
+	// => cmd.exec total < 5 after the window cut, so it should be excluded.
+	since := "2026-05-01T11:00:00Z"
+	sinceStats, err := reader.ActionStats(&since)
+	if err != nil {
+		t.Fatalf("ActionStats with since: %v", err)
+	}
+	// Only file.read survives (cmd.exec has only 2 receipts in the window).
+	if len(sinceStats) != 1 {
+		t.Fatalf("since filter: got %d entries, want 1", len(sinceStats))
+	}
+	if sinceStats[0].ActionType != "file.read" {
+		t.Errorf("since filter first: got %q, want file.read", sinceStats[0].ActionType)
+	}
 }
 
 func TestReader_IsReadOnly(t *testing.T) {


### PR DESCRIPTION
## What

Closes #86.

Adds a ranked view of action types by failure rate — answering "which action types are actually failing?", which the volume-only "Action distribution" chart doesn't.

**Backend**
- New `GET /api/stats/actions` endpoint (`store.ActionStats`). Groups receipts by `action_type`, computing total / success / failure counts and a failure rate. Action types with fewer than 5 receipts are excluded (`HAVING COUNT(*) >= 5`). Results sorted by failure rate desc, then total desc, then action type asc (deterministic). Optional `range` query param (Go duration string, e.g. `24h`) restricts the window; invalid values return 400.

**Frontend**
- New **Actions** tab: full table (Action type / Total / Failures / Failure rate as a mini bar + %), sorted by failure rate desc, clickable column headers to re-sort, max 10 rows with a "Show all" toggle. Clicking a row pre-filters the Receipts view to that action type with `status=failure`.
- **Overview** gains a "Top actions by failure rate" summary card (top 5 as horizontal bars) with a "View all →" link to the Actions tab.

## Why

Surfaces the most actionable signal for an operator (the SigNoz "most errored endpoints" equivalent) without having to scan raw receipts.

## Notes
- `failure_rate` is returned as a **0–1 ratio** (matching the issue example and `/api/stats/servers`); the frontend renders it as a percentage. _(Finalized after review — it initially returned 0–100.)_
- Copilot review (rounds 1–3) addressed: range validation (reject non-positive, drop `7d`); keyboard navigation for the Actions table; keyboard-operable sortable headers (`<button>` + `aria-sort`) and Overview summary rows.
- Self-review (`/code-review`) caught and fixed a broken row `onclick` (a `JSON.stringify` value collided with the double-quoted attribute, breaking click-through); switched to the repo's `data-*` + `this.dataset` idiom. Also isolated the summary-card fetch so a `/api/stats/actions` error can't take down recent-receipts polling on the Overview.

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] New functionality includes tests (`TestActionStats`, `TestActionStatsEndpoint`, `TestActionStatsEndpoint_WithSufficientData`)
- [x] Commit messages follow Conventional Commits
- [x] AGENTS.md updated if project structure changed (n/a)
- [x] Request a Copilot review for automated checks

