### PR TITLE
feat: read sub-agent identity from issuer.runtime (ADR-0026)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/dashboard
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.15.0
+	github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1
 	modernc.org/sqlite v1.52.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.15.0 h1:kMix5RHLn1dhdvPr5CrajluoUHEQVMW4xxKNLQ/PVDs=
-github.com/agent-receipts/ar/sdk/go v0.15.0/go.mod h1:beOZmNsSk/I9KrU46xJcegIFN3Fo0bdXo8luHhUmeuc=
+github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1 h1:4R1Bnhf3KQ5/jDz/yDyljTO4XgLUtqemGtEoAvmhdms=
+github.com/agent-receipts/ar/sdk/go v0.17.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1060,7 +1060,7 @@ func seedSessionsDB(t *testing.T) *Server {
 		t.Fatalf("open sdk store: %v", err)
 	}
 
-	// injectSession augments a receipt's JSON with issuer.session_id/agent_id
+	// injectSession augments a receipt's JSON with issuer.session_id and issuer.runtime.agent_id
 	// and inserts it via InsertRaw (same pattern as TestChainVerifyEndpoint_ForwardCompatChain).
 	injectSession := func(r receipt.AgentReceipt, sessionID, agentID string) {
 		var m map[string]any
@@ -1079,7 +1079,8 @@ func seedSessionsDB(t *testing.T) *Server {
 			issuer["session_id"] = sessionID
 		}
 		if agentID != "" {
-			issuer["agent_id"] = agentID
+			// agent_id lives under the issuer.runtime open sub-object (ADR-0026).
+			issuer["runtime"] = map[string]any{"agent_id": agentID}
 		}
 		m["issuer"] = issuer
 		raw, _ := json.Marshal(m)

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -2556,6 +2556,7 @@
           const a = session.agents.get(aid);
           return {
             agentId:    aid,
+            agentType:  (a.rawRows.find(r => r.agent_type) || {}).agent_type || null,
             delegation: a.delegation,
             rows:       collapseCorrelationPairs(a.rawRows),
           };
@@ -2649,9 +2650,12 @@
         const agentRowsHTML = session.agents.map(agent => {
           const aid    = agent.agentId;   // null for root/orchestrator agent
           const isRoot = aid === null;
+          const aTypeBadge = (!isRoot && agent.agentType)
+            ? `<span class="agent-type-badge" style="font-size:0.65rem;color:var(--muted);margin-left:0.4rem;">${escapeHtml(agent.agentType)}</span>`
+            : '';
           const aLabel = isRoot
             ? `<span class="agent-root-label">Orchestrator</span>`
-            : `<span class="agent-sub-label">↳ Subagent</span><span class="font-mono" style="font-size:0.7rem;color:var(--text);">${escapeHtml(aid)}</span>`;
+            : `<span class="agent-sub-label">↳ Subagent</span><span class="font-mono" style="font-size:0.7rem;color:var(--text);">${escapeHtml(aid)}</span>${aTypeBadge}`;
 
           const delEdge = agent.delegation
             ? `<span class="delegation-edge" title="Delegated from ${escapeAttr(agent.delegation.parent_chain_id)}">← ${escapeHtml(truncate(agent.delegation.parent_chain_id, 28))}</span>`
@@ -2979,6 +2983,8 @@
               <div class="muted text-xs mb-1">Issuer</div>
               <div class="font-mono text-xs">${escapeHtml(r.issuer.id)}</div>
               ${r.issuer.name ? `<div class="muted text-xs">${escapeHtml(r.issuer.name)}</div>` : ''}
+              ${r.issuer.runtime && r.issuer.runtime.agent_id ? `<div class="muted text-xs mt-1">runtime.agent_id <span class="font-mono" style="color:var(--text);">${escapeHtml(r.issuer.runtime.agent_id)}</span></div>` : ''}
+              ${r.issuer.runtime && r.issuer.runtime.agent_type ? `<div class="muted text-xs">runtime.agent_type <span class="font-mono" style="color:var(--text);">${escapeHtml(r.issuer.runtime.agent_type)}</span></div>` : ''}
             </div>
             <div>
               <div class="muted text-xs mb-1">Principal</div>

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -62,8 +62,12 @@ type ReceiptRow struct {
 	// receipt for the same tool call (same tool_use_id).
 	CorrelationID string `json:"correlation_id,omitempty"`
 	// AgentID identifies which subagent issued this receipt (orchestrator vs
-	// spawned subagent). Comes from issuer.agent_id in the receipt JSON.
+	// spawned subagent). Comes from issuer.runtime.agent_id in the receipt JSON
+	// (the issuer.runtime open metadata sub-object, daemon ≥ v0.18.0 / ADR-0026).
 	AgentID string `json:"agent_id,omitempty"`
+	// AgentType is the runtime-reported agent type label (e.g. "general-purpose"),
+	// from issuer.runtime.agent_type.
+	AgentType string `json:"agent_type,omitempty"`
 	// SessionID groups all receipts from the same agent session together.
 	// Comes from issuer.session_id in the receipt JSON.
 	SessionID string `json:"session_id,omitempty"`
@@ -312,8 +316,10 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 	// on text that json_valid has cleared — SQL AND does not short-circuit,
 	// and json_extract on non-JSON text raises a "malformed JSON" error.
 	//
-	// The last four columns are Layer 3 attribution fields (daemon ≥ v0.17.0).
-	// They are absent from older receipts and will scan as empty strings / NULL.
+	// The last five columns are Layer 3 attribution fields. correlation_id and
+	// delegation arrive with daemon ≥ v0.17.0; issuer.runtime.{agent_id,
+	// agent_type} with daemon ≥ v0.18.0 (ADR-0026). All are absent from older
+	// receipts and scan as empty strings / NULL.
 	query := fmt.Sprintf(
 		`SELECT id, chain_id, sequence, action_type,
 		        COALESCE(tool_name, ''),
@@ -331,7 +337,8 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		          ELSE 0
 		        END,
 		        COALESCE(json_extract(receipt_json, '$.credentialSubject.correlation_id'), ''),
-		        COALESCE(json_extract(receipt_json, '$.issuer.agent_id'), ''),
+		        COALESCE(json_extract(receipt_json, '$.issuer.runtime.agent_id'), ''),
+		        COALESCE(json_extract(receipt_json, '$.issuer.runtime.agent_type'), ''),
 		        COALESCE(json_extract(receipt_json, '$.issuer.session_id'), ''),
 		        json_extract(receipt_json, '$.credentialSubject.delegation')
 		 FROM receipts %s ORDER BY %s LIMIT ?`,
@@ -360,7 +367,7 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 			&row.ParametersInputPreview, &row.ParametersOutputPreview,
 			&row.HasParametersDisclosure,
 			&row.OutputStatusMismatch,
-			&row.CorrelationID, &row.AgentID, &row.SessionID,
+			&row.CorrelationID, &row.AgentID, &row.AgentType, &row.SessionID,
 			&delegationJSON,
 		); err != nil {
 			return nil, err
@@ -626,7 +633,7 @@ func (r *Reader) SessionStats(since *string) ([]SessionRow, error) {
 		SELECT
 			json_extract(receipt_json, '$.issuer.session_id') AS session_id,
 			COUNT(*) AS receipt_count,
-			COUNT(DISTINCT COALESCE(NULLIF(json_extract(receipt_json, '$.issuer.agent_id'), ''), json_extract(receipt_json, '$.issuer.id'))) AS agent_count,
+			COUNT(DISTINCT COALESCE(NULLIF(json_extract(receipt_json, '$.issuer.runtime.agent_id'), ''), json_extract(receipt_json, '$.issuer.id'))) AS agent_count,
 			MIN(timestamp) AS first_seen,
 			MAX(timestamp) AS last_seen
 		FROM receipts

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -1760,13 +1760,14 @@ func insertLayer3(t *testing.T, s *sdkstore.Store, r receipt.AgentReceipt, corre
 	}
 	m["credentialSubject"] = cs
 
-	// Inject agent_id into issuer.
+	// Inject agent_id into issuer.runtime (the open metadata sub-object, ADR-0026;
+	// daemon ≥ v0.18.0). Older receipts had no agent_id at all.
 	if agentID != "" {
 		issuer, _ := m["issuer"].(map[string]any)
 		if issuer == nil {
 			issuer = map[string]any{}
 		}
-		issuer["agent_id"] = agentID
+		issuer["runtime"] = map[string]any{"agent_id": agentID, "agent_type": "general-purpose"}
 		m["issuer"] = issuer
 	}
 
@@ -1880,6 +1881,9 @@ func TestReader_Layer3_NewFields(t *testing.T) {
 	}
 	if rowA.AgentID != "subagent-x" {
 		t.Errorf("l3a AgentID: got %q, want subagent-x", rowA.AgentID)
+	}
+	if rowA.AgentType != "general-purpose" {
+		t.Errorf("l3a AgentType: got %q, want general-purpose", rowA.AgentType)
 	}
 	if rowA.SessionID != "session-abc" {
 		t.Errorf("l3a SessionID: got %q, want session-abc", rowA.SessionID)


### PR DESCRIPTION
## Summary

The dashboard read the sub-agent id from a **flat `issuer.agent_id`**, but the daemon never emitted it there. As of protocol **v0.5.0** / daemon **v0.18.0-alpha.1** it lives under the open **`issuer.runtime`** sub-object (ADR-0026, ar#761). So the dashboard's `issuer.agent_id` extract always resolved to NULL and sub-agent grouping never lit up.

Proof against the live store:
```
$.issuer.agent_id          →  0 receipts
$.issuer.runtime.agent_id  → 33 receipts
```

## Changes
- **`internal/store/reader.go`** — list query and session-grouping query now extract `$.issuer.runtime.agent_id`; new `$.issuer.runtime.agent_type` column → `ReceiptRow.AgentType`.
- **`internal/server/static/index.html`** — the "↳ Subagent" header shows the `agent_type` badge; the receipt detail modal surfaces `runtime.agent_id` / `runtime.agent_type`.
- **`go.mod`** — bump `github.com/agent-receipts/ar/sdk/go` `0.15.0` → `0.17.0-alpha.1` (the `Issuer` Go struct gains the `Runtime` field).
- **tests** — store + server fixtures now nest `agent_id` under `issuer.runtime` to match real receipts; added an `agent_type` assertion.

## Verification
Ran the built dashboard against the live `receipts.db`:
- `/api/sessions` — the verify session resolves `agent_count = 3` (orchestrator + 2 sub-agents), where it previously collapsed to 1.
- `/api/receipts` — all **33** sub-agent rows now carry `agent_id` **and** `agent_type` (e.g. `general-purpose`, `Explore`); root-agent receipts correctly carry neither.
- `go build ./...`, `go vet ./...`, `go test ./...` — all green.

## Context
Closes the dashboard side of the `issuer.runtime` work (ar#761 / ADR-0026). The receipts already carry the data and verify cryptographically; this teaches the dashboard to read it from the new nested location.