### PR TITLE
chore(release): bump to v0.7.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0-alpha.2] - 2026-06-09
+
 ### Added
 
 - **Session ID filter** — the Receipts tab now has a "Session ID" filter input that restricts the list to receipts from a specific agent session (`issuer.session_id` exact match). Clicking a session header in the grouped view pre-fills this input and reloads. The "Clear filters" / per-chip clear buttons also clear the new input. The `GET /api/receipts` endpoint accepts a `session_id` query parameter backed by a `json_extract` WHERE clause.


### PR DESCRIPTION
Moves the `[Unreleased]` CHANGELOG entries into `[0.7.0-alpha.2]`.

After merging, tag `v0.7.0-alpha.2` on main to trigger the release workflow.