### PR TITLE
fix: clear session_id from URL when session filter is cleared (v0.7.0-alpha.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.0-alpha.5] - 2026-06-10
+
+### Fixed
+
+- **Session ID filter no longer sticky** — clearing the Session ID filter (via the chip ×, "Clear all", or emptying the input) now removes `session_id` from the URL instead of leaving a stale value behind. Previously only `?q=` was kept in sync, so a `?session_id=…` deep link or session click would survive a clear and get re-applied on the next reload/poll, forcing users to hand-edit the URL to widen the view.
+
 ## [0.7.0-alpha.4] - 2026-06-09
 
 ### Fixed

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -2276,7 +2276,9 @@
       const filters = currentReceiptFilters();
       const params = new URLSearchParams(filters);
 
-      // Sync active q into the URL so the user can share or bookmark a search.
+      // Sync the URL-backed filters (q, session_id) so they can be shared or
+      // bookmarked — and, crucially, cleared. Both delete when empty so a stale
+      // value doesn't get re-applied by the deep-link logic on the next reload.
       // Full filter URL-sync (risk, status, action, chain) is a possible follow-up.
       const qVal = filters.q || '';
       const url = new URL(location.href);
@@ -2284,6 +2286,11 @@
         url.searchParams.set('q', qVal);
       } else {
         url.searchParams.delete('q');
+      }
+      if (filters.session_id) {
+        url.searchParams.set('session_id', filters.session_id);
+      } else {
+        url.searchParams.delete('session_id');
       }
       history.replaceState(null, '', url.toString());
 
@@ -2348,22 +2355,18 @@
     // applySessionFilter switches to the Receipts tab and pre-filters by session_id.
     // Used by the Overview session pill to navigate from the Overview to the Receipts tab.
     function applySessionFilter(sessionId) {
-      const url = new URL(location.href);
-      url.searchParams.set('session_id', sessionId);
-      history.replaceState(null, '', url.toString());
       const sessionInput = document.getElementById('filter-session');
       if (sessionInput) sessionInput.value = sessionId;
+      // showView('receipts') calls loadReceipts(), which syncs session_id into
+      // the URL; do not set it here or call loadReceipts() again.
       showView('receipts');
-      // showView already calls loadReceipts(); do not call it again here.
     }
 
     // filterBySession pre-fills the Session ID filter with sid and reloads the
     // receipts table. Called when the user clicks a session header in the grouped view.
     function filterBySession(sid) {
-      const url = new URL(location.href);
-      url.searchParams.set('session_id', sid);
-      history.replaceState(null, '', url.toString());
       const el = document.getElementById('filter-session');
+      // loadReceipts() syncs session_id into the URL from the input value.
       if (el) { el.value = sid; loadReceipts(); }
     }
 


### PR DESCRIPTION
## Problem

The Session ID filter on the Receipts tab was "sticky": once a `?session_id=…` was applied (by clicking a session, an Overview pill, or a deep link), clearing the filter via the chip ×, "Clear all", or emptying the input updated the table but **left `?session_id=…` in the URL**. The deep-link boot logic then re-applied it on the next reload/poll, so the only way to widen the view was to hand-edit the URL.

## Root cause

`loadReceipts()` only synced `?q=` into the URL (set when present, deleted when empty). `session_id` was written into the URL by `applySessionFilter`/`filterBySession` but never removed when the filter was cleared, leaving the URL out of sync with the actual filter state.

## Fix

- `loadReceipts()` now owns URL sync for `session_id` the same way it does for `q`: set it when the filter is active, delete it when empty.
- Removed the now-redundant manual URL writes in `applySessionFilter` and `filterBySession`, making `loadReceipts()` the single source of truth for URL sync.
- Promotes `[Unreleased]` to `[0.7.0-alpha.5]` in `CHANGELOG.md`.

Frontend-only change to the embedded `index.html`.

## Testing

- `go vet ./...` — clean
- `go test ./...` — all packages pass