### PR TITLE
chore(release): bump to v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-06-08
+
 ### Added
 
 - **Activity timeline chart on the Overview tab** — a new collapsible "Activity timeline" card sits between the stats summary cards and the distribution grid. It renders an inline SVG stacked bar chart of receipt counts bucketed over the active time range: a green (success) segment at the bottom, red (failure) above it, and a muted grey segment for any remaining statuses (pending, other). Y-axis scales to the maximum bucket total; bars share the full panel width with small gaps. X-axis shows 4–6 evenly spaced tick labels, formatted as `HH:MM` for intraday ranges and `Mon D` for multi-day ranges. Each bar carries a native SVG `<title>` tooltip with the bucket timestamp, success count, failure count, and total. An empty-state message is shown when all buckets are zero. The chart updates automatically whenever the range picker changes (since `setOverviewRange()` re-calls `loadOverview()`), and its collapsed state is remembered in `localStorage` like other Overview cards.
@@ -171,7 +173,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Server now binds to `localhost` by default; `--host` flag added for custom binding
 
-[Unreleased]: https://github.com/agent-receipts/dashboard/compare/v0.5.1...HEAD
+[Unreleased]: https://github.com/agent-receipts/dashboard/compare/v0.6.0...HEAD
+[0.6.0]: https://github.com/agent-receipts/dashboard/compare/v0.5.1...v0.6.0
 [0.5.1]: https://github.com/agent-receipts/dashboard/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/agent-receipts/dashboard/compare/v0.4.0...v0.5.0
 [0.4.0]: https://github.com/agent-receipts/dashboard/compare/v0.3.0...v0.4.0


### PR DESCRIPTION
## What

Cuts **v0.6.0**. Moves the `[Unreleased]` changelog block under a dated `## [0.6.0] - 2026-06-08` heading and updates the compare-link refs — same shape as the v0.5.1 release commit. No code changes.

After this merges, tag `v0.6.0` on the merge commit and push it to trigger `release.yml`.

## Highlights of v0.6.0

A big Overview/observability batch:
- **Time-range picker** (`1h…All`, URL-hash persisted) driving every Overview panel, backed by a new **`GET /api/stats/timeseries`** endpoint and range-aware `GET /api/stats`.
- **Activity timeline** (stacked bar chart), **error-rate sparkline**, and a **throughput** stat card (replacing "Latest").
- **Top actions by failure rate** (Actions tab), **free-text receipt search**, **server/tool breakdown** (Servers tab) + server/tool receipt filters.
- **Collapsible Overview cards** (remembered), and a **GitHub link** in the header.
- Fixes: summary cards no longer hang on skeletons; "Server activity" includes the Unknown bucket.

## Checklist
- [x] CHANGELOG `[Unreleased]` moved under `## [0.6.0] - 2026-06-08`
- [x] Compare-link refs updated (`[Unreleased]` → `v0.6.0...HEAD`, added `[0.6.0]`)
- [x] `go build/vet ./...` pass (changelog-only change)
