### PR TITLE
feat: surface issuer.model in session graph nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Session graph view** — each row in the Sessions table now has a "Graph" button that opens a node-link graph of the session's agent delegation tree. Nodes represent agents (orchestrator + sub-agents), sized by receipt count and labelled by `agent_type`. Delegation edges connect orchestrators to their sub-agents. Clicking a node filters the receipt list below the graph to that agent's receipts; clicking again resets the filter. Works for single-agent sessions (just the root node) and multi-agent sessions.
+- **Model label in session graph** — each agent node in the delegation graph now shows the model name (e.g. `claude-sonnet-4-6`) when it is present in the receipt data (`issuer.model`). The field is exposed through the store layer as `issuer_model` on every `ReceiptRow`.
 
 ### Fixed
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -3559,11 +3559,12 @@
       for (const r of receipts) {
         const key = r.agent_id || '__root__';
         if (!agentMap.has(key)) {
-          agentMap.set(key, { agentType: null, receiptCount: 0, delegation: null });
+          agentMap.set(key, { agentType: null, model: null, receiptCount: 0, delegation: null });
         }
         const a = agentMap.get(key);
         a.receiptCount++;
         if (!a.agentType && r.agent_type) a.agentType = r.agent_type;
+        if (!a.model && r.issuer_model) a.model = r.issuer_model;
         if (!a.delegation && r.delegation) a.delegation = r.delegation;
       }
 
@@ -3576,6 +3577,7 @@
           id:           key,
           label:        isRoot ? 'Orchestrator' : (info.agentType || 'agent'),
           sublabel:     isRoot ? null : key.substring(0, 12),
+          model:        info.model || null,
           receiptCount: info.receiptCount,
           isRoot,
         });
@@ -3617,7 +3619,8 @@
       const rootX         = VB_W / 2;
 
       const subStartX  = subCount > 0 ? rootX - ((subCount - 1) * subSpacing) / 2 : rootX;
-      const VB_H       = subCount > 0 ? SUB_Y + 90 : ROOT_Y + 90;
+      const hasModel   = nodes.some(n => n.model);
+      const VB_H       = (subCount > 0 ? SUB_Y + 90 : ROOT_Y + 90) + (hasModel ? 12 : 0);
 
       const pos = new Map();
       pos.set(root.id, { x: rootX, y: ROOT_Y });
@@ -3638,7 +3641,7 @@
         const safeId = escapeAttr(n.id);
         return `
           <g class="sg-node" data-node-id="${safeId}" onclick="${clickFn}(this)"
-             role="button" tabindex="0" aria-label="${escapeAttr(n.label)}, ${n.receiptCount} receipts"
+             role="button" tabindex="0" aria-label="${escapeAttr(n.label)}${n.model ? ', ' + escapeAttr(n.model) : ''}, ${n.receiptCount} receipts"
              onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();${clickFn}(this)}">
             <circle cx="${p.x}" cy="${p.y}" r="${r}" fill="${fill}" opacity="0.9"/>
             <text class="sg-label" x="${p.x}" y="${p.y + 1}" text-anchor="middle" dominant-baseline="central"
@@ -3646,6 +3649,7 @@
             <text class="sg-label" x="${p.x}" y="${p.y + r + 14}" text-anchor="middle"
                   style="fill:var(--text);font-size:11px;">${escapeHtml(n.label)}</text>
             ${n.sublabel ? `<text class="sg-label" x="${p.x}" y="${p.y + r + 26}" text-anchor="middle" style="fill:var(--muted);font-size:10px;font-family:var(--font-mono);">${escapeHtml(n.sublabel)}…</text>` : ''}
+            ${n.model ? `<text class="sg-label" x="${p.x}" y="${p.y + r + 38}" text-anchor="middle" style="fill:var(--muted);font-size:10px;">${escapeHtml(n.model)}</text>` : ''}
           </g>`;
       }).join('');
 

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -68,6 +68,9 @@ type ReceiptRow struct {
 	// AgentType is the runtime-reported agent type label (e.g. "general-purpose"),
 	// from issuer.runtime.agent_type.
 	AgentType string `json:"agent_type,omitempty"`
+	// IssuerModel is the AI model that issued the receipt (e.g. "claude-sonnet-4-6"),
+	// from issuer.model in the receipt JSON.
+	IssuerModel string `json:"issuer_model,omitempty"`
 	// SessionID groups all receipts from the same agent session together.
 	// Comes from issuer.session_id in the receipt JSON.
 	SessionID string `json:"session_id,omitempty"`
@@ -316,9 +319,10 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 	// on text that json_valid has cleared — SQL AND does not short-circuit,
 	// and json_extract on non-JSON text raises a "malformed JSON" error.
 	//
-	// The last five columns are Layer 3 attribution fields. correlation_id and
+	// The last six columns are Layer 3 attribution fields. correlation_id and
 	// delegation arrive with daemon ≥ v0.17.0; issuer.runtime.{agent_id,
-	// agent_type} with daemon ≥ v0.18.0 (ADR-0026). All are absent from older
+	// agent_type} with daemon ≥ v0.18.0 (ADR-0026); issuer.model is present
+	// whenever the daemon stamps the issuer identity. All are absent from older
 	// receipts and scan as empty strings / NULL.
 	query := fmt.Sprintf(
 		`SELECT id, chain_id, sequence, action_type,
@@ -339,6 +343,7 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 		        COALESCE(json_extract(receipt_json, '$.credentialSubject.correlation_id'), ''),
 		        COALESCE(json_extract(receipt_json, '$.issuer.runtime.agent_id'), ''),
 		        COALESCE(json_extract(receipt_json, '$.issuer.runtime.agent_type'), ''),
+		        COALESCE(json_extract(receipt_json, '$.issuer.model'), ''),
 		        COALESCE(json_extract(receipt_json, '$.issuer.session_id'), ''),
 		        json_extract(receipt_json, '$.credentialSubject.delegation')
 		 FROM receipts %s ORDER BY %s LIMIT ?`,
@@ -367,7 +372,7 @@ func (r *Reader) ListReceipts(f Filter) ([]ReceiptRow, error) {
 			&row.ParametersInputPreview, &row.ParametersOutputPreview,
 			&row.HasParametersDisclosure,
 			&row.OutputStatusMismatch,
-			&row.CorrelationID, &row.AgentID, &row.AgentType, &row.SessionID,
+			&row.CorrelationID, &row.AgentID, &row.AgentType, &row.IssuerModel, &row.SessionID,
 			&delegationJSON,
 		); err != nil {
 			return nil, err

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -1816,8 +1816,8 @@ func TestReader_Layer3_GracefulDegradation(t *testing.T) {
 }
 
 // TestReader_Layer3_NewFields verifies that correlation_id, agent_id,
-// session_id, and delegation are correctly extracted from receipts emitted by
-// daemon ≥ v0.17.0 / hook ≥ v0.14.0.
+// issuer_model, session_id, and delegation are correctly extracted from
+// receipts emitted by daemon ≥ v0.17.0 / hook ≥ v0.14.0.
 func TestReader_Layer3_NewFields(t *testing.T) {
 	dbPath := t.TempDir() + "/layer3-test.db"
 	s, err := sdkstore.Open(dbPath)
@@ -1825,10 +1825,11 @@ func TestReader_Layer3_NewFields(t *testing.T) {
 		t.Fatalf("open sdk store: %v", err)
 	}
 
-	// Base receipt using the current Issuer struct with session_id set.
+	// Base receipt using the current Issuer struct with session_id and model set.
 	base := makeReceipt("urn:receipt:l3a", "chain-l3", 1, "tool.call",
 		receipt.RiskLow, receipt.StatusSuccess, "2026-04-01T10:00:00Z", nil)
 	base.Issuer.SessionID = "session-abc"
+	base.Issuer.Model = "claude-sonnet-4-6"
 
 	del := &DelegationInfo{
 		ParentChainID:   "urn:chain:parent",
@@ -1885,6 +1886,9 @@ func TestReader_Layer3_NewFields(t *testing.T) {
 	if rowA.AgentType != "general-purpose" {
 		t.Errorf("l3a AgentType: got %q, want general-purpose", rowA.AgentType)
 	}
+	if rowA.IssuerModel != "claude-sonnet-4-6" {
+		t.Errorf("l3a IssuerModel: got %q, want claude-sonnet-4-6", rowA.IssuerModel)
+	}
 	if rowA.SessionID != "session-abc" {
 		t.Errorf("l3a SessionID: got %q, want session-abc", rowA.SessionID)
 	}
@@ -1907,6 +1911,9 @@ func TestReader_Layer3_NewFields(t *testing.T) {
 	}
 	if rowB.AgentID != "" {
 		t.Errorf("l3b AgentID: got %q, want empty", rowB.AgentID)
+	}
+	if rowB.IssuerModel != "" {
+		t.Errorf("l3b IssuerModel: got %q, want empty", rowB.IssuerModel)
 	}
 	if rowB.SessionID != "session-abc" {
 		t.Errorf("l3b SessionID: got %q, want session-abc", rowB.SessionID)


### PR DESCRIPTION
## Summary

- Extracts `issuer.model` (`$.issuer.model`) from receipt JSON into a new `ReceiptRow.IssuerModel` field, exposed as `issuer_model` in the API response
- Session graph nodes render the model name as a third label line (muted, 10 px) below the existing `agent_type` and `agent_id` lines
- `VB_H` grows by 12 px when any node carries a model, so the label is never clipped
- Older receipts that predate the daemon stamping `issuer.model` degrade gracefully — the model line is absent

Stacked on #126 (session graph view).

## Test plan

- [ ] `go test ./...` passes (new assertions in `TestReader_Layer3_NewFields` cover round-trip extraction of `IssuerModel`)
- [ ] Open a session-filtered receipts view — model name appears under each node in the inline graph for receipts from daemon ≥ v0.18.0
- [ ] Open the session graph modal from the Sessions table — same model labels visible
- [ ] Old receipts (no `issuer.model`) show only `agent_type` + `agent_id` lines, no empty third line