### PR TITLE
chore(release): bump to v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-12
+
 ### Fixed
 
 - **`⚠ mv ops` no longer fires on file deletions** — `has_move_ops` was detected with `strings.Contains(actionType, "move")`, which matched `filesystem.file.remove` (delete) because "remove" contains the substring "move". Detection now requires an exact match against `filesystem.file.move` or `filesystem.file.rename`.


### PR DESCRIPTION
Moves `[Unreleased]` → `[0.8.0]` in CHANGELOG.md.

## What's in this release

### Added
- Session attribution and blast-radius view (ADR-0029 §4) — state-dep edges, risk rings, coverage fraction, `GET /api/sessions/{id}/attribution`
- Transcript-derived model and token usage surfaced in receipt detail modal

### Fixed
- `has_move_ops` false positives on file deletions
- Bidirectional state-dep edges collapsing correctly
- Empty-session attribution response using `[]` not `null`
- Delegation edge filter tightened to exact type match
- Agent-ID truncation ellipsis only appended when actually clipped
- Inline session graph now fetches attribution and shows blast-radius on node click
- State-dep edge causal direction uses globally-earliest timestamp, not map iteration order

After merging: tag `v0.8.0` to trigger CI release.