### PR TITLE
feat: filter receipts by session_id (#110)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Session ID filter** — the Receipts tab now has a "Session ID" filter input that restricts the list to receipts from a specific agent session (`issuer.session_id` exact match). Clicking a session header in the grouped view pre-fills this input and reloads. The "Clear filters" / per-chip clear buttons also clear the new input. The `GET /api/receipts` endpoint accepts a `session_id` query parameter backed by a `json_extract` WHERE clause.
-- **Session column in receipts table** — a Session column (first 8 chars of `issuer.session_id`) appears after Seq in both the flat and grouped receipts table. Clicking the session chip pre-fills the Session ID filter and reloads the list. Receipts without a session ID show a dash.
+- **Session column in receipts table** — a Session column (truncated to 8 chars with the full ID in a tooltip) appears after Seq in both the flat and grouped receipts table. Clicking the session chip pre-fills the Session ID filter and reloads the list. Receipts without a session ID show a dash.
 - **Session link in receipt detail modal** — the receipt detail view now shows a clickable Session field (below Chain) when the receipt carries an `issuer.session_id`. Clicking closes the modal and filters the receipts list to that session.
 
 ## [0.7.0-alpha.1] - 2026-06-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Session ID filter** — the Receipts tab now has a "Session ID" filter input that restricts the list to receipts from a specific agent session (`issuer.session_id` exact match). Clicking a session header in the grouped view pre-fills this input and reloads. The "Clear filters" / per-chip clear buttons also clear the new input. The `GET /api/receipts` endpoint accepts a `session_id` query parameter backed by a `json_extract` WHERE clause.
+- **Session column in receipts table** — a Session column (first 8 chars of `issuer.session_id`) appears after Seq in both the flat and grouped receipts table. Clicking the session chip pre-fills the Session ID filter and reloads the list. Receipts without a session ID show a dash.
+- **Session link in receipt detail modal** — the receipt detail view now shows a clickable Session field (below Chain) when the receipt carries an `issuer.session_id`. Clicking closes the modal and filters the receipts list to that session.
 
 ## [0.7.0-alpha.1] - 2026-06-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Session ID filter** — the Receipts tab now has a "Session ID" filter input that restricts the list to receipts from a specific agent session (`issuer.session_id` exact match). Clicking a session header in the grouped view pre-fills this input and reloads. The "Clear filters" / per-chip clear buttons also clear the new input. The `GET /api/receipts` endpoint accepts a `session_id` query parameter backed by a `json_extract` WHERE clause.
+
 ## [0.7.0-alpha.1] - 2026-06-09
 
 ### Added

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -391,7 +391,7 @@ func (s *Server) handleReceipts(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("tool_name"); v != "" {
 		f.ToolName = &v
 	}
-	if v := q.Get("session_id"); v != "" {
+	if v := strings.TrimSpace(q.Get("session_id")); v != "" {
 		f.SessionID = &v
 	}
 	if v := q.Get("q"); v != "" {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -391,6 +391,9 @@ func (s *Server) handleReceipts(w http.ResponseWriter, r *http.Request) {
 	if v := q.Get("tool_name"); v != "" {
 		f.ToolName = &v
 	}
+	if v := q.Get("session_id"); v != "" {
+		f.SessionID = &v
+	}
 	if v := q.Get("q"); v != "" {
 		f.Q = &v
 	}

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -820,6 +820,10 @@
           <label class="form-label" for="filter-tool">Tool</label>
           <input type="text" id="filter-tool" placeholder="list_pull_requests" oninput="debounceLoadReceipts()">
         </div>
+        <div class="form-field">
+          <label class="form-label" for="filter-session">Session ID</label>
+          <input type="text" id="filter-session" placeholder="session-…" oninput="debounceLoadReceipts()">
+        </div>
       </div>
 
       <div class="filter-bar-meta">
@@ -2150,16 +2154,18 @@
       const risk   = document.getElementById('filter-risk').value;
       const status = document.getElementById('filter-status').value;
       const action = document.getElementById('filter-action').value;
-      const chain  = document.getElementById('filter-chain').value;
-      const server = document.getElementById('filter-server').value;
-      const tool   = document.getElementById('filter-tool').value;
-      if (q)      f.q           = q;
-      if (risk)   f.risk_level  = risk;
-      if (status) f.status      = status;
-      if (action) f.action_type = action;
-      if (chain)  f.chain_id    = chain;
-      if (server) f.server      = server;
-      if (tool)   f.tool_name   = tool;
+      const chain   = document.getElementById('filter-chain').value;
+      const server  = document.getElementById('filter-server').value;
+      const tool    = document.getElementById('filter-tool').value;
+      const session = document.getElementById('filter-session').value;
+      if (q)       f.q           = q;
+      if (risk)    f.risk_level  = risk;
+      if (status)  f.status      = status;
+      if (action)  f.action_type = action;
+      if (chain)   f.chain_id    = chain;
+      if (server)  f.server      = server;
+      if (tool)    f.tool_name   = tool;
+      if (session) f.session_id  = session;
       return f;
     }
 
@@ -2207,7 +2213,7 @@
     }
 
     function renderFilterChips(filters) {
-      const labels = { q: 'search', risk_level: 'risk', status: 'status', action_type: 'action', chain_id: 'chain', server: 'server', tool_name: 'tool' };
+      const labels = { q: 'search', risk_level: 'risk', status: 'status', action_type: 'action', chain_id: 'chain', server: 'server', tool_name: 'tool', session_id: 'session' };
       const entries = Object.entries(filters);
       const chips = entries.map(([k, v]) => `
         <span class="chip">
@@ -2223,17 +2229,24 @@
     }
 
     function clearFilter(key) {
-      const map = { q: 'filter-q', risk_level: 'filter-risk', status: 'filter-status', action_type: 'filter-action', chain_id: 'filter-chain', server: 'filter-server', tool_name: 'filter-tool' };
+      const map = { q: 'filter-q', risk_level: 'filter-risk', status: 'filter-status', action_type: 'filter-action', chain_id: 'filter-chain', server: 'filter-server', tool_name: 'filter-tool', session_id: 'filter-session' };
       const el = document.getElementById(map[key]);
       if (el) { el.value = ''; loadReceipts(); }
     }
 
     function clearAllFilters() {
-      ['filter-q', 'filter-risk', 'filter-status', 'filter-action', 'filter-chain', 'filter-server', 'filter-tool'].forEach(id => {
+      ['filter-q', 'filter-risk', 'filter-status', 'filter-action', 'filter-chain', 'filter-server', 'filter-tool', 'filter-session'].forEach(id => {
         const el = document.getElementById(id);
         if (el) el.value = '';
       });
       loadReceipts();
+    }
+
+    // filterBySession pre-fills the Session ID filter with sid and reloads the
+    // receipts table. Called when the user clicks a session header in the grouped view.
+    function filterBySession(sid) {
+      const el = document.getElementById('filter-session');
+      if (el) { el.value = sid; loadReceipts(); }
     }
 
     function receiptRowHTML(r, opts) {
@@ -2502,7 +2515,7 @@
                <td colspan="${COL_COUNT}">
                  <div class="session-header-inner">
                    <button type="button" class="session-collapse-btn" data-target-session="${safeEsc}" onclick="toggleSession(this)" aria-expanded="true" aria-label="Collapse session">▾</button>
-                   <span class="font-mono" style="font-size:0.8rem;color:var(--accent);" title="${safeEsc}">${escapeHtml(truncate(sid, 40))}</span>
+                   <span class="font-mono" style="font-size:0.8rem;color:var(--accent);cursor:pointer;" title="Filter by this session" onclick="filterBySession(${JSON.stringify(sid)})">${escapeHtml(truncate(sid, 40))}</span>
                    <span style="font-size:0.72rem;color:var(--subtle);">· ${countLabel} · latest ${escapeHtml(timeLabel)}</span>
                  </div>
                </td>

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -2517,7 +2517,7 @@
                <td colspan="${COL_COUNT}">
                  <div class="session-header-inner">
                    <button type="button" class="session-collapse-btn" data-target-session="${safeEsc}" onclick="toggleSession(this)" aria-expanded="true" aria-label="Collapse session">▾</button>
-                   <span class="font-mono" style="font-size:0.8rem;color:var(--accent);cursor:pointer;" title="Filter by this session" onclick="filterBySession(${JSON.stringify(sid)})">${escapeHtml(truncate(sid, 40))}</span>
+                   <span class="font-mono" style="font-size:0.8rem;color:var(--accent);cursor:pointer;" title="Filter by this session" data-session-id="${safeEsc}" onclick="filterBySession(this.dataset.sessionId)">${escapeHtml(truncate(sid, 40))}</span>
                    <span style="font-size:0.72rem;color:var(--subtle);">· ${countLabel} · latest ${escapeHtml(timeLabel)}</span>
                  </div>
                </td>

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -2517,7 +2517,7 @@
                <td colspan="${COL_COUNT}">
                  <div class="session-header-inner">
                    <button type="button" class="session-collapse-btn" data-target-session="${safeEsc}" onclick="toggleSession(this)" aria-expanded="true" aria-label="Collapse session">▾</button>
-                   <span class="font-mono" style="font-size:0.8rem;color:var(--accent);cursor:pointer;" title="Filter by this session" data-session-id="${safeEsc}" onclick="filterBySession(this.dataset.sessionId)">${escapeHtml(truncate(sid, 40))}</span>
+                   <button type="button" class="font-mono session-filter-btn" style="font-size:0.8rem;color:var(--accent);background:none;border:none;padding:0;cursor:pointer;" title="${safeEsc}" data-session-id="${safeEsc}" onclick="filterBySession(this.dataset.sessionId)">${escapeHtml(truncate(sid, 40))}</button>
                    <span style="font-size:0.72rem;color:var(--subtle);">· ${countLabel} · latest ${escapeHtml(timeLabel)}</span>
                  </div>
                </td>

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -2265,6 +2265,7 @@
           <td><span class="badge ${statusClass(r.status)}">${escapeHtml(r.status)}</span>${mismatchIndicatorHTML(r)}</td>
           <td class="muted font-mono text-xs" data-chain-id="${escapeAttr(r.chain_id)}" onclick="event.stopPropagation(); showChain(this.dataset.chainId)" style="cursor:pointer;">${escapeHtml(truncate(r.chain_id, 20))}</td>
           <td class="muted">#${r.sequence}</td>
+          <td class="muted font-mono text-xs">${r.session_id ? `<span data-session-id="${escapeAttr(r.session_id)}" onclick="event.stopPropagation(); filterBySession(this.dataset.sessionId)" style="cursor:pointer;" title="${escapeAttr(r.session_id)}">${escapeHtml(truncate(r.session_id, 8))}</span>` : '<span class="subtle">—</span>'}</td>
         </tr>
       `;
     }
@@ -2367,6 +2368,7 @@
                   <th>Status</th>
                   <th>Chain</th>
                   <th>Seq</th>
+                  <th>Session</th>
                 </tr>
               </thead>
               <tbody id="${tbodyIdFor(containerId)}">
@@ -2484,8 +2486,8 @@
     }
 
     // Number of columns in the receipts table (Time, Server, Tool, Action,
-    // Risk, Status, Chain, Seq). Used as colspan for session/agent header rows.
-    const RECEIPT_COLS = 8;
+    // Risk, Status, Chain, Seq, Session). Used as colspan for session/agent header rows.
+    const RECEIPT_COLS = 9;
 
     // renderGroupedReceiptsTable renders the receipts view with session headers,
     // per-agent swimlane sub-headers, collapsed correlation pairs, and
@@ -2557,7 +2559,7 @@
               <thead>
                 <tr>
                   <th>Time</th><th>Server</th><th>Tool</th><th>Action</th>
-                  <th>Risk</th><th>Status</th><th>Chain</th><th>Seq</th>
+                  <th>Risk</th><th>Status</th><th>Chain</th><th>Seq</th><th>Session</th>
                 </tr>
               </thead>
               <tbody id="${tbodyIdFor(containerId)}">
@@ -2596,6 +2598,7 @@
           </td>
           <td class="muted font-mono text-xs" data-chain-id="${escapeAttr(post.chain_id)}" onclick="event.stopPropagation(); showChain(this.dataset.chainId)" style="cursor:pointer;">${escapeHtml(truncate(post.chain_id, 20))}</td>
           <td class="muted">#${pre.sequence}–${post.sequence}</td>
+          <td class="muted font-mono text-xs">${sessionId ? `<span data-session-id="${escapeAttr(sessionId)}" onclick="event.stopPropagation(); filterBySession(this.dataset.sessionId)" style="cursor:pointer;" title="${escapeAttr(sessionId)}">${escapeHtml(truncate(sessionId, 8))}</span>` : '<span class="subtle">—</span>'}</td>
         </tr>
       `;
     }
@@ -2875,6 +2878,15 @@
               — Sequence #${subj.chain.sequence}
             </div>
           </div>
+
+          ${r.issuer && r.issuer.session_id ? `
+          <div>
+            <div class="muted text-xs mb-1">Session</div>
+            <div class="text-sm">
+              <span class="font-mono text-xs accent" style="cursor:pointer;" title="${escapeAttr(r.issuer.session_id)}" data-session-id="${escapeAttr(r.issuer.session_id)}" onclick="closeModal(); filterBySession(this.dataset.sessionId)">${escapeHtml(truncate(r.issuer.session_id, 8))}</span>
+            </div>
+          </div>
+          ` : ''}
 
           <details class="mt-4">
             <summary class="muted text-sm" style="cursor:pointer;">Raw JSON</summary>

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -168,13 +168,14 @@ type Filter struct {
 	ActionType *string
 	RiskLevel  *string
 	Status     *string
-	Server     *string // target.system value (exact match)
-	ToolName   *string // tool_name column (exact match)
-	After      *string // ISO 8601 timestamp, inclusive
-	Before     *string // ISO 8601 timestamp, inclusive
-	Since      *string // ISO 8601 timestamp, inclusive — watermark for live polling; clients dedup by id
+	Server     *string    // target.system value (exact match)
+	ToolName   *string    // tool_name column (exact match)
+	SessionID  *string    // issuer.session_id value (exact match)
+	After      *string    // ISO 8601 timestamp, inclusive
+	Before     *string    // ISO 8601 timestamp, inclusive
+	Since      *string    // ISO 8601 timestamp, inclusive — watermark for live polling; clients dedup by id
 	Limit      *int
-	Q          *string // free-text search against the raw receipt JSON; nil or whitespace-only means no filter
+	Q          *string    // free-text search against the raw receipt JSON; nil or whitespace-only means no filter
 }
 
 // OpenReadOnly opens an existing receipt SQLite database in read-only mode.
@@ -255,6 +256,10 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 	if f.Server != nil {
 		conds = append(conds, "json_extract(receipt_json, '$.credentialSubject.action.target.system') = ?")
 		args = append(args, *f.Server)
+	}
+	if f.SessionID != nil {
+		conds = append(conds, "json_extract(receipt_json, '$.issuer.session_id') = ?")
+		args = append(args, *f.SessionID)
 	}
 	if f.After != nil {
 		conds = append(conds, "timestamp >= ?")

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -1926,6 +1926,85 @@ func TestReader_Layer3_NewFields(t *testing.T) {
 	}
 }
 
+// TestReader_ListReceipts_FilterBySessionID verifies that the session_id filter
+// returns only receipts whose issuer.session_id matches the supplied value.
+func TestReader_ListReceipts_FilterBySessionID(t *testing.T) {
+	dbPath := t.TempDir() + "/session-filter-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	// Two receipts in session-alpha, one in session-beta, one with no session.
+	r1 := makeReceipt("urn:receipt:sf1", "chain-sf", 1, "tool.call",
+		receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z", nil)
+	r1.Issuer.SessionID = "session-alpha"
+	insertLayer3(t, s, r1, "", "", nil)
+
+	r2 := makeReceipt("urn:receipt:sf2", "chain-sf", 2, "tool.call",
+		receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:01:00Z", nil)
+	r2.Issuer.SessionID = "session-alpha"
+	insertLayer3(t, s, r2, "", "", nil)
+
+	r3 := makeReceipt("urn:receipt:sf3", "chain-sf", 3, "tool.call",
+		receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:02:00Z", nil)
+	r3.Issuer.SessionID = "session-beta"
+	insertLayer3(t, s, r3, "", "", nil)
+
+	// Old-style receipt with no session_id at all.
+	r4 := makeReceipt("urn:receipt:sf4", "chain-sf-old", 1, "tool.call",
+		receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:03:00Z", nil)
+	hash4, err := receipt.HashReceipt(r4)
+	if err != nil {
+		t.Fatalf("hash: %v", err)
+	}
+	if err := s.Insert(r4, hash4); err != nil {
+		t.Fatalf("insert old receipt: %v", err)
+	}
+	s.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	// Filter by session-alpha — should return 2 rows.
+	rows, err := reader.ListReceipts(Filter{SessionID: strPtr("session-alpha")})
+	if err != nil {
+		t.Fatalf("list by session-alpha: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Errorf("got %d rows for session-alpha, want 2", len(rows))
+	}
+	for _, row := range rows {
+		if row.SessionID != "session-alpha" {
+			t.Errorf("row %s: session_id = %q, want session-alpha", row.ID, row.SessionID)
+		}
+	}
+
+	// Filter by session-beta — should return 1 row.
+	rows, err = reader.ListReceipts(Filter{SessionID: strPtr("session-beta")})
+	if err != nil {
+		t.Fatalf("list by session-beta: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Errorf("got %d rows for session-beta, want 1", len(rows))
+	}
+	if len(rows) == 1 && rows[0].ID != "urn:receipt:sf3" {
+		t.Errorf("session-beta row ID = %q, want urn:receipt:sf3", rows[0].ID)
+	}
+
+	// Filter by a non-existent session — should return 0 rows.
+	rows, err = reader.ListReceipts(Filter{SessionID: strPtr("session-nonexistent")})
+	if err != nil {
+		t.Fatalf("list by nonexistent session: %v", err)
+	}
+	if len(rows) != 0 {
+		t.Errorf("got %d rows for nonexistent session, want 0", len(rows))
+	}
+}
+
 // TestReader_Layer3_DelegationMalformed verifies that a malformed delegation
 // JSON value does not error — it results in nil Delegation (graceful
 // degradation for forward-compat payloads the dashboard can't fully parse).


### PR DESCRIPTION
## Summary

- Adds a **Session ID** filter input to the Receipts tab filter bar; typing an exact `session_id` value restricts the list to matching receipts.
- Clicking a session header in the grouped view pre-fills the input with that session's ID and triggers a reload.
- "Clear filters" and per-chip clear buttons also clear the new input.
- Backend: `Filter.SessionID *string` added to `store.Filter`; `ListReceipts` appends a `json_extract(receipt_json, '$.issuer.session_id') = ?` WHERE clause when set. `handleReceipts` reads the `session_id` query parameter.

## Test plan

- [ ] `go test ./...` passes (new `TestReader_ListReceipts_FilterBySessionID` covers two-match, one-match, and zero-match cases using `insertLayer3`)
- [ ] `go vet ./...` passes
- [ ] Load the dashboard against a store with session-grouped receipts; confirm typing a session ID in the new input narrows the list correctly
- [ ] Confirm clicking a session header pre-fills the input and reloads
- [ ] Confirm "Clear filters" and the chip ×-button both clear the session filter
- [ ] Confirm old receipts (no `session_id`) are unaffected when no session filter is set

Closes #110