### PR TITLE
feat: keyboard navigation between receipts in detail view (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Keyboard navigation between receipts in the detail view** — while the receipt detail modal is open, pressing `j` / `↓` opens the next receipt in the current list and `k` / `↑` opens the previous one. Navigation stops at the ends (no wrap). Works correctly in both flat and grouped table layouts; session/agent header rows are skipped. The keyboard shortcuts help modal documents these new bindings.
+
 ## [0.7.0-alpha.1] - 2026-06-09
 
 ### Added

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -889,6 +889,8 @@
           <div class="shortcut-row"><span class="shortcut-desc">Next row</span><span class="shortcut-keys"><span class="kbd">j</span><span class="kbd">↓</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Previous row</span><span class="shortcut-keys"><span class="kbd">k</span><span class="kbd">↑</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Open focused row</span><span class="shortcut-keys"><span class="kbd">↵</span></span></div>
+          <div class="shortcut-row"><span class="shortcut-desc">Next receipt (in detail view)</span><span class="shortcut-keys"><span class="kbd">j</span><span class="kbd">↓</span></span></div>
+          <div class="shortcut-row"><span class="shortcut-desc">Previous receipt (in detail view)</span><span class="shortcut-keys"><span class="kbd">k</span><span class="kbd">↑</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Close modal / blur input</span><span class="shortcut-keys"><span class="kbd">Esc</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Go to Overview</span><span class="shortcut-keys"><span class="kbd">g</span><span class="kbd">o</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Go to Receipts</span><span class="shortcut-keys"><span class="kbd">g</span><span class="kbd">r</span></span></div>
@@ -3226,6 +3228,20 @@
     function showShortcuts()   { openModal('shortcuts-modal'); }
     function closeShortcuts()  { closeModalById('shortcuts-modal'); }
 
+    // Navigate to the next (+1) or previous (-1) receipt in the current table
+    // when the receipt detail modal is open. Rows without [data-receipt-id] (e.g.
+    // session/agent header rows in grouped mode) are skipped. Stops at the ends.
+    function navigateReceipt(delta) {
+      if (!currentReceipt) return;
+      const rows = Array.from(document.querySelectorAll('#receipts-table tbody tr[data-receipt-id]'));
+      if (rows.length === 0) return;
+      const idx = rows.findIndex(r => r.dataset.receiptId === currentReceipt.id);
+      if (idx < 0) return;
+      const next = idx + delta;
+      if (next < 0 || next >= rows.length) return;
+      showReceipt(rows[next].dataset.receiptId);
+    }
+
     function isModalOpen() {
       return ['receipt-modal','chain-modal','shortcuts-modal','forensic-modal'].some(id => !document.getElementById(id).hidden);
     }
@@ -3812,6 +3828,18 @@
 
       // Don't intercept while typing in a filter input.
       if (isTypingTarget(e.target)) return;
+
+      // When the receipt detail modal is open, j/↓ and k/↑ navigate between
+      // receipts in the current list. All other keys (except Esc above) are
+      // blocked while any modal is open.
+      if (!document.getElementById('receipt-modal').hidden) {
+        if (e.key === 'j' || e.key === 'ArrowDown') {
+          e.preventDefault(); navigateReceipt(+1); return;
+        }
+        if (e.key === 'k' || e.key === 'ArrowUp') {
+          e.preventDefault(); navigateReceipt(-1); return;
+        }
+      }
 
       // Don't intercept while a modal is open (Esc handled above is the only key).
       if (isModalOpen()) return;

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -886,11 +886,11 @@
         <div class="modal-body">
           <div class="shortcut-row"><span class="shortcut-desc">Show this help</span><span class="shortcut-keys"><span class="kbd">?</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Focus action filter</span><span class="shortcut-keys"><span class="kbd">/</span></span></div>
-          <div class="shortcut-row"><span class="shortcut-desc">Next row</span><span class="shortcut-keys"><span class="kbd">j</span><span class="kbd">↓</span></span></div>
-          <div class="shortcut-row"><span class="shortcut-desc">Previous row</span><span class="shortcut-keys"><span class="kbd">k</span><span class="kbd">↑</span></span></div>
+          <div class="shortcut-row"><span class="shortcut-desc">Next row (receipts table)</span><span class="shortcut-keys"><span class="kbd">j</span><span class="kbd">↓</span></span></div>
+          <div class="shortcut-row"><span class="shortcut-desc">Previous row (receipts table)</span><span class="shortcut-keys"><span class="kbd">k</span><span class="kbd">↑</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Open focused row</span><span class="shortcut-keys"><span class="kbd">↵</span></span></div>
-          <div class="shortcut-row"><span class="shortcut-desc">Next receipt (in detail view)</span><span class="shortcut-keys"><span class="kbd">j</span><span class="kbd">↓</span></span></div>
-          <div class="shortcut-row"><span class="shortcut-desc">Previous receipt (in detail view)</span><span class="shortcut-keys"><span class="kbd">k</span><span class="kbd">↑</span></span></div>
+          <div class="shortcut-row"><span class="shortcut-desc">Next receipt (detail view open)</span><span class="shortcut-keys"><span class="kbd">j</span><span class="kbd">↓</span></span></div>
+          <div class="shortcut-row"><span class="shortcut-desc">Previous receipt (detail view open)</span><span class="shortcut-keys"><span class="kbd">k</span><span class="kbd">↑</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Close modal / blur input</span><span class="shortcut-keys"><span class="kbd">Esc</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Go to Overview</span><span class="shortcut-keys"><span class="kbd">g</span><span class="kbd">o</span></span></div>
           <div class="shortcut-row"><span class="shortcut-desc">Go to Receipts</span><span class="shortcut-keys"><span class="kbd">g</span><span class="kbd">r</span></span></div>
@@ -3231,15 +3231,18 @@
     // Navigate to the next (+1) or previous (-1) receipt in the current table
     // when the receipt detail modal is open. Rows without [data-receipt-id] (e.g.
     // session/agent header rows in grouped mode) are skipped. Stops at the ends.
+    // The flag prevents concurrent in-flight fetches when keys are pressed quickly.
+    let receiptNavigating = false;
     function navigateReceipt(delta) {
-      if (!currentReceipt) return;
+      if (!currentReceipt || receiptNavigating) return;
       const rows = Array.from(document.querySelectorAll('#receipts-table tbody tr[data-receipt-id]'));
       if (rows.length === 0) return;
       const idx = rows.findIndex(r => r.dataset.receiptId === currentReceipt.id);
       if (idx < 0) return;
       const next = idx + delta;
       if (next < 0 || next >= rows.length) return;
-      showReceipt(rows[next].dataset.receiptId);
+      receiptNavigating = true;
+      showReceipt(rows[next].dataset.receiptId).finally(() => { receiptNavigating = false; });
     }
 
     function isModalOpen() {


### PR DESCRIPTION
## What

When the receipt detail modal is open, `j` / `↓` navigates to the next receipt in the current list and `k` / `↑` navigates to the previous one. Navigation stops at the ends (no wrap). The keyboard shortcuts help modal is updated to document these bindings.

Closes #112.

## Why

Makes it faster to step through a sequence of receipts without closing and reopening the modal for each one — particularly useful when reviewing a chain of events or a session group.

## Implementation notes

- `navigateReceipt(delta)` queries `#receipts-table tbody tr[data-receipt-id]` to build the ordered row list, locates the currently open receipt by ID, and calls `showReceipt()` on the neighbour. The `[data-receipt-id]` selector naturally skips session/agent header rows in grouped mode.
- The keydown handler intercepts `j`/`↓` and `k`/`↑` specifically when `#receipt-modal` is not hidden, before the existing `isModalOpen()` guard that blocks all other keys. `isTypingTarget()` check is still applied, so focused inputs are unaffected.
- No Go changes — frontend only.

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] New functionality includes tests
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] AGENTS.md updated if project structure changed
- [x] Request a Copilot review for automated checks