### PR TITLE
feat: add free-text search to receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Top actions by failure rate** — a new `GET /api/stats/actions` endpoint returns per-action-type failure statistics (total, success, failure counts, and failure rate), filtered to action types with at least 5 receipts. An optional `range` query parameter (Go duration string, e.g. `24h`) restricts the window. Results are sorted by failure rate descending. A new **Actions** tab renders the full sortable table with clickable column headers and a "Show all" toggle; clicking a row pre-filters the Receipts view to that action type's failures. The Overview tab gains a new "Top actions by failure rate" summary card showing the top 5 action types as horizontal bars, with a "View all →" link to the Actions tab.
+- **Free-text search on the Receipts tab** — a "Search" input field at the left of the filter bar lets you search across the full raw receipt JSON (action type, tool name, IDs, parameters, and more). The active term is reflected in the URL as `?q=<value>` on `GET /api/receipts`, making searches bookmarkable and shareable. Loading the dashboard with `?q=<term>` pre-fills the search and opens the Receipts view automatically. The match count updates to "N receipts matching '<term>'" when a search is active.
 
 ## [0.5.1] - 2026-06-03
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -219,6 +219,9 @@ func (s *Server) handleReceipts(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("since"); v != "" {
 		f.Since = &v
 	}
+	if v := q.Get("q"); v != "" {
+		f.Q = &v
+	}
 	if v := q.Get("limit"); v != "" {
 		n, err := strconv.Atoi(v)
 		if err != nil || n < 1 {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -611,6 +611,43 @@ func TestActionStatsEndpoint_WithSufficientData(t *testing.T) {
 	}
 }
 
+func TestReceiptsEndpoint_Q(t *testing.T) {
+	srv := setupServer(t)
+
+	// A term unique to one receipt should return only that receipt.
+	req := httptest.NewRequest("GET", "/api/receipts?q=email", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("q=email: got status %d, want 200", w.Code)
+	}
+	var rows []store.ReceiptRow
+	if err := json.Unmarshal(w.Body.Bytes(), &rows); err != nil {
+		t.Fatalf("q=email: decode: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("q=email: got %d rows, want 1", len(rows))
+	}
+	if len(rows) > 0 && rows[0].ID != "urn:receipt:003" {
+		t.Errorf("q=email: got ID %q, want urn:receipt:003", rows[0].ID)
+	}
+
+	// An empty q= behaves like no param — returns all rows.
+	req = httptest.NewRequest("GET", "/api/receipts?q=", nil)
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("q=: got status %d, want 200", w.Code)
+	}
+	var allRows []store.ReceiptRow
+	if err := json.Unmarshal(w.Body.Bytes(), &allRows); err != nil {
+		t.Fatalf("q=: decode: %v", err)
+	}
+	if len(allRows) != 3 {
+		t.Errorf("q=: got %d rows, want 3 (same as no param)", len(allRows))
+	}
+}
+
 func TestIndexPage(t *testing.T) {
 	srv := setupServer(t)
 	req := httptest.NewRequest("GET", "/", nil)

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1249,7 +1249,9 @@
 
     function currentReceiptFilters() {
       const f = {};
-      const q      = document.getElementById('filter-q').value;
+      // Trim so a whitespace-only search isn't treated as an active filter
+      // (the backend ignores it) — keeps the URL and filter chips clean.
+      const q      = document.getElementById('filter-q').value.trim();
       const risk   = document.getElementById('filter-risk').value;
       const status = document.getElementById('filter-status').value;
       const action = document.getElementById('filter-action').value;

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -639,6 +639,10 @@
     <div id="view-receipts" class="hidden">
       <div class="flex flex-wrap gap-3 mb-2">
         <div class="form-field">
+          <label class="form-label" for="filter-q">Search</label>
+          <input type="text" id="filter-q" placeholder="Search receipts…" oninput="debounceLoadReceipts()">
+        </div>
+        <div class="form-field">
           <label class="form-label" for="filter-risk">Risk</label>
           <select id="filter-risk" onchange="loadReceipts()">
             <option value="">All</option>
@@ -1245,10 +1249,12 @@
 
     function currentReceiptFilters() {
       const f = {};
+      const q      = document.getElementById('filter-q').value;
       const risk   = document.getElementById('filter-risk').value;
       const status = document.getElementById('filter-status').value;
       const action = document.getElementById('filter-action').value;
       const chain  = document.getElementById('filter-chain').value;
+      if (q)      f.q           = q;
       if (risk)   f.risk_level  = risk;
       if (status) f.status      = status;
       if (action) f.action_type = action;
@@ -1260,6 +1266,17 @@
       const filters = currentReceiptFilters();
       const params = new URLSearchParams(filters);
 
+      // Sync active q into the URL so the user can share or bookmark a search.
+      // Full filter URL-sync (risk, status, action, chain) is a possible follow-up.
+      const qVal = filters.q || '';
+      const url = new URL(location.href);
+      if (qVal) {
+        url.searchParams.set('q', qVal);
+      } else {
+        url.searchParams.delete('q');
+      }
+      history.replaceState(null, '', url.toString());
+
       renderFilterChips(filters);
       document.getElementById('receipts-table').innerHTML = skeletonRows(8);
       document.getElementById('match-count').textContent = '';
@@ -1270,7 +1287,7 @@
         const receipts = await fetchJSON('/api/receipts?' + params.toString());
         if (gen !== poller.generation) return;
         renderReceiptsTable(receipts, 'receipts-table', { emptyHint: Object.keys(filters).length > 0 });
-        renderMatchCount(receipts.length);
+        renderMatchCount(receipts.length, qVal);
         startPolling('receipts', 'receipts-table', receipts, currentReceiptFilters);
         nav.setSelector('#receipts-table tbody tr');
       } catch (err) {
@@ -1280,13 +1297,14 @@
       }
     }
 
-    function renderMatchCount(n) {
+    function renderMatchCount(n, q) {
       const el = document.getElementById('match-count');
-      el.textContent = n === 1 ? '1 match' : `${n.toLocaleString()} matches`;
+      const noun = n === 1 ? '1 receipt' : `${n.toLocaleString()} receipts`;
+      el.textContent = q ? `${noun} matching '${q}'` : (n === 1 ? '1 match' : `${n.toLocaleString()} matches`);
     }
 
     function renderFilterChips(filters) {
-      const labels = { risk_level: 'risk', status: 'status', action_type: 'action', chain_id: 'chain' };
+      const labels = { q: 'search', risk_level: 'risk', status: 'status', action_type: 'action', chain_id: 'chain' };
       const entries = Object.entries(filters);
       const chips = entries.map(([k, v]) => `
         <span class="chip">
@@ -1302,13 +1320,13 @@
     }
 
     function clearFilter(key) {
-      const map = { risk_level: 'filter-risk', status: 'filter-status', action_type: 'filter-action', chain_id: 'filter-chain' };
+      const map = { q: 'filter-q', risk_level: 'filter-risk', status: 'filter-status', action_type: 'filter-action', chain_id: 'filter-chain' };
       const el = document.getElementById(map[key]);
       if (el) { el.value = ''; loadReceipts(); }
     }
 
     function clearAllFilters() {
-      ['filter-risk', 'filter-status', 'filter-action', 'filter-chain'].forEach(id => {
+      ['filter-q', 'filter-risk', 'filter-status', 'filter-action', 'filter-chain'].forEach(id => {
         const el = document.getElementById(id);
         if (el) el.value = '';
       });
@@ -2461,7 +2479,7 @@
       } else if (poller.activeView === 'receipts') {
         // Refresh match count when new rows arrive.
         const tableRows = tbody.rows.length;
-        renderMatchCount(tableRows);
+        renderMatchCount(tableRows, currentReceiptFilters().q || '');
       }
 
       showLiveToast(fresh.length);
@@ -2686,7 +2704,17 @@
     });
 
     // ---------- Boot ----------
-    loadPollConfig().then(loadOverview);
+    loadPollConfig().then(() => {
+      // If the URL contains ?q=<term>, pre-populate the search box and open
+      // the Receipts view with the term applied. Otherwise load the overview.
+      const initialQ = new URLSearchParams(location.search).get('q');
+      if (initialQ && initialQ.trim()) {
+        document.getElementById('filter-q').value = initialQ;
+        showView('receipts');
+      } else {
+        loadOverview();
+      }
+    });
     loadForensicStatus();
   </script>
 </body>

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -2706,12 +2706,22 @@
     });
 
     // ---------- Boot ----------
-    loadPollConfig().then(() => {
+    loadPollConfig().then(async () => {
       // If the URL contains ?q=<term>, pre-populate the search box and open
       // the Receipts view with the term applied. Otherwise load the overview.
       const initialQ = new URLSearchParams(location.search).get('q');
       if (initialQ && initialQ.trim()) {
         document.getElementById('filter-q').value = initialQ;
+        // loadOverview() is skipped on this path, so fetch stats here to fill
+        // the header context (receipt count + latest timestamp) — otherwise a
+        // shared ?q= deep link would leave the header blank until Overview is
+        // visited. Failure is non-fatal; the search still loads.
+        try {
+          const stats = await fetchJSON('/api/stats');
+          renderHeaderContext(null, stats);
+        } catch (err) {
+          console.warn('header stats on deep-link boot:', err);
+        }
         showView('receipts');
       } else {
         loadOverview();

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -109,6 +109,7 @@ type Filter struct {
 	Before     *string // ISO 8601 timestamp, inclusive
 	Since      *string // ISO 8601 timestamp, inclusive — watermark for live polling; clients dedup by id
 	Limit      *int
+	Q          *string // free-text search against the raw receipt JSON; nil or whitespace-only means no filter
 }
 
 // OpenReadOnly opens an existing receipt SQLite database in read-only mode.
@@ -196,6 +197,12 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		// dedups by id.
 		conds = append(conds, "timestamp >= ?")
 		args = append(args, *f.Since)
+	}
+	if f.Q != nil {
+		if term := strings.TrimSpace(*f.Q); term != "" {
+			conds = append(conds, `receipt_json LIKE '%' || ? || '%' ESCAPE '\'`)
+			args = append(args, escapeLikeTerm(term))
+		}
 	}
 
 	where := ""
@@ -459,6 +466,16 @@ var allowedGroupByColumns = map[string]bool{
 	"risk_level":  true,
 	"status":      true,
 	"action_type": true,
+}
+
+// escapeLikeTerm escapes a user-supplied search term so that %, _, and \ are
+// treated as literal characters in a SQLite LIKE pattern using backslash as the
+// escape character (ESCAPE '\').
+func escapeLikeTerm(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `%`, `\%`)
+	s = strings.ReplaceAll(s, `_`, `\_`)
+	return s
 }
 
 func (r *Reader) groupBy(column string) ([]GroupCount, error) {

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -889,15 +889,16 @@ func TestListReceiptsQ(t *testing.T) {
 		t.Errorf("q=mail+risk=high: got ID %q, want urn:receipt:q3", rows[0].ID)
 	}
 
-	// A term with LIKE metacharacters (%) must be treated as literal, not as a
-	// wildcard. "100%" should match a receipt whose JSON contains the literal
-	// string "100%" and not all receipts.
-	rowsMeta, err := reader.ListReceipts(Filter{Q: strPtr("100%")})
+	// A term with a LIKE metacharacter (%) must be literal, not a wildcard.
+	// "http%" is chosen so the test actually fails if escaping breaks: as a
+	// wildcard it would match the "http_get" tool (JSON contains "http"), but
+	// as a literal it matches nothing — no receipt JSON contains "http%".
+	rowsMeta, err := reader.ListReceipts(Filter{Q: strPtr("http%")})
 	if err != nil {
-		t.Fatalf("list q=100%%: %v", err)
+		t.Fatalf("list q=http%%: %v", err)
 	}
 	if len(rowsMeta) != 0 {
-		t.Errorf("q='100%%': got %d rows, want 0 (percent must not act as wildcard)", len(rowsMeta))
+		t.Errorf("q='http%%': got %d rows, want 0 (percent must not act as wildcard, else it would match http_get)", len(rowsMeta))
 	}
 
 	// Similarly, underscore (_) in the term must be literal.

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -807,6 +807,124 @@ func TestReader_Stats_EmptyStore(t *testing.T) {
 	}
 }
 
+func TestListReceiptsQ(t *testing.T) {
+	dbPath := t.TempDir() + "/q-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	// Receipts differ in action_type so we can search by a unique substring of
+	// their JSON, and in risk_level so we can combine Q with another filter.
+	recs := []receipt.AgentReceipt{
+		makeReceiptWithTool("urn:receipt:q1", "chain-q", 1, "filesystem.file.read", "read_file", "fs-server", receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z"),
+		makeReceiptWithTool("urn:receipt:q2", "chain-q", 2, "network.http.request", "http_get", "net-server", receipt.RiskHigh, receipt.StatusSuccess, "2026-04-01T10:01:00Z"),
+		makeReceiptWithTool("urn:receipt:q3", "chain-q", 3, "communication.email.send", "send_mail", "mail-server", receipt.RiskHigh, receipt.StatusSuccess, "2026-04-01T10:02:00Z"),
+	}
+	for _, r := range recs {
+		hash, err := receipt.HashReceipt(r)
+		if err != nil {
+			t.Fatalf("hash: %v", err)
+		}
+		if err := s.Insert(r, hash); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	s.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	// A term matching a single receipt returns only that receipt.
+	rows, err := reader.ListReceipts(Filter{Q: strPtr("http_get")})
+	if err != nil {
+		t.Fatalf("list q=http_get: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("q=http_get: got %d rows, want 1", len(rows))
+	}
+	if rows[0].ID != "urn:receipt:q2" {
+		t.Errorf("q=http_get: got ID %q, want urn:receipt:q2", rows[0].ID)
+	}
+
+	// A pointer to empty string returns all rows (same as nil).
+	rowsAll, err := reader.ListReceipts(Filter{Q: strPtr("")})
+	if err != nil {
+		t.Fatalf("list q='': %v", err)
+	}
+	if len(rowsAll) != 3 {
+		t.Errorf("q='': got %d rows, want 3 (same as nil)", len(rowsAll))
+	}
+
+	// nil Q also returns all rows.
+	rowsNil, err := reader.ListReceipts(Filter{Q: nil})
+	if err != nil {
+		t.Fatalf("list q=nil: %v", err)
+	}
+	if len(rowsNil) != 3 {
+		t.Errorf("q=nil: got %d rows, want 3", len(rowsNil))
+	}
+
+	// Whitespace-only Q returns all rows (trimmed before matching).
+	rowsWS, err := reader.ListReceipts(Filter{Q: strPtr("   ")})
+	if err != nil {
+		t.Fatalf("list q=whitespace: %v", err)
+	}
+	if len(rowsWS) != 3 {
+		t.Errorf("q=whitespace: got %d rows, want 3", len(rowsWS))
+	}
+
+	// Q combined with another filter narrows to the intersection.
+	rows, err = reader.ListReceipts(Filter{Q: strPtr("mail"), RiskLevel: strPtr("high")})
+	if err != nil {
+		t.Fatalf("list q=mail + risk=high: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("q=mail+risk=high: got %d rows, want 1", len(rows))
+	}
+	if rows[0].ID != "urn:receipt:q3" {
+		t.Errorf("q=mail+risk=high: got ID %q, want urn:receipt:q3", rows[0].ID)
+	}
+
+	// A term with LIKE metacharacters (%) must be treated as literal, not as a
+	// wildcard. "100%" should match a receipt whose JSON contains the literal
+	// string "100%" and not all receipts.
+	rowsMeta, err := reader.ListReceipts(Filter{Q: strPtr("100%")})
+	if err != nil {
+		t.Fatalf("list q=100%%: %v", err)
+	}
+	if len(rowsMeta) != 0 {
+		t.Errorf("q='100%%': got %d rows, want 0 (percent must not act as wildcard)", len(rowsMeta))
+	}
+
+	// Similarly, underscore (_) in the term must be literal.
+	rowsUnderscore, err := reader.ListReceipts(Filter{Q: strPtr("q_")})
+	if err != nil {
+		t.Fatalf("list q=q_: %v", err)
+	}
+	// "q_" with a literal underscore would not match any action_type or tool_name
+	// in the seeded data (the chain_id is "chain-q", not "chain_q").
+	if len(rowsUnderscore) != 0 {
+		t.Errorf("q='q_': got %d rows, want 0 (underscore must not act as wildcard)", len(rowsUnderscore))
+	}
+
+	// Search is case-insensitive (SQLite LIKE folds ASCII case): an uppercase
+	// term matches lowercase JSON content.
+	rowsCase, err := reader.ListReceipts(Filter{Q: strPtr("EMAIL")})
+	if err != nil {
+		t.Fatalf("list q=EMAIL: %v", err)
+	}
+	if len(rowsCase) != 1 {
+		t.Fatalf("q=EMAIL: got %d rows, want 1 (case-insensitive match of communication.email.send)", len(rowsCase))
+	}
+	if rowsCase[0].ID != "urn:receipt:q3" {
+		t.Errorf("q=EMAIL: got ID %q, want urn:receipt:q3", rowsCase[0].ID)
+	}
+}
+
 // seedEmptyDB creates a temporary SQLite file with the receipts schema in
 // place but no rows — used to exercise empty-store paths like NULL MAX().
 func seedEmptyDB(t *testing.T) string {


### PR DESCRIPTION
## What

Closes #87.

Adds keyword search to the Receipts tab — "find all receipts involving a file path / resource / error message" — the trace-search equivalent.

**Backend**
- `GET /api/receipts` accepts a `q=` param. `store.Filter.Q` adds `receipt_json LIKE '%' || ? || '%' ESCAPE '\'`, a full-text scan over the raw JSON column (covers action type, tool name, resource path, error message, principal ID, issuer, intent preview). `escapeLikeTerm` escapes `\`, `%`, `_` so user metacharacters are literal. nil / empty / whitespace-only `q` adds no condition — identical to omitting it. SQLite `LIKE` folds ASCII case, satisfying the case-insensitive requirement.

**Frontend**
- "Search" input at the left of the Receipts filter bar, 300ms debounce (reuses the existing `debounceLoadReceipts`).
- Wired through `currentReceiptFilters` / `clearFilter` / `clearAllFilters` / filter chips.
- Result count reads "N receipts matching '<term>'" when a search is active (rendered via `textContent`, no injection).
- Active term synced to the URL as `?q=` via `history.replaceState` (shareable/bookmarkable); a `?q=` deep link pre-fills the box and opens Receipts on load. Full URL-sync of the other filters is left as a noted follow-up.

## Why

Operators need to search by content, not just the existing risk/status/action/chain dropdowns.

## Notes
- Self-review (`/code-review`) added a case-insensitivity test (acceptance criterion that was previously unguarded). One cosmetic edge case noted but not changed: opening a `?q=` deep link skips the Overview load, so the header's receipt-count / latest-timestamp stay blank until Overview is first visited — happy to address if you'd prefer.

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] New functionality includes tests (`TestListReceiptsQ`, `TestReceiptsEndpoint_Q`)
- [x] Commit messages follow Conventional Commits
- [x] AGENTS.md updated if project structure changed (n/a)
- [x] Request a Copilot review for automated checks
