### PR TITLE
chore(release): bump to v0.9.0-alpha.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0-alpha.2] - 2026-06-19
+
 ### Added
 
 - **Structured issuer and principal details in the receipt detail view** — the detail modal now renders the issuer's `type` and (when present) top-level `model` and `operator` (`{name, id}`) as their own labelled fields, and shows the principal's `type` as a badge alongside its id. Previously these fields were only visible in the raw JSON blob. All new fields render conditionally and degrade gracefully when absent.


### PR DESCRIPTION
Stamps the CHANGELOG for the `v0.9.0-alpha.2` release: moves the `[Unreleased]` entries into a dated `[0.9.0-alpha.2] - 2026-06-19` heading.

Since `v0.9.0-alpha.1`:

- **Added** — structured issuer/principal details in the receipt detail view ([#139](https://github.com/agent-receipts/dashboard/pull/139)); action-type taxonomy awareness ([#138](https://github.com/agent-receipts/dashboard/pull/138)).
- **Fixed** — chain signature verification no longer false-negatives on forward-compat receipts ([#73](https://github.com/agent-receipts/dashboard/issues/73), [#141](https://github.com/agent-receipts/dashboard/pull/141)); requires SDK `v0.20.0-alpha.2`.

Once merged, the tag `v0.9.0-alpha.2` is pushed to trigger the `release` workflow.