### PR TITLE
feat: add a GitHub link to the header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Server/tool breakdown panel** — a new "Servers" tab shows an expandable table of every MCP server (extracted from `credentialSubject.action.target.system`) with per-server totals, failure counts, and a mini failure-rate bar. Each server row expands to reveal its tools with the same metrics. Clicking a tool row pre-filters the Receipts view to that server and tool. Receipts with no server are folded into an "Unknown" group, which is listed after named servers. The Overview tab gains a "Server activity" summary card showing the top 5 named servers as horizontal bars. New endpoint: `GET /api/stats/servers` (optional `?range=<duration>` for time-scoped results).
 - **Server and tool filters on Receipts** — two new filter inputs (`Server` and `Tool`) on the Receipts tab allow filtering by `target.system` and `tool_name` independently or in combination, with the same chip and clear-all behaviour as existing filters.
 - **Collapsible Overview cards** — each card on the Overview tab (Risk / Status / Action distribution, Top actions, Server activity, Recent receipts) has a chevron to collapse it down to its title. Collapsed state is remembered per card in `localStorage`, so cards you hide stay hidden across reloads.
+- **GitHub link in the header** — a GitHub icon next to the keyboard-shortcuts button opens the project repository (`github.com/agent-receipts/dashboard`) in a new tab, so operators can find the source or report an issue.
 
 ### Fixed
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -612,6 +612,9 @@
         <button class="forensic-chip" id="forensic-chip" type="button" onclick="openForensic()" aria-haspopup="dialog" title="Forensic decryption key">
           <span id="forensic-chip-label">🔒 Forensic key</span>
         </button>
+        <a class="icon-btn" href="https://github.com/agent-receipts/dashboard" target="_blank" rel="noopener noreferrer" aria-label="View source and report issues on GitHub" title="View on GitHub — source &amp; report an issue" style="text-decoration:none;">
+          <svg width="17" height="17" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+        </a>
         <button class="icon-btn" id="btn-shortcuts" type="button" aria-label="Keyboard shortcuts (?)" title="Keyboard shortcuts (?)">?</button>
         <span class="ctx-item" id="ctx-version">
           <span class="ctx-label">v</span>


### PR DESCRIPTION
## What

Adds a **GitHub icon-link in the header**, between the Forensic-key chip and the `?` shortcuts button. It opens `https://github.com/agent-receipts/dashboard` in a new tab — so a self-hosting operator can jump to the source or report an issue without hunting for the repo.

- Reuses the existing `.icon-btn` styling (muted 28×28, brightens on hover) so it sits naturally next to the `?` button.
- `target="_blank"` + `rel="noopener noreferrer"`; `aria-label`/`title` for accessibility.
- No backend changes.

## Test plan
- `go build/test/vet ./...` pass (frontend-only).
- Manual: GitHub icon appears in the header; clicking opens the repo in a new tab.

## Checklist
- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] Commit messages follow Conventional Commits
- [x] Request a Copilot review for automated checks
