### PR TITLE
docs: correct internal/store description (not multi-DB)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,7 +8,7 @@ Lightweight local dashboard for viewing Agent Receipts — cryptographically sig
 cmd/dashboard/          # CLI entry point
 internal/server/        # HTTP server, routes, handlers
 internal/server/static/ # Embedded HTML, htmx, CSS (no build step)
-internal/store/         # Read-only SQLite access, queries, multi-DB
+internal/store/         # Read-only SQLite access and queries
 internal/verify/        # Hash linkage and chain verification
 ```
 


### PR DESCRIPTION
## What

AGENTS.md described `internal/store/` as "multi-DB" in the project layout. That capability was never implemented — `OpenReadOnly` (internal/store/reader.go:195) opens exactly one database. This corrects the description to what the package actually does.

## Why

Surfaced while assessing #12. All agent-receipts tools write through the daemon to a single store, so multi-DB was never built and the doc overclaimed it. See the rescope note on #12.

## Scope

Doc-only; no behavior change, so no CHANGELOG entry. Multi-`--db` support itself is tracked (rescoped) in #12.