### PR TITLE
feat: Layer 3 attribution rendering (session groups, swimlanes, correlation pairs, delegation edges)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Layer 3 attribution rendering** — the Receipts view now renders session grouping, subagent swimlanes, correlation pairing, and delegation edges for receipts emitted by daemon ≥ v0.17.0 / hook ≥ v0.14.0. When any receipt in the current result set carries a `session_id`, the flat table is replaced with a grouped layout:
+  - **Session groups** — receipts are grouped under collapsible session headers keyed by `issuer.session_id`; clicking the ▾ button hides all rows in that session.
+  - **Subagent swimlanes** — within each session, receipts are split by `issuer.agent_id` into labelled sub-groups ("Orchestrator" for the root agent, "↳ Subagent <id>" for spawned agents).
+  - **Delegation edges** — subagent swimlane headers show a `← <parent_chain_id>` indicator when the first receipt of that agent carries a `credentialSubject.delegation` object, making parent→child chain relationships visible at a glance.
+  - **Correlation pairing** — hook pre-check and mcp-proxy post-action receipts sharing the same `credentialSubject.correlation_id` are collapsed into a single row showing both statuses (`pre-status → post-status`) with a `pre+post` badge; clicking opens the post-action receipt.
+  - **Graceful degradation** — old receipts without these fields continue to render correctly in both the flat and grouped layouts; receipts without a `session_id` are grouped under a "Legacy receipts" section at the bottom.
+
 ## [0.6.1] - 2026-06-09
 
 ### Fixed

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -2401,6 +2401,14 @@
         }
       }
 
+      // Legacy receipts (sid === null) must always appear at the end regardless
+      // of when the first legacy receipt was encountered.
+      const legacyIdx = sessionOrder.indexOf(null);
+      if (legacyIdx !== -1 && legacyIdx !== sessionOrder.length - 1) {
+        sessionOrder.splice(legacyIdx, 1);
+        sessionOrder.push(null);
+      }
+
       const result = [];
       for (const sid of sessionOrder) {
         const session  = sessionMap.get(sid);
@@ -2426,10 +2434,10 @@
 
     // collapseCorrelationPairs merges pairs of receipts sharing the same
     // correlation_id into a two-element [pre, post] array sorted by sequence.
-    // Receipts without a correlation_id, or whose correlation_id appears only
-    // once in the list, are wrapped in single-element arrays [r].
+    // Receipts without a correlation_id, or whose correlation_id count != 2,
+    // are emitted as single-element arrays [r] at their original position.
     function collapseCorrelationPairs(rows) {
-      // First pass: collect all rows per correlation_id.
+      // First pass: count group size per correlation_id.
       const corrMap = new Map();
       for (const r of rows) {
         if (!r.correlation_id) continue;
@@ -2437,24 +2445,26 @@
         corrMap.get(r.correlation_id).push(r);
       }
 
-      // Second pass: walk the original order and emit items.
-      const result  = [];
-      const emitted = new Set(); // correlation_ids already emitted as a pair
+      // Second pass: walk original order and emit items.
+      const result   = [];
+      const pairedIds = new Set(); // correlation_ids already emitted as a pair
       for (const r of rows) {
         if (!r.correlation_id) {
           result.push([r]);
           continue;
         }
-        if (emitted.has(r.correlation_id)) continue;
         const group = corrMap.get(r.correlation_id);
         if (group.length === 2) {
-          emitted.add(r.correlation_id);
-          group.sort((a, b) => a.sequence - b.sequence);
-          result.push(group); // [pre, post]
+          if (!pairedIds.has(r.correlation_id)) {
+            pairedIds.add(r.correlation_id);
+            group.sort((a, b) => a.sequence - b.sequence);
+            result.push(group); // [pre, post]
+          }
+          // Second member of the pair is skipped — already emitted above.
         } else {
-          // Odd count or singleton: emit individually.
-          emitted.add(r.correlation_id);
-          for (const gr of group) result.push([gr]);
+          // Not exactly two: emit individually at original position to
+          // preserve ordering of surrounding receipts.
+          result.push([r]);
         }
       }
       return result;
@@ -2493,7 +2503,7 @@
                  <div class="session-header-inner">
                    <button type="button" class="session-collapse-btn" data-target-session="${safeEsc}" onclick="toggleSession(this)" aria-label="Collapse session">▾</button>
                    <span class="font-mono" style="font-size:0.8rem;color:var(--accent);" title="${safeEsc}">${escapeHtml(truncate(sid, 40))}</span>
-                   <span style="font-size:0.72rem;color:var(--subtle);">· ${countLabel} · started ${escapeHtml(timeLabel)}</span>
+                   <span style="font-size:0.72rem;color:var(--subtle);">· ${countLabel} · latest ${escapeHtml(timeLabel)}</span>
                  </div>
                </td>
              </tr>`;

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -569,6 +569,47 @@
     }
     .range-btn:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
+    /* ---------- Session grouping / Layer 3 ---------- */
+    .session-header-tr td {
+      padding: 6px 12px;
+      background: var(--surface-hover);
+      border-bottom: 1px solid var(--border);
+    }
+    .session-header-inner {
+      display: flex; align-items: center; gap: 8px;
+    }
+    .session-collapse-btn {
+      background: none; border: none; cursor: pointer;
+      color: var(--muted); font-size: 0.8rem; padding: 1px 4px;
+      transition: color 0.12s ease;
+    }
+    .session-collapse-btn:hover { color: var(--text); }
+    .agent-header-tr td {
+      padding: 4px 12px 4px 28px;
+      background: rgba(255,255,255,0.015);
+      border-bottom: 1px solid rgba(48,54,61,0.4);
+    }
+    .agent-header-inner {
+      display: flex; align-items: center; gap: 6px;
+      font-size: 0.75rem; color: var(--muted);
+    }
+    .agent-root-label { color: var(--accent); font-weight: 500; }
+    .agent-sub-label  { color: var(--muted); }
+    .delegation-edge {
+      display: inline-flex; align-items: center; gap: 4px;
+      font-size: 0.7rem; color: var(--subtle);
+      margin-left: 8px; font-family: var(--font-mono);
+    }
+    .corr-pair-badge {
+      display: inline-block; padding: 1px 5px;
+      background: rgba(88,166,255,0.12);
+      color: var(--accent);
+      border: 1px solid rgba(88,166,255,0.3);
+      border-radius: 9999px;
+      font-size: 0.65rem; font-weight: 500;
+      margin-left: 5px; vertical-align: middle;
+    }
+
     /* ---------- Layout helpers ---------- */
     main.app-main { padding: 24px; max-width: 1280px; margin: 0 auto; }
     @media (max-width: 720px) {
@@ -2150,7 +2191,8 @@
         renderReceiptsTable(receiptList, 'receipts-table', { emptyHint: Object.keys(filters).length > 0 });
         renderMatchCount(receiptList.length, qVal);
         startPolling('receipts', 'receipts-table', receiptList, currentReceiptFilters);
-        nav.setSelector('#receipts-table tbody tr');
+        // Use [data-receipt-id] to skip session/agent header rows in grouped view.
+        nav.setSelector('#receipts-table tbody tr[data-receipt-id]');
       } catch (err) {
         showError('Failed to load receipts: ' + err.message);
         document.getElementById('receipts-table').innerHTML =
@@ -2197,8 +2239,11 @@
     function receiptRowHTML(r, opts) {
       const flash = opts && opts.flash ? ' row-new' : '';
       const tsAttr = r.timestamp ? ` title="${escapeAttr(r.timestamp)}"` : '';
+      // When rendered inside a session group, carry the session ID so
+      // toggleSession() can show/hide this row with its peers.
+      const sessionAttr = (opts && opts.sessionId) ? ` data-session-id="${escapeAttr(opts.sessionId)}"` : '';
       return `
-        <tr class="${flash}" data-receipt-id="${escapeAttr(r.id)}" onclick="showReceipt(this.dataset.receiptId)">
+        <tr class="${flash}"${sessionAttr} data-receipt-id="${escapeAttr(r.id)}" onclick="showReceipt(this.dataset.receiptId)">
           <td class="muted whitespace-nowrap"${tsAttr}>${formatRelative(r.timestamp)}</td>
           <td class="font-mono text-xs muted">${r.server ? escapeHtml(r.server) : '<span class="subtle">—</span>'}</td>
           <td class="font-mono text-xs">${r.tool_name ? escapeHtml(r.tool_name) : '<span class="subtle">—</span>'}</td>
@@ -2285,6 +2330,16 @@
         `;
         return;
       }
+
+      // Use session-grouped rendering for the full receipts table whenever any
+      // receipt carries a session_id (daemon ≥ v0.17.0). The overview
+      // recent-receipts mini-table always uses the flat layout.
+      if (containerId === 'receipts-table' && receipts.some(r => r.session_id)) {
+        renderGroupedReceiptsTable(receipts, container, containerId);
+        hydrateListDisclosurePreviews(receipts);
+        return;
+      }
+
       container.innerHTML = `
         <div class="receipts-table-wrap">
           <div class="receipts-table-scroll">
@@ -2309,6 +2364,226 @@
         </div>
       `;
       hydrateListDisclosurePreviews(receipts);
+    }
+
+    // ---------- Layer 3 session grouping ----------
+
+    // groupReceiptsBySession returns an array of session groups ordered by
+    // their first receipt's timestamp (preserving the server's newest-first
+    // ordering). Each group has the shape:
+    //   { sessionId, firstTimestamp, receiptCount, agents: [ { agentId, delegation, rows } ] }
+    // where rows is an array of "items": each item is either a single-element
+    // array [r] (ungrouped receipt) or a two-element array [pre, post]
+    // (correlated pair). Receipts without session_id are bucketed under the
+    // sentinel key '__legacy__' and appended at the end.
+    function groupReceiptsBySession(receipts) {
+      const sessionMap  = new Map();
+      const sessionOrder = [];
+
+      for (const r of receipts) {
+        const sid = r.session_id || '__legacy__';
+        if (!sessionMap.has(sid)) {
+          sessionMap.set(sid, { firstTimestamp: r.timestamp, agents: new Map(), agentOrder: [] });
+          sessionOrder.push(sid);
+        }
+        const session = sessionMap.get(sid);
+        const aid = r.agent_id || '__root__';
+        if (!session.agents.has(aid)) {
+          session.agents.set(aid, { rawRows: [], delegation: null });
+          session.agentOrder.push(aid);
+        }
+        const agent = session.agents.get(aid);
+        agent.rawRows.push(r);
+        // Capture delegation from first receipt of a delegated chain.
+        if (!agent.delegation && r.delegation) {
+          agent.delegation = r.delegation;
+        }
+      }
+
+      const result = [];
+      for (const sid of sessionOrder) {
+        const session  = sessionMap.get(sid);
+        const rawCount = Array.from(session.agents.values())
+          .reduce((n, a) => n + a.rawRows.length, 0);
+        const agents = session.agentOrder.map(aid => {
+          const a = session.agents.get(aid);
+          return {
+            agentId:    aid,
+            delegation: a.delegation,
+            rows:       collapseCorrelationPairs(a.rawRows),
+          };
+        });
+        result.push({
+          sessionId:      sid,
+          firstTimestamp: session.firstTimestamp,
+          receiptCount:   rawCount,
+          agents,
+        });
+      }
+      return result;
+    }
+
+    // collapseCorrelationPairs merges pairs of receipts sharing the same
+    // correlation_id into a two-element [pre, post] array sorted by sequence.
+    // Receipts without a correlation_id, or whose correlation_id appears only
+    // once in the list, are wrapped in single-element arrays [r].
+    function collapseCorrelationPairs(rows) {
+      // First pass: collect all rows per correlation_id.
+      const corrMap = new Map();
+      for (const r of rows) {
+        if (!r.correlation_id) continue;
+        if (!corrMap.has(r.correlation_id)) corrMap.set(r.correlation_id, []);
+        corrMap.get(r.correlation_id).push(r);
+      }
+
+      // Second pass: walk the original order and emit items.
+      const result  = [];
+      const emitted = new Set(); // correlation_ids already emitted as a pair
+      for (const r of rows) {
+        if (!r.correlation_id) {
+          result.push([r]);
+          continue;
+        }
+        if (emitted.has(r.correlation_id)) continue;
+        const group = corrMap.get(r.correlation_id);
+        if (group.length === 2) {
+          emitted.add(r.correlation_id);
+          group.sort((a, b) => a.sequence - b.sequence);
+          result.push(group); // [pre, post]
+        } else {
+          // Odd count or singleton: emit individually.
+          emitted.add(r.correlation_id);
+          for (const gr of group) result.push([gr]);
+        }
+      }
+      return result;
+    }
+
+    // renderGroupedReceiptsTable renders the receipts view with session headers,
+    // per-agent swimlane sub-headers, collapsed correlation pairs, and
+    // delegation edge indicators. Only used when at least one receipt carries
+    // a session_id; falls back to the flat table otherwise.
+    function renderGroupedReceiptsTable(receipts, container, containerId) {
+      const groups   = groupReceiptsBySession(receipts);
+      const COL_COUNT = 8;
+
+      const bodyHTML = groups.map(session => {
+        const sid      = session.sessionId;
+        const isLegacy = sid === '__legacy__';
+        const safeEsc  = escapeAttr(sid);
+        const countLabel = `${session.receiptCount} receipt${session.receiptCount !== 1 ? 's' : ''}`;
+        const timeLabel  = session.firstTimestamp ? formatRelative(session.firstTimestamp) : '';
+
+        const headerRow = isLegacy
+          ? `<tr class="session-header-tr">
+               <td colspan="${COL_COUNT}">
+                 <div class="session-header-inner">
+                   <span style="font-size:0.78rem;color:var(--muted);">Legacy receipts (no session)</span>
+                   <span style="font-size:0.72rem;color:var(--subtle);">· ${countLabel}</span>
+                 </div>
+               </td>
+             </tr>`
+          : `<tr class="session-header-tr">
+               <td colspan="${COL_COUNT}">
+                 <div class="session-header-inner">
+                   <button type="button" class="session-collapse-btn" onclick="toggleSession(this,${JSON.stringify(sid)})" aria-label="Collapse session">▾</button>
+                   <span class="font-mono" style="font-size:0.8rem;color:var(--accent);" title="${safeEsc}">${escapeHtml(truncate(sid, 40))}</span>
+                   <span style="font-size:0.72rem;color:var(--subtle);">· ${countLabel} · started ${escapeHtml(timeLabel)}</span>
+                 </div>
+               </td>
+             </tr>`;
+
+        const agentRowsHTML = session.agents.map(agent => {
+          const aid    = agent.agentId;
+          const isRoot = aid === '__root__';
+          const aLabel = isRoot
+            ? `<span class="agent-root-label">Orchestrator</span>`
+            : `<span class="agent-sub-label">↳ Subagent</span><span class="font-mono" style="font-size:0.7rem;color:var(--text);">${escapeHtml(aid)}</span>`;
+
+          const delEdge = agent.delegation
+            ? `<span class="delegation-edge" title="Delegated from ${escapeAttr(agent.delegation.parent_chain_id)}">← ${escapeHtml(truncate(agent.delegation.parent_chain_id, 28))}</span>`
+            : '';
+
+          const agentHeaderRow = `<tr class="agent-header-tr" data-session-id="${safeEsc}">
+               <td colspan="${COL_COUNT}">
+                 <div class="agent-header-inner">${aLabel}${delEdge}</div>
+               </td>
+             </tr>`;
+
+          const receiptRowsHTML = agent.rows.map(item =>
+            item.length === 2
+              ? corrPairRowHTML(item[0], item[1], sid)
+              : receiptRowHTML(item[0], { sessionId: sid })
+          ).join('');
+
+          return agentHeaderRow + receiptRowsHTML;
+        }).join('');
+
+        return headerRow + agentRowsHTML;
+      }).join('');
+
+      container.innerHTML = `
+        <div class="receipts-table-wrap">
+          <div class="receipts-table-scroll">
+            <table class="receipts">
+              <thead>
+                <tr>
+                  <th>Time</th><th>Server</th><th>Tool</th><th>Action</th>
+                  <th>Risk</th><th>Status</th><th>Chain</th><th>Seq</th>
+                </tr>
+              </thead>
+              <tbody id="${tbodyIdFor(containerId)}">
+                ${bodyHTML}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      `;
+    }
+
+    // corrPairRowHTML renders a pre+post correlated pair as a single table row.
+    // Clicking opens the post-action receipt (which carries the final outcome).
+    function corrPairRowHTML(pre, post, sessionId) {
+      const ts          = pre.timestamp || post.timestamp || '';
+      const server      = pre.server    || post.server    || '';
+      const tool        = pre.tool_name || post.tool_name || '';
+      const action      = pre.action_type || post.action_type || '';
+      const riskLevel   = post.risk_level || pre.risk_level || '';
+      const tsTitle     = ts
+        ? ` title="${escapeAttr(ts)} (pre) → ${escapeAttr(post.timestamp || '')} (post)"`
+        : '';
+      const sessionAttr = sessionId ? ` data-session-id="${escapeAttr(sessionId)}"` : '';
+      return `
+        <tr${sessionAttr} class="corr-pair-tr" data-receipt-id="${escapeAttr(post.id)}" onclick="showReceipt(this.dataset.receiptId)">
+          <td class="muted whitespace-nowrap"${tsTitle}>${formatRelative(ts)}</td>
+          <td class="font-mono text-xs muted">${server ? escapeHtml(server) : '<span class="subtle">—</span>'}</td>
+          <td class="font-mono text-xs">${tool ? escapeHtml(tool) : '<span class="subtle">—</span>'}</td>
+          <td class="font-mono text-xs">${escapeHtml(action)}<span class="corr-pair-badge">pre+post</span>${disclosureIndicatorHTML(post)}</td>
+          <td><span class="badge ${riskClass(riskLevel)}">${escapeHtml(riskLevel)}</span></td>
+          <td>
+            <span class="badge ${statusClass(pre.status)}" style="opacity:0.6;">${escapeHtml(pre.status)}</span>
+            <span class="subtle" style="font-size:0.7rem;margin:0 2px;">→</span>
+            <span class="badge ${statusClass(post.status)}">${escapeHtml(post.status)}</span>
+            ${mismatchIndicatorHTML(post)}
+          </td>
+          <td class="muted font-mono text-xs" data-chain-id="${escapeAttr(post.chain_id)}" onclick="event.stopPropagation(); showChain(this.dataset.chainId)" style="cursor:pointer;">${escapeHtml(truncate(post.chain_id, 20))}</td>
+          <td class="muted">#${pre.sequence}</td>
+        </tr>
+      `;
+    }
+
+    // toggleSession collapses or expands all rows belonging to a session group.
+    // Non-header rows are identified by data-session-id matching the given sid.
+    function toggleSession(btn, sid) {
+      const tbody = btn.closest('tbody');
+      if (!tbody) return;
+      const memberRows = Array.from(tbody.rows).filter(r =>
+        r.dataset && r.dataset.sessionId === sid
+      );
+      const anyVisible = memberRows.some(r => !r.hidden);
+      memberRows.forEach(r => { r.hidden = anyVisible; });
+      btn.textContent = anyVisible ? '▶' : '▾';
+      btn.setAttribute('aria-label', anyVisible ? 'Expand session' : 'Collapse session');
     }
 
     // disclosureHydrationConcurrency caps how many /api/disclosure requests
@@ -3338,8 +3613,9 @@
         }
         refreshOverviewStats();
       } else if (poller.activeView === 'receipts') {
-        // Refresh match count when new rows arrive.
-        const tableRows = tbody.rows.length;
+        // Count only receipt rows (not session/agent header rows which lack
+        // data-receipt-id) so the match count is correct in grouped view.
+        const tableRows = Array.from(tbody.rows).filter(r => r.dataset.receiptId).length;
         renderMatchCount(tableRows, currentReceiptFilters().q || '');
       }
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -2374,20 +2374,21 @@
     //   { sessionId, firstTimestamp, receiptCount, agents: [ { agentId, delegation, rows } ] }
     // where rows is an array of "items": each item is either a single-element
     // array [r] (ungrouped receipt) or a two-element array [pre, post]
-    // (correlated pair). Receipts without session_id are bucketed under the
-    // sentinel key '__legacy__' and appended at the end.
+    // (correlated pair). Receipts without session_id have sessionId === null
+    // and are appended at the end. Receipts without agent_id have agentId === null
+    // and are labelled "Orchestrator" in the swimlane header.
     function groupReceiptsBySession(receipts) {
       const sessionMap  = new Map();
       const sessionOrder = [];
 
       for (const r of receipts) {
-        const sid = r.session_id || '__legacy__';
+        const sid = r.session_id || null;
         if (!sessionMap.has(sid)) {
           sessionMap.set(sid, { firstTimestamp: r.timestamp, agents: new Map(), agentOrder: [] });
           sessionOrder.push(sid);
         }
         const session = sessionMap.get(sid);
-        const aid = r.agent_id || '__root__';
+        const aid = r.agent_id || null;
         if (!session.agents.has(aid)) {
           session.agents.set(aid, { rawRows: [], delegation: null });
           session.agentOrder.push(aid);
@@ -2459,18 +2460,22 @@
       return result;
     }
 
+    // Number of columns in the receipts table (Time, Server, Tool, Action,
+    // Risk, Status, Chain, Seq). Used as colspan for session/agent header rows.
+    const RECEIPT_COLS = 8;
+
     // renderGroupedReceiptsTable renders the receipts view with session headers,
     // per-agent swimlane sub-headers, collapsed correlation pairs, and
     // delegation edge indicators. Only used when at least one receipt carries
     // a session_id; falls back to the flat table otherwise.
     function renderGroupedReceiptsTable(receipts, container, containerId) {
-      const groups   = groupReceiptsBySession(receipts);
-      const COL_COUNT = 8;
+      const groups    = groupReceiptsBySession(receipts);
+      const COL_COUNT = RECEIPT_COLS;
 
       const bodyHTML = groups.map(session => {
-        const sid      = session.sessionId;
-        const isLegacy = sid === '__legacy__';
-        const safeEsc  = escapeAttr(sid);
+        const sid      = session.sessionId;   // null for legacy receipts
+        const isLegacy = sid === null;
+        const safeEsc  = sid !== null ? escapeAttr(sid) : '';
         const countLabel = `${session.receiptCount} receipt${session.receiptCount !== 1 ? 's' : ''}`;
         const timeLabel  = session.firstTimestamp ? formatRelative(session.firstTimestamp) : '';
 
@@ -2486,7 +2491,7 @@
           : `<tr class="session-header-tr">
                <td colspan="${COL_COUNT}">
                  <div class="session-header-inner">
-                   <button type="button" class="session-collapse-btn" onclick="toggleSession(this,${JSON.stringify(sid)})" aria-label="Collapse session">▾</button>
+                   <button type="button" class="session-collapse-btn" data-target-session="${safeEsc}" onclick="toggleSession(this)" aria-label="Collapse session">▾</button>
                    <span class="font-mono" style="font-size:0.8rem;color:var(--accent);" title="${safeEsc}">${escapeHtml(truncate(sid, 40))}</span>
                    <span style="font-size:0.72rem;color:var(--subtle);">· ${countLabel} · started ${escapeHtml(timeLabel)}</span>
                  </div>
@@ -2494,8 +2499,8 @@
              </tr>`;
 
         const agentRowsHTML = session.agents.map(agent => {
-          const aid    = agent.agentId;
-          const isRoot = aid === '__root__';
+          const aid    = agent.agentId;   // null for root/orchestrator agent
+          const isRoot = aid === null;
           const aLabel = isRoot
             ? `<span class="agent-root-label">Orchestrator</span>`
             : `<span class="agent-sub-label">↳ Subagent</span><span class="font-mono" style="font-size:0.7rem;color:var(--text);">${escapeHtml(aid)}</span>`;
@@ -2567,14 +2572,16 @@
             ${mismatchIndicatorHTML(post)}
           </td>
           <td class="muted font-mono text-xs" data-chain-id="${escapeAttr(post.chain_id)}" onclick="event.stopPropagation(); showChain(this.dataset.chainId)" style="cursor:pointer;">${escapeHtml(truncate(post.chain_id, 20))}</td>
-          <td class="muted">#${pre.sequence}</td>
+          <td class="muted">#${pre.sequence}–${post.sequence}</td>
         </tr>
       `;
     }
 
     // toggleSession collapses or expands all rows belonging to a session group.
-    // Non-header rows are identified by data-session-id matching the given sid.
-    function toggleSession(btn, sid) {
+    // The target session ID is read from data-target-session on the button so
+    // it never passes through an onclick attribute string (safe for any ID value).
+    function toggleSession(btn) {
+      const sid   = btn.dataset.targetSession;
       const tbody = btn.closest('tbody');
       if (!tbody) return;
       const memberRows = Array.from(tbody.rows).filter(r =>
@@ -3602,10 +3609,29 @@
         return;
       }
 
-      const html = sorted.map(r => receiptRowHTML(r, { flash: true })).join('');
-      tbody.insertAdjacentHTML('afterbegin', html);
       sorted.forEach(r => poller.knownIds.add(r.id));
       bumpWatermark(sorted);
+      const snap          = lastRenderedReceipts.get(poller.containerId);
+      const prevReceipts  = snap ? snap.receipts : [];
+      const merged        = [...sorted, ...prevReceipts];
+
+      // In grouped mode a full re-render is needed so new rows land inside the
+      // correct session/agent group and remain controllable by toggleSession.
+      // This also keeps lastRenderedReceipts current so rerenderAllReceiptTables
+      // (triggered by forensic-key load) always rebuilds from fresh data.
+      const isGrouped = poller.containerId === 'receipts-table' &&
+                        merged.some(r => r.session_id);
+      if (isGrouped) {
+        renderReceiptsTable(merged, poller.containerId, snap ? snap.opts : undefined);
+        renderMatchCount(merged.length, currentReceiptFilters().q || '');
+        showLiveToast(fresh.length);
+        nav.refresh();
+        return;
+      }
+
+      // Flat mode: prepend rows directly.
+      const html = sorted.map(r => receiptRowHTML(r, { flash: true })).join('');
+      tbody.insertAdjacentHTML('afterbegin', html);
 
       if (poller.activeView === 'overview') {
         while (tbody.rows.length > RECENT_LIMIT) {
@@ -3613,10 +3639,9 @@
         }
         refreshOverviewStats();
       } else if (poller.activeView === 'receipts') {
-        // Count only receipt rows (not session/agent header rows which lack
-        // data-receipt-id) so the match count is correct in grouped view.
-        const tableRows = Array.from(tbody.rows).filter(r => r.dataset.receiptId).length;
-        renderMatchCount(tableRows, currentReceiptFilters().q || '');
+        // Update the snapshot so rerenderAllReceiptTables has current data.
+        lastRenderedReceipts.set(poller.containerId, { receipts: merged, opts: snap ? snap.opts : undefined });
+        renderMatchCount(merged.length, currentReceiptFilters().q || '');
       }
 
       showLiveToast(fresh.length);

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -2501,7 +2501,7 @@
           : `<tr class="session-header-tr">
                <td colspan="${COL_COUNT}">
                  <div class="session-header-inner">
-                   <button type="button" class="session-collapse-btn" data-target-session="${safeEsc}" onclick="toggleSession(this)" aria-label="Collapse session">▾</button>
+                   <button type="button" class="session-collapse-btn" data-target-session="${safeEsc}" onclick="toggleSession(this)" aria-expanded="true" aria-label="Collapse session">▾</button>
                    <span class="font-mono" style="font-size:0.8rem;color:var(--accent);" title="${safeEsc}">${escapeHtml(truncate(sid, 40))}</span>
                    <span style="font-size:0.72rem;color:var(--subtle);">· ${countLabel} · latest ${escapeHtml(timeLabel)}</span>
                  </div>
@@ -2600,6 +2600,7 @@
       const anyVisible = memberRows.some(r => !r.hidden);
       memberRows.forEach(r => { r.hidden = anyVisible; });
       btn.textContent = anyVisible ? '▶' : '▾';
+      btn.setAttribute('aria-expanded', anyVisible ? 'false' : 'true');
       btn.setAttribute('aria-label', anyVisible ? 'Expand session' : 'Collapse session');
     }
 

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -830,7 +830,7 @@ func parseDelegationJSON(s string) *DelegationInfo {
 	if err := json.Unmarshal([]byte(s), &wire); err != nil {
 		return nil
 	}
-	if wire.ParentChainID == "" && wire.ParentReceiptID == "" {
+	if wire.ParentChainID == "" || wire.ParentReceiptID == "" {
 		return nil
 	}
 	return &DelegationInfo{

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -54,6 +54,33 @@ type ReceiptRow struct {
 	// status (see issue #50). This is a read-only display hint; the dashboard
 	// never rewrites the receipt or its hash.
 	OutputStatusMismatch bool `json:"output_status_mismatch"`
+
+	// Layer 3 attribution fields — only present on receipts from daemon ≥ v0.17.0
+	// / hook ≥ v0.14.0. Empty/nil for older receipts; the UI degrades gracefully.
+
+	// CorrelationID links a hook pre-check receipt to its mcp-proxy post-action
+	// receipt for the same tool call (same tool_use_id).
+	CorrelationID string `json:"correlation_id,omitempty"`
+	// AgentID identifies which subagent issued this receipt (orchestrator vs
+	// spawned subagent). Comes from issuer.agent_id in the receipt JSON.
+	AgentID string `json:"agent_id,omitempty"`
+	// SessionID groups all receipts from the same agent session together.
+	// Comes from issuer.session_id in the receipt JSON.
+	SessionID string `json:"session_id,omitempty"`
+	// Delegation is non-nil on the first receipt of a subagent chain and
+	// carries the parent chain reference, enabling delegation edge rendering.
+	Delegation *DelegationInfo `json:"delegation,omitempty"`
+}
+
+// DelegationInfo holds parent-chain attribution fields emitted by subagents
+// delegated from a parent chain (daemon ≥ v0.17.0). Maps to
+// credentialSubject.delegation in the receipt JSON.
+type DelegationInfo struct {
+	ParentChainID   string `json:"parent_chain_id"`
+	ParentReceiptID string `json:"parent_receipt_id"`
+	// DelegatorID is the id of the entity that issued the delegation
+	// (from credentialSubject.delegation.delegator.id).
+	DelegatorID string `json:"delegator_id,omitempty"`
 }
 
 // disclosurePreviewMaxLen bounds the size of input/output previews returned
@@ -279,6 +306,9 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 	// reach into it. The CASE gate ensures the inner json_extract only runs
 	// on text that json_valid has cleared — SQL AND does not short-circuit,
 	// and json_extract on non-JSON text raises a "malformed JSON" error.
+	//
+	// The last four columns are Layer 3 attribution fields (daemon ≥ v0.17.0).
+	// They are absent from older receipts and will scan as empty strings / NULL.
 	query := fmt.Sprintf(
 		`SELECT id, chain_id, sequence, action_type,
 		        COALESCE(tool_name, ''),
@@ -294,7 +324,11 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		           AND json_valid(IFNULL(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.output'), 'null')) = 1
 		          THEN IFNULL(json_extract(IFNULL(json_extract(receipt_json, '$.credentialSubject.action.parameters_disclosure.output'), 'null'), '$.isError'), 0) = 1
 		          ELSE 0
-		        END
+		        END,
+		        COALESCE(json_extract(receipt_json, '$.credentialSubject.correlation_id'), ''),
+		        COALESCE(json_extract(receipt_json, '$.issuer.agent_id'), ''),
+		        COALESCE(json_extract(receipt_json, '$.issuer.session_id'), ''),
+		        json_extract(receipt_json, '$.credentialSubject.delegation')
 		 FROM receipts %s ORDER BY %s LIMIT ?`,
 		where, orderBy,
 	)
@@ -312,6 +346,7 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 	out := make([]ReceiptRow, 0)
 	for rows.Next() {
 		var row ReceiptRow
+		var delegationJSON sql.NullString
 		if err := rows.Scan(
 			&row.ID, &row.ChainID, &row.Sequence, &row.ActionType,
 			&row.ToolName, &row.Server,
@@ -320,8 +355,13 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 			&row.ParametersInputPreview, &row.ParametersOutputPreview,
 			&row.HasParametersDisclosure,
 			&row.OutputStatusMismatch,
+			&row.CorrelationID, &row.AgentID, &row.SessionID,
+			&delegationJSON,
 		); err != nil {
 			return nil, err
+		}
+		if delegationJSON.Valid && delegationJSON.String != "" && delegationJSON.String != "null" {
+			row.Delegation = parseDelegationJSON(delegationJSON.String)
 		}
 		out = append(out, row)
 	}
@@ -774,6 +814,30 @@ var allowedGroupByColumns = map[string]bool{
 	"risk_level":  true,
 	"status":      true,
 	"action_type": true,
+}
+
+// parseDelegationJSON decodes the credentialSubject.delegation JSON object and
+// returns a DelegationInfo. Unknown fields are ignored. Returns nil on any
+// parse error so callers degrade gracefully on malformed or forward-compat JSON.
+func parseDelegationJSON(s string) *DelegationInfo {
+	var wire struct {
+		ParentChainID   string `json:"parent_chain_id"`
+		ParentReceiptID string `json:"parent_receipt_id"`
+		Delegator       struct {
+			ID string `json:"id"`
+		} `json:"delegator"`
+	}
+	if err := json.Unmarshal([]byte(s), &wire); err != nil {
+		return nil
+	}
+	if wire.ParentChainID == "" && wire.ParentReceiptID == "" {
+		return nil
+	}
+	return &DelegationInfo{
+		ParentChainID:   wire.ParentChainID,
+		ParentReceiptID: wire.ParentReceiptID,
+		DelegatorID:     wire.Delegator.ID,
+	}
 }
 
 // escapeLikeTerm escapes a user-supplied search term so that %, _, and \ are

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -1733,11 +1733,6 @@ func TestStatsWithRange(t *testing.T) {
 // receipts with fields not yet in the SDK Go types.
 func insertLayer3(t *testing.T, s *sdkstore.Store, r receipt.AgentReceipt, correlationID, agentID string, delegation *DelegationInfo) {
 	t.Helper()
-	hash, err := receipt.HashReceipt(r)
-	if err != nil {
-		t.Fatalf("hash receipt: %v", err)
-	}
-
 	rawJSON, err := json.Marshal(r)
 	if err != nil {
 		t.Fatalf("marshal receipt: %v", err)
@@ -1778,6 +1773,10 @@ func insertLayer3(t *testing.T, s *sdkstore.Store, r receipt.AgentReceipt, corre
 	augmented, err := json.Marshal(m)
 	if err != nil {
 		t.Fatalf("marshal augmented: %v", err)
+	}
+	hash, err := receipt.HashRawReceipt(augmented)
+	if err != nil {
+		t.Fatalf("hash augmented receipt: %v", err)
 	}
 	if err := s.InsertRaw(r, augmented, hash); err != nil {
 		t.Fatalf("insert receipt: %v", err)
@@ -1939,10 +1938,6 @@ func TestReader_Layer3_DelegationMalformed(t *testing.T) {
 
 	base := makeReceipt("urn:receipt:dm1", "chain-dm", 1, "tool.call",
 		receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z", nil)
-	hash, err := receipt.HashReceipt(base)
-	if err != nil {
-		t.Fatalf("hash: %v", err)
-	}
 
 	rawJSON, err := json.Marshal(base)
 	if err != nil {
@@ -1963,6 +1958,10 @@ func TestReader_Layer3_DelegationMalformed(t *testing.T) {
 	augmented, err := json.Marshal(m)
 	if err != nil {
 		t.Fatalf("marshal augmented: %v", err)
+	}
+	hash, err := receipt.HashRawReceipt(augmented)
+	if err != nil {
+		t.Fatalf("hash augmented receipt: %v", err)
 	}
 	if err := s.InsertRaw(base, augmented, hash); err != nil {
 		t.Fatalf("insert: %v", err)

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -1960,7 +1960,10 @@ func TestReader_Layer3_DelegationMalformed(t *testing.T) {
 	cs["delegation"] = map[string]any{"unexpected_key": "value"}
 	m["credentialSubject"] = cs
 
-	augmented, _ := json.Marshal(m)
+	augmented, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal augmented: %v", err)
+	}
 	if err := s.InsertRaw(base, augmented, hash); err != nil {
 		t.Fatalf("insert: %v", err)
 	}
@@ -1981,6 +1984,35 @@ func TestReader_Layer3_DelegationMalformed(t *testing.T) {
 	}
 	if rows[0].Delegation != nil {
 		t.Errorf("want nil Delegation for empty-keys object, got %+v", rows[0].Delegation)
+	}
+}
+
+// TestParseDelegationJSON unit-tests parseDelegationJSON directly, covering
+// the boundary cases that the DB-roundtrip tests cannot easily express.
+func TestParseDelegationJSON(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		wantNil bool
+	}{
+		{"both fields present", `{"parent_chain_id":"urn:chain:a","parent_receipt_id":"urn:receipt:b"}`, false},
+		{"both fields with delegator", `{"parent_chain_id":"c","parent_receipt_id":"r","delegator":{"id":"did:agent:x"}}`, false},
+		{"only parent_chain_id", `{"parent_chain_id":"urn:chain:a"}`, true},
+		{"only parent_receipt_id", `{"parent_receipt_id":"urn:receipt:b"}`, true},
+		{"neither field", `{"unexpected":"value"}`, true},
+		{"empty object", `{}`, true},
+		{"malformed JSON", `not-json`, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := parseDelegationJSON(tc.input)
+			if tc.wantNil && got != nil {
+				t.Errorf("want nil, got %+v", got)
+			}
+			if !tc.wantNil && got == nil {
+				t.Errorf("want non-nil DelegationInfo, got nil")
+			}
+		})
 	}
 }
 

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -1721,6 +1722,265 @@ func TestStatsWithRange(t *testing.T) {
 	}
 	if beforeFiltered.Total != 2 {
 		t.Errorf("before-filtered total = %d, want 2", beforeFiltered.Total)
+	}
+}
+
+// ---------- Layer 3 attribution tests ----------
+
+// insertLayer3 creates a receipt with Layer 3 attribution fields by marshalling
+// the base receipt to JSON, injecting the new fields, and inserting the
+// augmented bytes via InsertRaw. This mirrors how daemon ≥ v0.17.0 emits
+// receipts with fields not yet in the SDK Go types.
+func insertLayer3(t *testing.T, s *sdkstore.Store, r receipt.AgentReceipt, correlationID, agentID string, delegation *DelegationInfo) {
+	t.Helper()
+	hash, err := receipt.HashReceipt(r)
+	if err != nil {
+		t.Fatalf("hash receipt: %v", err)
+	}
+
+	rawJSON, err := json.Marshal(r)
+	if err != nil {
+		t.Fatalf("marshal receipt: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(rawJSON, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// Inject correlation_id and delegation into credentialSubject.
+	cs, _ := m["credentialSubject"].(map[string]any)
+	if cs == nil {
+		cs = map[string]any{}
+	}
+	if correlationID != "" {
+		cs["correlation_id"] = correlationID
+	}
+	if delegation != nil {
+		cs["delegation"] = map[string]any{
+			"parent_chain_id":   delegation.ParentChainID,
+			"parent_receipt_id": delegation.ParentReceiptID,
+			"delegator":         map[string]any{"id": delegation.DelegatorID},
+		}
+	}
+	m["credentialSubject"] = cs
+
+	// Inject agent_id into issuer.
+	if agentID != "" {
+		issuer, _ := m["issuer"].(map[string]any)
+		if issuer == nil {
+			issuer = map[string]any{}
+		}
+		issuer["agent_id"] = agentID
+		m["issuer"] = issuer
+	}
+
+	augmented, err := json.Marshal(m)
+	if err != nil {
+		t.Fatalf("marshal augmented: %v", err)
+	}
+	if err := s.InsertRaw(r, augmented, hash); err != nil {
+		t.Fatalf("insert receipt: %v", err)
+	}
+}
+
+// TestReader_Layer3_GracefulDegradation verifies that old receipts (no Layer 3
+// fields) are returned with empty CorrelationID, AgentID, SessionID, and nil
+// Delegation — no errors and no zero-value noise.
+func TestReader_Layer3_GracefulDegradation(t *testing.T) {
+	dbPath := seedFileDB(t)
+	r, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer r.Close()
+
+	rows, err := r.ListReceipts(Filter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	for _, row := range rows {
+		if row.CorrelationID != "" {
+			t.Errorf("row %s: want empty CorrelationID for old receipt, got %q", row.ID, row.CorrelationID)
+		}
+		if row.AgentID != "" {
+			t.Errorf("row %s: want empty AgentID for old receipt, got %q", row.ID, row.AgentID)
+		}
+		if row.SessionID != "" {
+			t.Errorf("row %s: want empty SessionID for old receipt, got %q", row.ID, row.SessionID)
+		}
+		if row.Delegation != nil {
+			t.Errorf("row %s: want nil Delegation for old receipt, got %+v", row.ID, row.Delegation)
+		}
+	}
+}
+
+// TestReader_Layer3_NewFields verifies that correlation_id, agent_id,
+// session_id, and delegation are correctly extracted from receipts emitted by
+// daemon ≥ v0.17.0 / hook ≥ v0.14.0.
+func TestReader_Layer3_NewFields(t *testing.T) {
+	dbPath := t.TempDir() + "/layer3-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	// Base receipt using the current Issuer struct with session_id set.
+	base := makeReceipt("urn:receipt:l3a", "chain-l3", 1, "tool.call",
+		receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z", nil)
+	base.Issuer.SessionID = "session-abc"
+
+	del := &DelegationInfo{
+		ParentChainID:   "urn:chain:parent",
+		ParentReceiptID: "urn:receipt:parent-last",
+		DelegatorID:     "did:agent:orchestrator",
+	}
+	insertLayer3(t, s, base, "corr-001", "subagent-x", del)
+
+	// Receipt with only correlation_id (no delegation, no agent_id).
+	r2 := makeReceipt("urn:receipt:l3b", "chain-l3", 2, "tool.call",
+		receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:01:00Z", nil)
+	r2.Issuer.SessionID = "session-abc"
+	insertLayer3(t, s, r2, "corr-001", "", nil)
+
+	// Old-style receipt with no Layer 3 fields at all.
+	r3 := makeReceipt("urn:receipt:l3c", "chain-l3-old", 1, "tool.call",
+		receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:02:00Z", nil)
+	hash3, err := receipt.HashReceipt(r3)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if err := s.Insert(r3, hash3); err != nil {
+		t.Fatalf("insert old receipt: %v", err)
+	}
+
+	s.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	rows, err := reader.ListReceipts(Filter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("got %d rows, want 3", len(rows))
+	}
+
+	// Rows are newest-first: l3c (index 0), l3b (index 1), l3a (index 2).
+	rowC := rows[0] // old-style, no Layer 3
+	rowB := rows[1] // correlation only
+	rowA := rows[2] // full Layer 3
+
+	// l3a: all Layer 3 fields set.
+	if rowA.CorrelationID != "corr-001" {
+		t.Errorf("l3a CorrelationID: got %q, want corr-001", rowA.CorrelationID)
+	}
+	if rowA.AgentID != "subagent-x" {
+		t.Errorf("l3a AgentID: got %q, want subagent-x", rowA.AgentID)
+	}
+	if rowA.SessionID != "session-abc" {
+		t.Errorf("l3a SessionID: got %q, want session-abc", rowA.SessionID)
+	}
+	if rowA.Delegation == nil {
+		t.Fatal("l3a Delegation: got nil, want non-nil")
+	}
+	if rowA.Delegation.ParentChainID != "urn:chain:parent" {
+		t.Errorf("l3a Delegation.ParentChainID: got %q, want urn:chain:parent", rowA.Delegation.ParentChainID)
+	}
+	if rowA.Delegation.ParentReceiptID != "urn:receipt:parent-last" {
+		t.Errorf("l3a Delegation.ParentReceiptID: got %q, want urn:receipt:parent-last", rowA.Delegation.ParentReceiptID)
+	}
+	if rowA.Delegation.DelegatorID != "did:agent:orchestrator" {
+		t.Errorf("l3a Delegation.DelegatorID: got %q, want did:agent:orchestrator", rowA.Delegation.DelegatorID)
+	}
+
+	// l3b: correlation_id + session_id, no agent_id or delegation.
+	if rowB.CorrelationID != "corr-001" {
+		t.Errorf("l3b CorrelationID: got %q, want corr-001", rowB.CorrelationID)
+	}
+	if rowB.AgentID != "" {
+		t.Errorf("l3b AgentID: got %q, want empty", rowB.AgentID)
+	}
+	if rowB.SessionID != "session-abc" {
+		t.Errorf("l3b SessionID: got %q, want session-abc", rowB.SessionID)
+	}
+	if rowB.Delegation != nil {
+		t.Errorf("l3b Delegation: got %+v, want nil", rowB.Delegation)
+	}
+
+	// l3c: old-style receipt — all Layer 3 fields empty/nil.
+	if rowC.CorrelationID != "" {
+		t.Errorf("l3c CorrelationID: got %q, want empty", rowC.CorrelationID)
+	}
+	if rowC.AgentID != "" {
+		t.Errorf("l3c AgentID: got %q, want empty", rowC.AgentID)
+	}
+	if rowC.SessionID != "" {
+		t.Errorf("l3c SessionID: got %q, want empty", rowC.SessionID)
+	}
+	if rowC.Delegation != nil {
+		t.Errorf("l3c Delegation: got %+v, want nil", rowC.Delegation)
+	}
+}
+
+// TestReader_Layer3_DelegationMalformed verifies that a malformed delegation
+// JSON value does not error — it results in nil Delegation (graceful
+// degradation for forward-compat payloads the dashboard can't fully parse).
+func TestReader_Layer3_DelegationMalformed(t *testing.T) {
+	dbPath := t.TempDir() + "/layer3-malformed.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	base := makeReceipt("urn:receipt:dm1", "chain-dm", 1, "tool.call",
+		receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z", nil)
+	hash, err := receipt.HashReceipt(base)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+
+	rawJSON, err := json.Marshal(base)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var m map[string]any
+	if err := json.Unmarshal(rawJSON, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	cs, _ := m["credentialSubject"].(map[string]any)
+	if cs == nil {
+		cs = map[string]any{}
+	}
+	// Inject a delegation field with missing required keys — should parse to nil.
+	cs["delegation"] = map[string]any{"unexpected_key": "value"}
+	m["credentialSubject"] = cs
+
+	augmented, _ := json.Marshal(m)
+	if err := s.InsertRaw(base, augmented, hash); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	s.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	rows, err := reader.ListReceipts(Filter{})
+	if err != nil {
+		t.Fatalf("list: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows, want 1", len(rows))
+	}
+	if rows[0].Delegation != nil {
+		t.Errorf("want nil Delegation for empty-keys object, got %+v", rows[0].Delegation)
 	}
 }
 


### PR DESCRIPTION
## Summary

Daemon v0.17.0-alpha.1 and hook v0.14.0-alpha.1 now emit three new fields per receipt: `issuer.agent_id`, `issuer.session_id`, `credentialSubject.correlation_id`, and `credentialSubject.delegation`. This PR surfaces those fields in the store layer and renders them in the Receipts UI.

### Store (`internal/store/reader.go`)
- Added `CorrelationID`, `AgentID`, `SessionID`, `Delegation` fields to `ReceiptRow`
- Added `DelegationInfo` struct mapping `credentialSubject.delegation` (parent_chain_id, parent_receipt_id, delegator.id)
- Extended `ListReceipts` SQL with four `json_extract()` columns — old receipts scan as empty string / NULL with no error
- Added `parseDelegationJSON` helper: returns nil when required keys are absent or JSON is malformed (forward-compat)

### Tests (`internal/store/reader_test.go`)
- `TestReader_Layer3_GracefulDegradation` — verifies old receipts produce empty/nil Layer 3 fields
- `TestReader_Layer3_NewFields` — verifies all four fields are extracted correctly from augmented JSON
- `TestReader_Layer3_DelegationMalformed` — verifies bad/partial delegation JSON → nil Delegation, no error

### UI (`internal/server/static/index.html`)
- **Session-grouped table** — when any receipt in the result set has a `session_id`, the flat table is replaced with a grouped layout; collapsible session headers keyed by `session_id`
- **Subagent swimlanes** — within each session, receipts split by `agent_id`; root agent labelled "Orchestrator", spawned agents labelled "↳ Subagent \<id\>"
- **Delegation edges** — subagent swimlane headers show `← <parent_chain_id>` when the first receipt of that agent carries `credentialSubject.delegation`
- **Correlation pairs** — receipts sharing a `correlation_id` collapsed to a single row showing `pre-status → post-status` with a `pre+post` badge; clicking opens the post-action receipt
- **Graceful degradation** — receipts without `session_id` render in a "Legacy receipts" section at the bottom; the flat table is unchanged for old receipt sets
- Nav selector updated to `tr[data-receipt-id]` to skip session/agent header rows in keyboard nav
- Match count fix: filter by `data-receipt-id` rather than `tbody.rows.length` in live-polling update path

## Test plan

- [ ] `go test ./...` passes (run in worktree)
- [ ] `go vet ./...` passes
- [ ] Open dashboard with a receipt DB containing no `session_id` fields → flat table renders normally
- [ ] Open dashboard with a DB seeded with `session_id` / `agent_id` / `correlation_id` / `delegation` → grouped layout appears
- [ ] Session collapse button hides/shows all rows in that session
- [ ] Correlated pair rows show `pre+post` badge and both statuses; clicking opens the post-action receipt
- [ ] Delegation edge shows `← parent_chain_id` on subagent swimlane header
- [ ] Keyboard nav (↑/↓) skips session/agent header rows correctly
- [ ] Live polling match count is correct in grouped view