### PR TITLE
fix: return [] instead of null for empty API result sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Overview no longer crashes when the selected time range contains no receipts** — API endpoints now return `[]` instead of `null` for empty result sets, and the frontend guards against a `null` receipts response to show a clean zero-state instead of an error banner.
+
 - **Overview "Top actions by failure rate" and "Server activity" cards no longer hang on their loading skeletons.** Both summary fetches captured the polling generation counter and then ran after `startPolling()` incremented it, so their stale-generation guard always tripped and the render was skipped. Live polling and keyboard nav now start first, and the summary cards load afterwards guarded by a fresh generation captured after `startPolling()` — so the cards render correctly while a slow or failing `/api/stats/*` still can't stall recent-receipts polling.
 - **Overview "Server activity" card now includes the "Unknown" (no-server) group** instead of filtering it out, so receipts with no `target.system` still show activity rather than rendering "No data". The empty state now only appears for a genuinely empty store.
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -302,11 +302,6 @@ func (s *Server) handleTimeseriesStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Ensure the slice is never null in JSON.
-	if buckets == nil {
-		buckets = []store.BucketRow{}
-	}
-
 	rangeFrom := from.UTC().Format(time.RFC3339)
 	if from.IsZero() && len(buckets) > 0 {
 		rangeFrom = buckets[0].Ts
@@ -341,10 +336,6 @@ func (s *Server) handleActionStats(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Return an empty slice rather than null in JSON.
-	if stats == nil {
-		stats = []store.ActionStat{}
-	}
 	writeJSON(w, http.StatusOK, map[string]any{"actions": stats})
 }
 
@@ -365,9 +356,6 @@ func (s *Server) handleServerStats(w http.ResponseWriter, r *http.Request) {
 		writeError(w, http.StatusInternalServerError, "server stats query failed")
 		log.Printf("server stats error: %v", err)
 		return
-	}
-	if stats == nil {
-		stats = []store.ServerStat{}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"servers": stats})
 }

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -1113,13 +1113,14 @@
         const receiptsURL = `/api/receipts?limit=${RECENT_LIMIT}` + (afterQ ? '&' + afterQ : '');
         const receipts = await fetchJSON(receiptsURL);
         if (gen !== poller.generation) return;
-        renderReceiptsTable(receipts.slice(0, RECENT_LIMIT), 'recent-receipts');
+        const receiptList = receipts || [];
+        renderReceiptsTable(receiptList.slice(0, RECENT_LIMIT), 'recent-receipts');
 
         // Start live polling + keyboard nav immediately so a slow/hung summary
         // fetch can't delay core overview UX. The poller always tails with
         // `since=` regardless of the active range — new receipts should appear
         // in the live feed even when a short range is selected.
-        startPolling('overview', 'recent-receipts', receipts, () => ({}));
+        startPolling('overview', 'recent-receipts', receiptList, () => ({}));
         // Wire keyboard nav after startPolling so the j/k/Enter row list is
         // initialised even though stopPolling() cleared activeView above.
         nav.setSelector('#recent-receipts tbody tr');
@@ -2143,11 +2144,12 @@
       stopPolling();
       const gen = ++poller.generation;
       try {
-        const receipts = await fetchJSON('/api/receipts?' + params.toString());
+        const receiptsFetched = await fetchJSON('/api/receipts?' + params.toString());
         if (gen !== poller.generation) return;
-        renderReceiptsTable(receipts, 'receipts-table', { emptyHint: Object.keys(filters).length > 0 });
-        renderMatchCount(receipts.length, qVal);
-        startPolling('receipts', 'receipts-table', receipts, currentReceiptFilters);
+        const receiptList = receiptsFetched || [];
+        renderReceiptsTable(receiptList, 'receipts-table', { emptyHint: Object.keys(filters).length > 0 });
+        renderMatchCount(receiptList.length, qVal);
+        startPolling('receipts', 'receipts-table', receiptList, currentReceiptFilters);
         nav.setSelector('#receipts-table tbody tr');
       } catch (err) {
         showError('Failed to load receipts: ' + err.message);

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -309,7 +309,7 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 	}
 	defer rows.Close()
 
-	var out []ReceiptRow
+	out := make([]ReceiptRow, 0)
 	for rows.Next() {
 		var row ReceiptRow
 		if err := rows.Scan(
@@ -341,7 +341,7 @@ func (r *Reader) GetChain(chainID string) ([]ChainReceipt, error) {
 	}
 	defer rows.Close()
 
-	var out []ChainReceipt
+	out := make([]ChainReceipt, 0)
 	for rows.Next() {
 		// Scan into []byte (not string): database/sql hands *[]byte a fresh
 		// copy owned by the caller, so we reuse the one allocation for both
@@ -372,7 +372,7 @@ func (r *Reader) ListChains() ([]ChainSummary, error) {
 	}
 	defer rows.Close()
 
-	var out []ChainSummary
+	out := make([]ChainSummary, 0)
 	for rows.Next() {
 		var cs ChainSummary
 		if err := rows.Scan(&cs.ChainID, &cs.ReceiptCount, &cs.FirstTimestamp, &cs.LastTimestamp); err != nil {
@@ -528,7 +528,7 @@ func (r *Reader) TimeseriesStats(from, to time.Time, bucket time.Duration) ([]Bu
 	}
 
 	// Generate every bucket from from to to (exclusive), filling zeros where absent.
-	var out []BucketRow
+	out := make([]BucketRow, 0)
 	for t := fromSec; t < toSec; t += bucketSec {
 		ts := time.Unix(t, 0).UTC().Format(time.RFC3339)
 		rd := bucketMap[t]
@@ -598,7 +598,7 @@ func (r *Reader) ActionStats(since *string) ([]ActionStat, error) {
 	}
 	defer rows.Close()
 
-	var out []ActionStat
+	out := make([]ActionStat, 0)
 	for rows.Next() {
 		var s ActionStat
 		if err := rows.Scan(&s.ActionType, &s.Total, &s.Success, &s.Failure); err != nil {
@@ -705,7 +705,7 @@ func (r *Reader) ServerStats(since *string) ([]ServerStat, error) {
 	// bucket (keyed by ""). The missing bucket keeps an empty server string in
 	// the response so a real server literally named "Unknown" stays
 	// distinguishable; the frontend renders "" as the "Unknown" label.
-	var named []ServerStat
+	named := make([]ServerStat, 0)
 	var unknown *ServerStat
 	for _, key := range serverOrder {
 		st := serverMap[key]
@@ -804,7 +804,7 @@ func (r *Reader) groupByFiltered(column, where string, args []any) ([]GroupCount
 	}
 	defer rows.Close()
 
-	var out []GroupCount
+	out := make([]GroupCount, 0)
 	for rows.Next() {
 		var gc GroupCount
 		if err := rows.Scan(&gc.Label, &gc.Count); err != nil {

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -528,7 +528,7 @@ func (r *Reader) TimeseriesStats(from, to time.Time, bucket time.Duration) ([]Bu
 	}
 
 	// Generate every bucket from from to to (exclusive), filling zeros where absent.
-	out := make([]BucketRow, 0)
+	out := make([]BucketRow, 0, bucketCount)
 	for t := fromSec; t < toSec; t += bucketSec {
 		ts := time.Unix(t, 0).UTC().Format(time.RFC3339)
 		rd := bucketMap[t]

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -1136,6 +1136,79 @@ func TestReader_Stats_EmptyStore(t *testing.T) {
 	}
 }
 
+// TestEmptyResultsNeverNil guards against the class of bug where a store
+// function returns a nil Go slice on an empty result set, which json.Marshal
+// encodes as JSON null rather than []. All list/stat functions that feed API
+// responses must return non-nil slices so clients always receive [].
+func TestEmptyResultsNeverNil(t *testing.T) {
+	dbPath := seedEmptyDB(t)
+	r, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer r.Close()
+
+	t.Run("ListReceipts", func(t *testing.T) {
+		rows, err := r.ListReceipts(Filter{})
+		if err != nil {
+			t.Fatalf("ListReceipts: %v", err)
+		}
+		if rows == nil {
+			t.Error("ListReceipts returned nil slice; want non-nil empty slice (would JSON-encode as null)")
+		}
+	})
+
+	t.Run("GetChain", func(t *testing.T) {
+		rows, err := r.GetChain("nonexistent")
+		if err != nil {
+			t.Fatalf("GetChain: %v", err)
+		}
+		if rows == nil {
+			t.Error("GetChain returned nil slice; want non-nil empty slice (would JSON-encode as null)")
+		}
+	})
+
+	t.Run("ListChains", func(t *testing.T) {
+		chains, err := r.ListChains()
+		if err != nil {
+			t.Fatalf("ListChains: %v", err)
+		}
+		if chains == nil {
+			t.Error("ListChains returned nil slice; want non-nil empty slice (would JSON-encode as null)")
+		}
+	})
+
+	t.Run("TimeseriesStats", func(t *testing.T) {
+		buckets, err := r.TimeseriesStats(time.Time{}, time.Now(), time.Hour)
+		if err != nil {
+			t.Fatalf("TimeseriesStats: %v", err)
+		}
+		if buckets == nil {
+			t.Error("TimeseriesStats returned nil slice; want non-nil empty slice (would JSON-encode as null)")
+		}
+	})
+
+	t.Run("ActionStats", func(t *testing.T) {
+		stats, err := r.ActionStats(nil)
+		if err != nil {
+			t.Fatalf("ActionStats: %v", err)
+		}
+		if stats == nil {
+			t.Error("ActionStats returned nil slice; want non-nil empty slice (would JSON-encode as null)")
+		}
+	})
+
+	t.Run("ServerStats", func(t *testing.T) {
+		stats, err := r.ServerStats(nil)
+		if err != nil {
+			t.Fatalf("ServerStats: %v", err)
+		}
+		if stats == nil {
+			t.Error("ServerStats returned nil slice; want non-nil empty slice (would JSON-encode as null)")
+		}
+	})
+}
+
 func TestListReceiptsQ(t *testing.T) {
 	dbPath := t.TempDir() + "/q-test.db"
 	s, err := sdkstore.Open(dbPath)


### PR DESCRIPTION
## Summary

Fixes #105 — Overview crashes with `Cannot read properties of null (reading 'slice')` when the selected time range contains no receipts.

- **Root cause:** Go nil slices JSON-encode as `null`; all six list-returning store functions (`ListReceipts`, `GetChain`, `ListChains`, `TimeseriesStats`, `ActionStats`, `groupByFiltered`, `ServerStats`) used `var out []T`, which stays nil on empty results and serialises as `null` instead of `[]`.
- **Store fix:** All seven functions now use `make([]T, 0)` so they always return a non-nil slice.
- **JS fix (defence-in-depth):** Both `loadOverview` and `loadReceipts` now normalise the receipts response with `|| []` before calling `.slice()`, `.length`, `renderReceiptsTable`, and `startPolling`.
- **Handler cleanup:** The now-unreachable `if buckets == nil`, `if stats == nil` nil-guards in `handleTimeseriesStats`, `handleActionStats`, and `handleServerStats` were removed.

## Test plan

- [ ] `go vet ./...` passes
- [ ] `go test ./...` passes
- [ ] Open dashboard at `#range=1h` with a DB whose most recent receipt is older than 1 hour — Overview tab shows zero-state UI instead of error banner