### PR TITLE
fix(verify): verify chain signatures from raw wire bytes (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Structured issuer and principal details in the receipt detail view** — the detail modal now renders the issuer's `type` and (when present) top-level `model` and `operator` (`{name, id}`) as their own labelled fields, and shows the principal's `type` as a badge alongside its id. Previously these fields were only visible in the raw JSON blob. All new fields render conditionally and degrade gracefully when absent.
 - **Action type taxonomy awareness** — the dashboard now surfaces the SDK's built-in action-type registry so auditors can interpret raw action types without external docs. A new `GET /api/taxonomy` endpoint serves every known action type with its description and default risk level, grouped by category (Filesystem, System, Data, Network, Diagnostic, Other). The Actions view gains a collapsible **Action type reference** card listing all built-ins grouped by category, and known action types in the receipts list, Actions stats table, and receipt detail now carry a hover tooltip ("Read a file · default risk: low"); the detail modal additionally shows a **Meaning** row. Unknown action types degrade gracefully to plain text.
 
+### Fixed
+
+- **Chain signature verification no longer false-negatives on forward-compat receipts** ([#73](https://github.com/agent-receipts/dashboard/issues/73)) — `GET /api/chains/{id}/verify?public_key=…` now checks each Ed25519 signature against the receipt's verbatim wire bytes via the SDK's new `receipt.VerifyRaw`, instead of re-marshalling the parsed Go struct with `receipt.Verify`. The struct path dropped any field a newer SDK signed over but nested inside the payload (e.g. under `credentialSubject`), canonicalizing different bytes and reporting a genuinely valid signature as invalid. This is the signature-side twin of the hash-linkage fix for [#719](https://github.com/agent-receipts/ar/issues/719); the signature path now matches the existing `HashRawReceipt` hash path. Requires SDK `v0.20.0-alpha.2`.
+
 ## [0.9.0-alpha.1] - 2026-06-19
 
 ### Added

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/dashboard
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.1
+	github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.2
 	modernc.org/sqlite v1.52.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.1 h1:ty9GWmGRPYEU3o7SZjFoXMSLxDYU9Qoj3r4M/IlT6f8=
-github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.1/go.mod h1:aMH5iT4D4SdVbd16/+6+w0fSsmmfPU/ab5yhPRTmpN0=
+github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.2 h1:u/1czC2DB3S9yAVgR6k+hv9/7pGmsBEHFHbIN1NQlew=
+github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.2/go.mod h1:T1hd+n4TaLjMZ45zCAFK/2U/2BhR+/NVdNSuZkFGl6g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=

--- a/internal/verify/chain.go
+++ b/internal/verify/chain.go
@@ -35,11 +35,13 @@ type ChainLinkResult struct {
 // verified using the ar SDK; SignatureValid will be set per receipt.
 // When publicKeyPEM is empty, signature checks are skipped (SignatureValid is nil).
 //
-// Hash linkage is recomputed from each receipt's verbatim wire bytes
-// (receipt.HashRawReceipt), which is the canonical hash form that the
-// collector stored and an auditor would reproduce. Hashing the re-marshalled Go struct
-// instead (receipt.HashReceipt) drops any forward-compat fields a newer SDK
-// emitted, making a valid chain look broken — issue #719.
+// Both hash linkage and signatures are recomputed from each receipt's verbatim
+// wire bytes — receipt.HashRawReceipt and receipt.VerifyRaw — the canonical
+// forms the collector stored and an auditor would reproduce. Round-tripping
+// through the Go struct instead (receipt.HashReceipt / receipt.Verify) drops any
+// forward-compat field a newer SDK emitted inside the signed payload before
+// hashing or canonicalizing, making a valid chain look broken (issue #719) or a
+// valid signature look forged (issue #73).
 func VerifyChainLinks(receipts []store.ChainReceipt, publicKeyPEM string) ChainLinkResult {
 	if len(receipts) == 0 {
 		return ChainLinkResult{Valid: true, Length: 0, BrokenAt: -1}
@@ -82,7 +84,7 @@ func VerifyChainLinks(receipts []store.ChainReceipt, publicKeyPEM string) ChainL
 		}
 
 		if publicKeyPEM != "" {
-			ok, err := receipt.Verify(r, publicKeyPEM)
+			ok, err := receipt.VerifyRaw(cr.Raw, publicKeyPEM)
 			if err != nil {
 				log.Printf("signature verify error for receipt %s: %v", r.ID, err)
 			}

--- a/internal/verify/chain_test.go
+++ b/internal/verify/chain_test.go
@@ -1,7 +1,11 @@
 package verify
 
 import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -317,5 +321,101 @@ func TestVerifyChainLinks_NoPublicKey_SignatureNotChecked(t *testing.T) {
 	result := VerifyChainLinks([]store.ChainReceipt{cr}, "")
 	if result.Receipts[0].SignatureValid != nil {
 		t.Error("SignatureValid should be nil when no public key provided")
+	}
+}
+
+// signRawPayload signs a generic receipt payload (without a proof block) and
+// returns the full wire bytes with the proof spliced in, the way an SDK newer
+// than this build would. It lets the test carry a signed field that the
+// AgentReceipt struct does not model.
+func signRawPayload(t *testing.T, payload map[string]any, privateKeyPEM string) []byte {
+	t.Helper()
+	block, _ := pem.Decode([]byte(privateKeyPEM))
+	if block == nil {
+		t.Fatal("decode private key PEM")
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse private key: %v", err)
+	}
+	priv, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		t.Fatal("private key is not Ed25519")
+	}
+	canonical, err := receipt.Canonicalize(payload)
+	if err != nil {
+		t.Fatalf("canonicalize: %v", err)
+	}
+	sig := ed25519.Sign(priv, []byte(canonical))
+	payload["proof"] = map[string]any{
+		"type":               "Ed25519Signature2020",
+		"proofValue":         "u" + base64.RawURLEncoding.EncodeToString(sig),
+		"verificationMethod": "did:agent:test#key-1",
+		"proofPurpose":       "assertionMethod",
+	}
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("marshal payload: %v", err)
+	}
+	return raw
+}
+
+func TestVerifyChainLinks_SignatureValid_ForwardCompatNested(t *testing.T) {
+	// Issue #73: a newer SDK can sign over a field nested inside the payload
+	// (e.g. under credentialSubject) that this build's struct does not model.
+	// VerifyChainLinks must verify the signature against the verbatim wire bytes
+	// (receipt.VerifyRaw), not a re-marshal of the struct (receipt.Verify) that
+	// drops the field and false-negatives a genuinely valid signature.
+	kp, err := receipt.GenerateKeyPair()
+	if err != nil {
+		t.Fatalf("generate key pair: %v", err)
+	}
+
+	r := makeReceipt("urn:receipt:fc-sig", "chain-fc-sig", 1, nil)
+	// Derive the signed payload from the struct so field names match the wire,
+	// then splice in one field nested under credentialSubject.
+	ub, err := json.Marshal(receipt.UnsignedAgentReceipt{
+		Context:           r.Context,
+		ID:                r.ID,
+		Type:              r.Type,
+		Version:           r.Version,
+		Issuer:            r.Issuer,
+		IssuanceDate:      r.IssuanceDate,
+		CredentialSubject: r.CredentialSubject,
+	})
+	if err != nil {
+		t.Fatalf("marshal unsigned: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(ub, &payload); err != nil {
+		t.Fatalf("unmarshal payload: %v", err)
+	}
+	payload["credentialSubject"].(map[string]any)["_future_nested"] = "v2"
+
+	raw := signRawPayload(t, payload, kp.PrivateKey)
+	cr := store.ChainReceipt{Receipt: r, Raw: raw}
+
+	result := VerifyChainLinks([]store.ChainReceipt{cr}, kp.PublicKey)
+	sv := result.Receipts[0].SignatureValid
+	if sv == nil {
+		t.Fatal("SignatureValid should not be nil when public key provided")
+	}
+	if !*sv {
+		t.Fatal("signature over a nested forward-compat field should verify via raw bytes (issue #73)")
+	}
+
+	// Sanity check: the old struct-based path drops the nested field and
+	// false-negatives, proving the test exercises the real divergence the swap
+	// to VerifyRaw fixes — not a no-op.
+	var parsed receipt.AgentReceipt
+	if err := json.Unmarshal(raw, &parsed); err != nil {
+		t.Fatalf("unmarshal parsed: %v", err)
+	}
+	structOK, err := receipt.Verify(parsed, kp.PublicKey)
+	if err != nil {
+		t.Fatalf("verify: %v", err)
+	}
+	if structOK {
+		t.Fatal("expected struct-based Verify to false-negative on the nested field")
 	}
 }


### PR DESCRIPTION
Fixes #73.

## Problem

`VerifyChainLinks` checked each receipt's Ed25519 signature with `receipt.Verify(r, …)` on the **parsed Go struct**. `receipt.Verify` rebuilds an `UnsignedAgentReceipt` from the struct and canonicalizes *that*, so any field a newer SDK added and signed over — nested inside the signed payload (e.g. under `credentialSubject`) — is silently dropped on `json.Unmarshal` before verification. The Ed25519 check then runs over different bytes than were signed and **false-negatives a genuinely valid signature**.

The hash-linkage half of the same function already moved to `receipt.HashRawReceipt` (verbatim wire bytes) in the #719 fix. So for a forward-compat signed chain, `GET /api/chains/{id}/verify?public_key=…` would report the hash links intact but every signature invalid — a contradictory, misleading result. This was the latent signature-side twin called out in #73.

## Fix

Swap the signature check to the SDK's new `receipt.VerifyRaw(cr.Raw, publicKeyPEM)` — which canonicalizes the verbatim wire bytes minus `proof`, exactly mirroring `HashRawReceipt`. Both the hash and signature paths now verify the same canonical bytes the collector stored and an auditor would reproduce.

- `internal/verify/chain.go` — one-line swap (`receipt.Verify(r, …)` → `receipt.VerifyRaw(cr.Raw, …)`) plus an updated doc comment covering both #719 and #73. `cr.Raw` is the current receipt's own wire bytes (distinct from the `receipts[i-1].Raw` used for previous-hash linkage).
- Bumps the SDK dep to **`v0.20.0-alpha.2`**, which adds `receipt.VerifyRaw` ([obsigna#887](https://github.com/agent-receipts/obsigna/pull/887)).

## Tests

- New `TestVerifyChainLinks_SignatureValid_ForwardCompatNested` — a chain receipt whose signed payload carries a field nested under `credentialSubject` that the struct does not model. With a public key, `SignatureValid` is now `true`; a sanity assertion confirms the old struct-based `receipt.Verify` over the same bytes false-negatives, proving the swap is not a no-op.
- Existing `TestVerifyChainLinks_SignatureValid` / `_SignatureInvalid` / `_NoPublicKey_SignatureNotChecked` pass unchanged (their `Raw` is the wire bytes of the signed receipt).

`go vet ./...` clean, `go test ./...` green. CHANGELOG updated under `[Unreleased] → Fixed`.

## Note on reachability

Reachable via the `?public_key=` API parameter (`server.go` reads it and passes it to `VerifyChainLinks`). The dashboard UI's "Verify signatures" button does hash/sequence checks only and does not currently pass a key, so end users are not yet exposed — but the API contract is now correct for auditors who do supply one.
