### PR TITLE
chore(release): bump to v0.9.0-alpha.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0-alpha.1] - 2026-06-19
+
 ### Added
 
 - **Connected-component highlight in agent graph** — clicking a node now highlights its entire state-dep connected component (all agents reachable via shared-resource contention edges), dims everything outside it, and emphasizes the in-component state-dep edges. Delegation edges are excluded from component computation so the root node does not collapse the whole graph into one component. A node with no state-dep edges highlights only itself, preserving today's single-node behavior. The blast-radius panel and receipts filter remain keyed to the clicked node, unchanged.


### PR DESCRIPTION
Release bump for **v0.9.0-alpha.1**.

Adds the dated `## [0.9.0-alpha.1] - 2026-06-19` section to `CHANGELOG.md` (mirrors the v0.8.0 bump process), capturing the one change since v0.8.0:

- Connected-component highlight in the agent graph (#136, closes #135).

## Release steps (after merge)

1. `git checkout main && git pull`
2. `scripts/release.sh 0.9.0-alpha.1` — runs vet/build/test, pushes tag `v0.9.0-alpha.1`
3. `release.yml` triggers on the tag: builds binaries, publishes the Homebrew formula, and creates the GitHub release (auto-marked **prerelease** because the version contains `-`).