### PR TITLE
fix: fall back to issuer.id for Sessions tab agent count

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Sessions tab agent count** — sessions now always show at least 1 agent. Previously the agent count used `issuer.agent_id`, a Layer 3 extension field not yet produced by any current daemon version, so the count was always 0. The query now falls back to `issuer.id` when `agent_id` is absent; once the daemon starts emitting `agent_id` for multi-agent sessions, the correct subagent count will appear automatically.
+
 ## [0.7.0-alpha.2] - 2026-06-09
 
 ### Added

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -626,7 +626,7 @@ func (r *Reader) SessionStats(since *string) ([]SessionRow, error) {
 		SELECT
 			json_extract(receipt_json, '$.issuer.session_id') AS session_id,
 			COUNT(*) AS receipt_count,
-			COUNT(DISTINCT NULLIF(json_extract(receipt_json, '$.issuer.agent_id'), '')) AS agent_count,
+			COUNT(DISTINCT COALESCE(NULLIF(json_extract(receipt_json, '$.issuer.agent_id'), ''), json_extract(receipt_json, '$.issuer.id'))) AS agent_count,
 			MIN(timestamp) AS first_seen,
 			MAX(timestamp) AS last_seen
 		FROM receipts


### PR DESCRIPTION
## Summary

- `issuer.agent_id` is a Layer 3 extension field not yet emitted by any current daemon version — the agent count was therefore always 0 for all real sessions
- The `SessionStats` query now falls back to `issuer.id` via `COALESCE(NULLIF(issuer.agent_id, ''), issuer.id)` — current receipts show ≥ 1 agent per session; once the daemon starts emitting `agent_id` the correct subagent count will appear automatically

## Test plan

- [ ] Existing `TestReader_SessionStats` and `TestSessionsEndpoint` tests still pass (they seed `agent_id` explicitly, so they exercise the `agent_id` path and remain valid)
- [ ] Sessions tab in the dashboard shows ≥ 1 agent for real sessions instead of 0