### PR TITLE
fix(forensic): harden key file reads — reject non-regular files, zero oversize buffer, return 413

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Hardened forensic key file reads** ([#78](https://github.com/agent-receipts/dashboard/issues/78)) — `readFileLimited` now rejects non-regular files (symlinks, FIFOs, devices, directories) via `Lstat` before opening, preventing startup hangs on a FIFO at `ForensicKeyPath` and blocking `/dev/zero`-style reads via the path endpoint. The path endpoint (`POST /api/forensic-key/path`) now returns **413 Request Entity Too Large** when the file exceeds the size limit (previously 400). Over-size buffers are zeroed before the error is returned so key material does not linger in GC.
+- **Hardened forensic key file reads** ([#78](https://github.com/agent-receipts/dashboard/issues/78)) — `readFileLimited` now rejects non-regular files (symlinks, FIFOs, devices, directories) via `Lstat` before opening, preventing startup hangs on a FIFO at `ForensicKeyPath` and blocking `/dev/zero`-style reads via the path endpoint. The path endpoint (`POST /api/forensic-key/path`) now returns **413 Request Entity Too Large** when the file exceeds the size limit (previously 400). The over-size buffer is zeroed before the error is returned, narrowing the window in which discarded key material sits in memory (intermediate `io.ReadAll` allocations may still persist until GC).
 
 ## [0.9.0-alpha.2] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
-- **Hardened forensic key file reads** ([#78](https://github.com/agent-receipts/dashboard/issues/78)) — `readFileLimited` now rejects non-regular files (symlinks, FIFOs, devices, directories) via `Lstat` before opening, preventing startup hangs on a FIFO at `ForensicKeyPath` and blocking `/dev/zero`-style reads via the path endpoint. The path endpoint (`POST /api/forensic-key/path`) now returns **413 Request Entity Too Large** when the file exceeds the size limit (previously 400). The over-size buffer is zeroed before the error is returned, narrowing the window in which discarded key material sits in memory (intermediate `io.ReadAll` allocations may still persist until GC).
+- **Hardened forensic key file reads** ([#78](https://github.com/agent-receipts/dashboard/issues/78)) — `readFileLimited` now rejects non-regular files (symlinks, FIFOs, devices, directories) via `Lstat` before opening, preventing startup hangs on a FIFO at `ForensicKeyPath` and blocking `/dev/zero`-style reads via the path endpoint. The path endpoint (`POST /api/forensic-key/path`) now returns **413 Request Entity Too Large** when the file exceeds the size limit (previously 400). The over-size buffer is zeroed before the error is returned, narrowing the window in which discarded key material sits in memory (intermediate `io.ReadAll` allocations may still persist until GC). The path endpoint now routes the operator-supplied path through a single `validateForensicKeyPath` barrier that rejects `..` traversal segments and embedded NUL bytes before any filesystem access.
 
 ## [0.9.0-alpha.2] - 2026-06-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`-forensic-key-dirs` flag** ([#78](https://github.com/agent-receipts/dashboard/issues/78)) — comma-separated list of extra absolute directories from which the forensic key path endpoint (`POST /api/forensic-key/path`) may load a key. The user's home directory is always allowed; non-absolute entries are silently skipped.
+
 ### Security
 
+- **Forensic key path endpoint confined to an allowlist** ([#78](https://github.com/agent-receipts/dashboard/issues/78)) — `POST /api/forensic-key/path` now requires the resolved path to equal or be nested under the user's home directory or an entry in `-forensic-key-dirs`. Paths outside every allowed root are rejected with **403 Forbidden** before any filesystem access, resolving the CodeQL `go/path-injection` alert on the `os.Lstat` sink. `..` traversal segments and NUL bytes continue to be rejected earlier in the same validation barrier.
 - **Hardened forensic key file reads** ([#78](https://github.com/agent-receipts/dashboard/issues/78)) — `readFileLimited` now rejects non-regular files (symlinks, FIFOs, devices, directories) via `Lstat` before opening, preventing startup hangs on a FIFO at `ForensicKeyPath` and blocking `/dev/zero`-style reads via the path endpoint. The path endpoint (`POST /api/forensic-key/path`) now returns **413 Request Entity Too Large** when the file exceeds the size limit (previously 400). The over-size buffer is zeroed before the error is returned, narrowing the window in which discarded key material sits in memory (intermediate `io.ReadAll` allocations may still persist until GC). The path endpoint now routes the operator-supplied path through a single `validateForensicKeyPath` barrier that rejects `..` traversal segments and embedded NUL bytes before any filesystem access.
 
 ## [0.9.0-alpha.2] - 2026-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Hardened forensic key file reads** ([#78](https://github.com/agent-receipts/dashboard/issues/78)) — `readFileLimited` now rejects non-regular files (symlinks, FIFOs, devices, directories) via `Lstat` before opening, preventing startup hangs on a FIFO at `ForensicKeyPath` and blocking `/dev/zero`-style reads via the path endpoint. The path endpoint (`POST /api/forensic-key/path`) now returns **413 Request Entity Too Large** when the file exceeds the size limit (previously 400). Over-size buffers are zeroed before the error is returned so key material does not linger in GC.
+
 ## [0.9.0-alpha.2] - 2026-06-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Opens http://localhost:8080 and reads `~/.local/share/agent-receipts/receipts.db
 | `-port` | `8080` | HTTP server port |
 | `-host` | `127.0.0.1` | Address to bind (use `0.0.0.0` for all interfaces) |
 | `-poll-interval` | `5s` | How often the UI polls for new receipts. Also honoured via `AR_DASHBOARD_POLL_INTERVAL`. |
+| `-forensic-key-dirs` | _(home dir)_ | Comma-separated list of extra absolute directories from which the forensic key path endpoint (`POST /api/forensic-key/path`) may load a key. The user's home directory is always allowed. Non-absolute entries are silently skipped. |
 | `-version`, `--version` | | Print the version and exit |
 | `-h`, `--help` | | Print usage and exit |
 
@@ -176,6 +177,7 @@ The dashboard is **read-only** and binds to **`127.0.0.1` by default**. Forensic
 - **Loopback-only** — forensic-key and disclosure endpoints return `403` unless the server is bound to a loopback address. Running with `-host 0.0.0.0` disables forensic decryption.
 - **Host-header validation** — requests whose `Host` header does not name loopback are rejected, blocking DNS-rebinding attacks where a remote page points its own domain at `127.0.0.1`.
 - **CSRF guard** — forensic `POST` endpoints require `Content-Type: application/json`, closing the same-browser cross-origin gap the loopback and Host-header guards don't cover.
+- **Path allowlist** — the key path endpoint (`POST /api/forensic-key/path`) only reads files inside the user's home directory or directories explicitly listed via `-forensic-key-dirs`. Paths outside every allowed root return `403 Forbidden`. Paths containing `..` or NUL bytes are rejected before any filesystem access.
 - The private key stays in the dashboard process; decrypted snippets are cached only in the browser tab and cleared when the key state changes.
 
 ## Project structure

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime/debug"
+	"strings"
 	"time"
 
 	"github.com/agent-receipts/dashboard/internal/server"
@@ -125,6 +126,7 @@ func main() {
 	host := flag.String("host", "127.0.0.1", "address to bind to (use 0.0.0.0 for all interfaces)")
 	port := flag.Int("port", 8080, "HTTP server port")
 	pollInterval := flag.Duration("poll-interval", server.DefaultPollInterval, "interval between live receipt polls (e.g. 5s)")
+	forensicKeyDirsFlag := flag.String("forensic-key-dirs", "", "comma-separated list of extra absolute directories from which the forensic key path endpoint may load a key (the user's home directory is always allowed)")
 	flag.Parse()
 
 	pollFlagSet := false
@@ -169,12 +171,20 @@ func main() {
 	if abs, err := filepath.Abs(*dbPath); err == nil {
 		displayDBPath = abs
 	}
+	var forensicKeyDirs []string
+	for _, d := range strings.Split(*forensicKeyDirsFlag, ",") {
+		if d := strings.TrimSpace(d); d != "" {
+			forensicKeyDirs = append(forensicKeyDirs, d)
+		}
+	}
+
 	srv := server.New(reader, server.Config{
 		PollInterval:    *pollInterval,
 		DBPath:          displayDBPath,
 		Version:         resolveVersion(),
 		Host:            *host,
 		ForensicKeyPath: defaultForensicKeyPath(),
+		ForensicKeyDirs: forensicKeyDirs,
 	})
 	addr := fmt.Sprintf("%s:%d", *host, *port)
 	log.Printf("dashboard listening on http://%s", addr)

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -281,9 +282,14 @@ func (s *Server) handleForensicKeyLoadPath(w http.ResponseWriter, r *http.Reques
 	}
 	data, err := readFileLimited(expanded, maxForensicKeyBody)
 	if err != nil {
-		if isNotExist(err) {
+		switch {
+		case isNotExist(err):
 			writeError(w, http.StatusBadRequest, "key file not found: "+req.Path)
-		} else {
+		case errors.Is(err, errFileTooLarge):
+			writeError(w, http.StatusRequestEntityTooLarge, "forensic key file is too large")
+		case errors.Is(err, errNotRegularFile):
+			writeError(w, http.StatusBadRequest, "key file must be a regular file")
+		default:
 			writeError(w, http.StatusBadRequest, "could not read key file: "+err.Error())
 		}
 		return

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -277,11 +277,14 @@ func (s *Server) handleForensicKeyLoadPath(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	cleaned, err := validateForensicKeyPath(req.Path)
+	cleaned, err := validateForensicKeyPath(req.Path, s.forensicKeyDirs)
 	if err != nil {
-		if errors.Is(err, errPathNotAbsolute) {
+		switch {
+		case errors.Is(err, errPathNotAbsolute):
 			writeError(w, http.StatusBadRequest, "path must be absolute (or start with ~/)")
-		} else {
+		case errors.Is(err, errPathNotAllowed):
+			writeError(w, http.StatusForbidden, "key file path is not within an allowed directory")
+		default:
 			writeError(w, http.StatusBadRequest, "path must not contain '..' or a NUL byte")
 		}
 		return
@@ -331,21 +334,31 @@ func expandHomePath(p string) string {
 	return p
 }
 
-// errPathNotAbsolute and errPathInvalid are returned by validateForensicKeyPath
-// for an operator-supplied path that does not resolve to an absolute location
-// or that contains a traversal segment or NUL byte.
+// errPathNotAbsolute, errPathInvalid, and errPathNotAllowed are returned by
+// validateForensicKeyPath for an operator-supplied path that does not resolve
+// to an absolute location, that contains a traversal segment or NUL byte, or
+// that falls outside every allowed directory root.
 var (
 	errPathNotAbsolute = errors.New("path must be absolute")
 	errPathInvalid     = errors.New("path contains a traversal segment or NUL byte")
+	errPathNotAllowed  = errors.New("path not within an allowed directory")
 )
 
 // validateForensicKeyPath is the single validation barrier for the
 // operator-supplied forensic key path. It expands a leading ~, rejects an
 // embedded NUL byte and any ".." traversal segment outright (rather than
-// silently resolving it to an unexpected location), and requires the cleaned
-// result to be absolute. The returned cleaned path is the only value that
-// reaches the filesystem, so untrusted input cannot flow to a read unchecked.
-func validateForensicKeyPath(raw string) (string, error) {
+// silently resolving it to an unexpected location), requires the cleaned
+// result to be absolute, and then checks that the path equals one of the
+// allowed roots or sits beneath one (boundary-safe prefix check).
+//
+// The returned cleaned path is the only value that reaches the filesystem, so
+// untrusted input cannot flow to a read unchecked.
+//
+// Note: intermediate symlinked directories are not resolved here, but the
+// target file itself must be a regular file (readFileLimited already rejects
+// symlinks/non-regular via Lstat), so a symlinked key file cannot escape the
+// allowlist.
+func validateForensicKeyPath(raw string, allowedDirs []string) (string, error) {
 	if strings.ContainsRune(raw, 0) {
 		return "", errPathInvalid
 	}
@@ -357,7 +370,12 @@ func validateForensicKeyPath(raw string) (string, error) {
 	if !filepath.IsAbs(cleaned) {
 		return "", errPathNotAbsolute
 	}
-	return cleaned, nil
+	for _, root := range allowedDirs {
+		if cleaned == root || strings.HasPrefix(cleaned, root+string(os.PathSeparator)) {
+			return cleaned, nil
+		}
+	}
+	return "", errPathNotAllowed
 }
 
 // containsDotDot reports whether the path has a ".." element, splitting on both

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -243,9 +243,11 @@ func (s *Server) handleForensicKeyLoad(w http.ResponseWriter, r *http.Request) {
 
 // handleForensicKeyLoadPath loads the forensic private key from an absolute
 // path on the server's filesystem. The path is supplied as JSON in the request
-// body and may use a leading ~ for the current user's home directory. Relative
-// paths are rejected so a typo like "forensic.key" does not silently resolve
-// against the dashboard's working directory.
+// body and may use a leading ~ for the current user's home directory. The path
+// is validated by validateForensicKeyPath: relative paths are rejected so a
+// typo like "forensic.key" does not silently resolve against the dashboard's
+// working directory, and ".." traversal segments and NUL bytes are rejected
+// before any filesystem access.
 func (s *Server) handleForensicKeyLoadPath(w http.ResponseWriter, r *http.Request) {
 	if !s.guardForensic(w, r) {
 		return
@@ -275,12 +277,16 @@ func (s *Server) handleForensicKeyLoadPath(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	expanded := expandHomePath(req.Path)
-	if !filepath.IsAbs(expanded) {
-		writeError(w, http.StatusBadRequest, "path must be absolute (or start with ~/)")
+	cleaned, err := validateForensicKeyPath(req.Path)
+	if err != nil {
+		if errors.Is(err, errPathNotAbsolute) {
+			writeError(w, http.StatusBadRequest, "path must be absolute (or start with ~/)")
+		} else {
+			writeError(w, http.StatusBadRequest, "path must not contain '..' or a NUL byte")
+		}
 		return
 	}
-	data, err := readFileLimited(expanded, maxForensicKeyBody)
+	data, err := readFileLimited(cleaned, maxForensicKeyBody)
 	if err != nil {
 		switch {
 		case isNotExist(err):
@@ -323,6 +329,50 @@ func expandHomePath(p string) string {
 		}
 	}
 	return p
+}
+
+// errPathNotAbsolute and errPathInvalid are returned by validateForensicKeyPath
+// for an operator-supplied path that does not resolve to an absolute location
+// or that contains a traversal segment or NUL byte.
+var (
+	errPathNotAbsolute = errors.New("path must be absolute")
+	errPathInvalid     = errors.New("path contains a traversal segment or NUL byte")
+)
+
+// validateForensicKeyPath is the single validation barrier for the
+// operator-supplied forensic key path. It expands a leading ~, rejects an
+// embedded NUL byte and any ".." traversal segment outright (rather than
+// silently resolving it to an unexpected location), and requires the cleaned
+// result to be absolute. The returned cleaned path is the only value that
+// reaches the filesystem, so untrusted input cannot flow to a read unchecked.
+func validateForensicKeyPath(raw string) (string, error) {
+	if strings.ContainsRune(raw, 0) {
+		return "", errPathInvalid
+	}
+	expanded := expandHomePath(raw)
+	if containsDotDot(expanded) {
+		return "", errPathInvalid
+	}
+	cleaned := filepath.Clean(expanded)
+	if !filepath.IsAbs(cleaned) {
+		return "", errPathNotAbsolute
+	}
+	return cleaned, nil
+}
+
+// containsDotDot reports whether the path has a ".." element, splitting on both
+// the forward and backward slash so the check holds regardless of platform
+// separator. Mirrors the guard net/http uses for file serving.
+func containsDotDot(p string) bool {
+	if !strings.Contains(p, "..") {
+		return false
+	}
+	for _, seg := range strings.FieldsFunc(p, func(r rune) bool { return r == '/' || r == '\\' }) {
+		if seg == ".." {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *Server) handleForensicKeyClear(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/forensic_fifo_test.go
+++ b/internal/server/forensic_fifo_test.go
@@ -28,13 +28,16 @@ func TestReadFileLimited_RejectsFIFO(t *testing.T) {
 
 // TestForensicKeyLoadPath_RejectsFIFO verifies that pointing the path endpoint
 // at a FIFO is rejected before open (preventing a hang waiting for a writer).
+// The dir is added to ForensicKeyDirs so the allowlist passes and rejection
+// comes from readFileLimited (Lstat sees a non-regular file).
 func TestForensicKeyLoadPath_RejectsFIFO(t *testing.T) {
-	fifo := t.TempDir() + "/forensic.fifo"
+	dir := t.TempDir()
+	fifo := dir + "/forensic.fifo"
 	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
 		t.Skipf("cannot create FIFO: %v", err)
 	}
 
-	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyDirs: []string{dir}})
 	body, _ := json.Marshal(map[string]string{"path": fifo})
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))

--- a/internal/server/forensic_fifo_test.go
+++ b/internal/server/forensic_fifo_test.go
@@ -1,0 +1,43 @@
+//go:build unix
+
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"syscall"
+	"testing"
+)
+
+// TestReadFileLimited_RejectsFIFO verifies that a named pipe (FIFO) is
+// rejected before opening, preventing a hang that would occur if os.Open
+// blocked waiting for a writer.
+func TestReadFileLimited_RejectsFIFO(t *testing.T) {
+	fifo := t.TempDir() + "/forensic.fifo"
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("cannot create FIFO: %v", err)
+	}
+	_, err := readFileLimited(fifo, 1024)
+	if err == nil {
+		t.Fatal("expected error for FIFO, got nil")
+	}
+}
+
+// TestForensicKeyLoadPath_RejectsFIFO verifies that pointing the path endpoint
+// at a FIFO is rejected before open (preventing a hang waiting for a writer).
+func TestForensicKeyLoadPath_RejectsFIFO(t *testing.T) {
+	fifo := t.TempDir() + "/forensic.fifo"
+	if err := syscall.Mkfifo(fifo, 0o600); err != nil {
+		t.Skipf("cannot create FIFO: %v", err)
+	}
+
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	body, _ := json.Marshal(map[string]string{"path": fifo})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", w.Code)
+	}
+}

--- a/internal/server/forensic_fifo_test.go
+++ b/internal/server/forensic_fifo_test.go
@@ -5,6 +5,7 @@ package server
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"syscall"
@@ -20,8 +21,8 @@ func TestReadFileLimited_RejectsFIFO(t *testing.T) {
 		t.Skipf("cannot create FIFO: %v", err)
 	}
 	_, err := readFileLimited(fifo, 1024)
-	if err == nil {
-		t.Fatal("expected error for FIFO, got nil")
+	if !errors.Is(err, errNotRegularFile) {
+		t.Fatalf("got error %v, want errNotRegularFile", err)
 	}
 }
 

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/agent-receipts/ar/sdk/go/receipt"
@@ -443,12 +444,13 @@ func TestForensicKeyLoadPath(t *testing.T) {
 	priv, _, fp := forensicKeyPair(t)
 
 	// Write the raw private key to a temp file.
-	keyFile := t.TempDir() + "/forensic.key"
+	dir := t.TempDir()
+	keyFile := dir + "/forensic.key"
 	if err := os.WriteFile(keyFile, priv, 0o600); err != nil {
 		t.Fatalf("write key file: %v", err)
 	}
 
-	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyDirs: []string{dir}})
 	h := srv.Handler()
 
 	body, _ := json.Marshal(map[string]string{"path": keyFile})
@@ -468,8 +470,11 @@ func TestForensicKeyLoadPath(t *testing.T) {
 }
 
 func TestForensicKeyLoadPathNotFound(t *testing.T) {
-	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
-	body, _ := json.Marshal(map[string]string{"path": "/nonexistent/forensic.key"})
+	// Use a temp dir as an allowed root so the path passes the allowlist check
+	// but the file itself does not exist.
+	dir := t.TempDir()
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyDirs: []string{dir}})
+	body, _ := json.Marshal(map[string]string{"path": dir + "/nonexistent.key"})
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
 	if w.Code != http.StatusBadRequest {
@@ -478,12 +483,13 @@ func TestForensicKeyLoadPathNotFound(t *testing.T) {
 }
 
 func TestForensicKeyLoadPathInvalidKey(t *testing.T) {
-	keyFile := t.TempDir() + "/bad.key"
+	dir := t.TempDir()
+	keyFile := dir + "/bad.key"
 	if err := os.WriteFile(keyFile, []byte("not a valid key"), 0o600); err != nil {
 		t.Fatalf("write file: %v", err)
 	}
 
-	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyDirs: []string{dir}})
 	body, _ := json.Marshal(map[string]string{"path": keyFile})
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
@@ -523,11 +529,12 @@ func TestForensicKeyLoadPathRequiresJSONContentType(t *testing.T) {
 	}
 
 	// Sanity-check: the helper that adds Content-Type: application/json reaches
-	// the path-validation branch (400) rather than being bounced at 415.
+	// the path-validation branch rather than being bounced at 415. The path
+	// /some/key is outside any allowed directory, so we expect 403 Forbidden.
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
-	if w.Code != http.StatusBadRequest {
-		t.Fatalf("with application/json: got %d, want 400 (file not found)", w.Code)
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("with application/json: got %d, want 403 (path not in allowed dir)", w.Code)
 	}
 }
 
@@ -680,12 +687,13 @@ func TestReadFileLimited_ReturnsTooLarge(t *testing.T) {
 // returns 413 (not 400) when the key file exceeds the size limit.
 func TestForensicKeyLoadPath_OversizedFile(t *testing.T) {
 	// Write a file larger than maxForensicKeyBody.
-	bigFile := t.TempDir() + "/big.key"
+	dir := t.TempDir()
+	bigFile := dir + "/big.key"
 	if err := os.WriteFile(bigFile, bytes.Repeat([]byte("x"), maxForensicKeyBody+1), 0o600); err != nil {
 		t.Fatalf("write big file: %v", err)
 	}
 
-	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyDirs: []string{dir}})
 	body, _ := json.Marshal(map[string]string{"path": bigFile})
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
@@ -695,10 +703,15 @@ func TestForensicKeyLoadPath_OversizedFile(t *testing.T) {
 }
 
 // TestForensicKeyLoadPath_RejectsDirectory verifies that pointing the path
-// endpoint at a directory returns 400 (not a hang or 500).
+// endpoint at a directory returns 400 (not a hang or 500). The directory
+// itself is added to ForensicKeyDirs so it passes the allowlist check and the
+// rejection comes from readFileLimited (non-regular file), not the allowlist.
 func TestForensicKeyLoadPath_RejectsDirectory(t *testing.T) {
 	dir := t.TempDir()
-	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	// Add the parent so the directory path itself (an exact-match of the root)
+	// passes the allowlist and is rejected by readFileLimited as non-regular.
+	parent := filepath.Dir(dir)
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyDirs: []string{parent}})
 	body, _ := json.Marshal(map[string]string{"path": dir})
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
@@ -709,6 +722,8 @@ func TestForensicKeyLoadPath_RejectsDirectory(t *testing.T) {
 
 // TestForensicKeyLoadPath_RejectsSymlink verifies that pointing the path
 // endpoint at a symlink (even one pointing to a valid key file) is rejected.
+// The dir is added to ForensicKeyDirs so the allowlist passes and rejection
+// comes from readFileLimited (Lstat sees a symlink, not a regular file).
 func TestForensicKeyLoadPath_RejectsSymlink(t *testing.T) {
 	priv, _, _ := forensicKeyPair(t)
 	dir := t.TempDir()
@@ -721,7 +736,7 @@ func TestForensicKeyLoadPath_RejectsSymlink(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 
-	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyDirs: []string{dir}})
 	body, _ := json.Marshal(map[string]string{"path": link})
 	w := httptest.NewRecorder()
 	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
@@ -746,6 +761,9 @@ func TestForensicAutoLoad_RejectsNonRegularFile(t *testing.T) {
 // ---------- validateForensicKeyPath barrier tests ----------
 
 func TestValidateForensicKeyPath(t *testing.T) {
+	// Allowed roots for these tests.
+	allowedDirs := []string{"/etc/agent-receipts", "/var/lib"}
+
 	tests := []struct {
 		name    string
 		path    string
@@ -758,10 +776,11 @@ func TestValidateForensicKeyPath(t *testing.T) {
 		{"dot-dot rejected", "/home/op/../../etc/passwd", "", errPathInvalid},
 		{"dot-dot backslash rejected", `/home/op\..\secret`, "", errPathInvalid},
 		{"nul byte rejected", "/home/op/forensic\x00.key", "", errPathInvalid},
+		{"outside allowed dirs", "/tmp/forensic.key", "", errPathNotAllowed},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			got, err := validateForensicKeyPath(tc.path)
+			got, err := validateForensicKeyPath(tc.path, allowedDirs)
 			if tc.wantErr != nil {
 				if !errors.Is(err, tc.wantErr) {
 					t.Fatalf("got err %v, want %v", err, tc.wantErr)
@@ -775,6 +794,119 @@ func TestValidateForensicKeyPath(t *testing.T) {
 				t.Fatalf("got %q, want %q", got, tc.want)
 			}
 		})
+	}
+}
+
+// TestValidateForensicKeyPathAllowlist verifies all allowlist edge cases.
+func TestValidateForensicKeyPathAllowlist(t *testing.T) {
+	root := "/home/user"
+	allowedDirs := []string{root}
+
+	tests := []struct {
+		name    string
+		path    string
+		wantErr error
+	}{
+		{
+			name:    "inside allowed dir",
+			path:    "/home/user/keys/forensic.key",
+			wantErr: nil,
+		},
+		{
+			name:    "equals allowed root",
+			path:    "/home/user",
+			wantErr: nil,
+		},
+		{
+			name:    "outside all roots",
+			path:    "/tmp/forensic.key",
+			wantErr: errPathNotAllowed,
+		},
+		{
+			// /home/user must not allow /home/usr2/x: the prefix check requires
+			// a path separator after the root to prevent a sibling directory from
+			// matching a root that is a prefix of its name.
+			name:    "boundary: sibling dir with common prefix not allowed",
+			path:    "/home/usr2/x",
+			wantErr: errPathNotAllowed,
+		},
+		{
+			name:    "still rejects dotdot",
+			path:    "/home/user/../etc/passwd",
+			wantErr: errPathInvalid,
+		},
+		{
+			name:    "still rejects NUL",
+			path:    "/home/user/forensic\x00.key",
+			wantErr: errPathInvalid,
+		},
+		{
+			name:    "still rejects relative",
+			path:    "forensic.key",
+			wantErr: errPathNotAbsolute,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := validateForensicKeyPath(tc.path, allowedDirs)
+			if tc.wantErr == nil {
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				return
+			}
+			if !errors.Is(err, tc.wantErr) {
+				t.Fatalf("got err %v, want %v", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// TestForensicKeyPathEndpointAllowlist verifies that a key file in an
+// explicitly configured ForensicKeyDirs entry loads successfully (200).
+func TestForensicKeyPathEndpointAllowlist(t *testing.T) {
+	priv, _, fp := forensicKeyPair(t)
+	dir := t.TempDir()
+	keyFile := dir + "/forensic.key"
+	if err := os.WriteFile(keyFile, priv, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyDirs: []string{dir}})
+	body, _ := json.Marshal(map[string]string{"path": keyFile})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusOK {
+		t.Fatalf("got %d, want 200 (body=%s)", w.Code, w.Body)
+	}
+	var st forensicKeyStatus
+	if err := json.Unmarshal(w.Body.Bytes(), &st); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !st.Loaded || st.Fingerprint != fp {
+		t.Fatalf("status: loaded=%v fingerprint=%q want loaded=true fingerprint=%q", st.Loaded, st.Fingerprint, fp)
+	}
+}
+
+// TestForensicKeyPathEndpointNotAllowed verifies that a key file outside all
+// allowed directories is rejected with 403 Forbidden.
+func TestForensicKeyPathEndpointNotAllowed(t *testing.T) {
+	priv, _, _ := forensicKeyPair(t)
+	// Write the key to a temp dir, but do NOT add that dir to ForensicKeyDirs.
+	dir := t.TempDir()
+	keyFile := dir + "/forensic.key"
+	if err := os.WriteFile(keyFile, priv, 0o600); err != nil {
+		t.Fatalf("write key file: %v", err)
+	}
+
+	// Use a different temp dir as the allowed root so the key file is outside it.
+	allowedDir := t.TempDir()
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyDirs: []string{allowedDir}})
+	body, _ := json.Marshal(map[string]string{"path": keyFile})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("got %d, want 403", w.Code)
 	}
 }
 

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -8,6 +8,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"encoding/pem"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -610,5 +611,134 @@ func TestForensicAutoLoadSkipsNonLoopback(t *testing.T) {
 	loaded, _ := srv.forensic.status()
 	if loaded {
 		t.Fatal("key was auto-loaded on non-loopback bind, should have been skipped")
+	}
+}
+
+// ---------- readFileLimited hardening tests ----------
+
+// TestReadFileLimited_RegularFile verifies the happy path still works.
+func TestReadFileLimited_RegularFile(t *testing.T) {
+	f := t.TempDir() + "/ok.bin"
+	want := []byte("hello forensic")
+	if err := os.WriteFile(f, want, 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	got, err := readFileLimited(f, 1024)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+// TestReadFileLimited_RejectsDirectory verifies that a directory path is
+// rejected as a non-regular file.
+func TestReadFileLimited_RejectsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	_, err := readFileLimited(dir, 1024)
+	if err == nil {
+		t.Fatal("expected error for directory, got nil")
+	}
+}
+
+// TestReadFileLimited_RejectsSymlink verifies that a symlink (even one that
+// points at a valid regular file) is rejected. We use Lstat, so the symlink
+// itself is seen as a non-regular file rather than its target.
+func TestReadFileLimited_RejectsSymlink(t *testing.T) {
+	dir := t.TempDir()
+	target := dir + "/real.bin"
+	link := dir + "/link.bin"
+	if err := os.WriteFile(target, []byte("data"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+	_, err := readFileLimited(link, 1024)
+	if err == nil {
+		t.Fatal("expected error for symlink, got nil")
+	}
+}
+
+// TestReadFileLimited_ReturnsTooLarge verifies errFileTooLarge is returned
+// when the file exceeds the limit.
+func TestReadFileLimited_ReturnsTooLarge(t *testing.T) {
+	f := t.TempDir() + "/big.bin"
+	if err := os.WriteFile(f, bytes.Repeat([]byte("x"), 10), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	_, err := readFileLimited(f, 5)
+	if !errors.Is(err, errFileTooLarge) {
+		t.Fatalf("got error %v, want errFileTooLarge", err)
+	}
+}
+
+// ---------- HTTP endpoint tests for the new hardening ----------
+
+// TestForensicKeyLoadPath_OversizedFile verifies that the path endpoint
+// returns 413 (not 400) when the key file exceeds the size limit.
+func TestForensicKeyLoadPath_OversizedFile(t *testing.T) {
+	// Write a file larger than maxForensicKeyBody.
+	bigFile := t.TempDir() + "/big.key"
+	if err := os.WriteFile(bigFile, bytes.Repeat([]byte("x"), maxForensicKeyBody+1), 0o600); err != nil {
+		t.Fatalf("write big file: %v", err)
+	}
+
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	body, _ := json.Marshal(map[string]string{"path": bigFile})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusRequestEntityTooLarge {
+		t.Fatalf("got %d, want 413", w.Code)
+	}
+}
+
+// TestForensicKeyLoadPath_RejectsDirectory verifies that pointing the path
+// endpoint at a directory returns 400 (not a hang or 500).
+func TestForensicKeyLoadPath_RejectsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	body, _ := json.Marshal(map[string]string{"path": dir})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", w.Code)
+	}
+}
+
+// TestForensicKeyLoadPath_RejectsSymlink verifies that pointing the path
+// endpoint at a symlink (even one pointing to a valid key file) is rejected.
+func TestForensicKeyLoadPath_RejectsSymlink(t *testing.T) {
+	priv, _, _ := forensicKeyPair(t)
+	dir := t.TempDir()
+	target := dir + "/forensic.key"
+	link := dir + "/link.key"
+	if err := os.WriteFile(target, priv, 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	if err := os.Symlink(target, link); err != nil {
+		t.Fatalf("symlink: %v", err)
+	}
+
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	body, _ := json.Marshal(map[string]string{"path": link})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", w.Code)
+	}
+}
+
+// TestForensicAutoLoad_RejectsNonRegularFile verifies that tryLoadDefaultForensicKey
+// does not hang or crash when ForensicKeyPath points at a non-regular file such
+// as a directory. The server must start successfully and leave the key unloaded.
+func TestForensicAutoLoad_RejectsNonRegularFile(t *testing.T) {
+	dir := t.TempDir()
+	// Use the directory itself as the "key path" — clearly non-regular.
+	srv := seedReceipts(t, Config{Host: "127.0.0.1", ForensicKeyPath: dir})
+	loaded, _ := srv.forensic.status()
+	if loaded {
+		t.Fatal("key was auto-loaded from a directory, should have been skipped")
 	}
 }

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -742,3 +742,50 @@ func TestForensicAutoLoad_RejectsNonRegularFile(t *testing.T) {
 		t.Fatal("key was auto-loaded from a directory, should have been skipped")
 	}
 }
+
+// ---------- validateForensicKeyPath barrier tests ----------
+
+func TestValidateForensicKeyPath(t *testing.T) {
+	tests := []struct {
+		name    string
+		path    string
+		want    string
+		wantErr error
+	}{
+		{"absolute", "/etc/agent-receipts/forensic.key", "/etc/agent-receipts/forensic.key", nil},
+		{"cleans redundant separators", "/var//lib/./forensic.key", "/var/lib/forensic.key", nil},
+		{"relative rejected", "forensic.key", "", errPathNotAbsolute},
+		{"dot-dot rejected", "/home/op/../../etc/passwd", "", errPathInvalid},
+		{"dot-dot backslash rejected", `/home/op\..\secret`, "", errPathInvalid},
+		{"nul byte rejected", "/home/op/forensic\x00.key", "", errPathInvalid},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateForensicKeyPath(tc.path)
+			if tc.wantErr != nil {
+				if !errors.Is(err, tc.wantErr) {
+					t.Fatalf("got err %v, want %v", err, tc.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Fatalf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestForensicKeyLoadPath_RejectsTraversal verifies the path endpoint rejects a
+// traversal segment with 400 before any filesystem read.
+func TestForensicKeyLoadPath_RejectsTraversal(t *testing.T) {
+	srv := seedReceipts(t, Config{Host: "127.0.0.1"})
+	body, _ := json.Marshal(map[string]string{"path": "/home/op/../../../etc/passwd"})
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, localJSONReq("POST", "/api/forensic-key/path", bytes.NewReader(body)))
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("got %d, want 400", w.Code)
+	}
+}

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -637,8 +637,8 @@ func TestReadFileLimited_RegularFile(t *testing.T) {
 func TestReadFileLimited_RejectsDirectory(t *testing.T) {
 	dir := t.TempDir()
 	_, err := readFileLimited(dir, 1024)
-	if err == nil {
-		t.Fatal("expected error for directory, got nil")
+	if !errors.Is(err, errNotRegularFile) {
+		t.Fatalf("got error %v, want errNotRegularFile", err)
 	}
 }
 
@@ -656,8 +656,8 @@ func TestReadFileLimited_RejectsSymlink(t *testing.T) {
 		t.Fatalf("symlink: %v", err)
 	}
 	_, err := readFileLimited(link, 1024)
-	if err == nil {
-		t.Fatal("expected error for symlink, got nil")
+	if !errors.Is(err, errNotRegularFile) {
+		t.Fatalf("got error %v, want errNotRegularFile", err)
 	}
 }
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -49,6 +49,9 @@ type Config struct {
 	// loads it automatically so operators with a single-user install do not
 	// need to paste the key into the UI.
 	ForensicKeyPath string
+	// ForensicKeyDirs lists extra directories, in addition to the user's home
+	// directory, from which the forensic key path endpoint may load a key.
+	ForensicKeyDirs []string
 }
 
 //go:embed static
@@ -56,20 +59,39 @@ var staticFS embed.FS
 
 // Server is the dashboard HTTP server.
 type Server struct {
-	reader   *store.Reader
-	cfg      Config
-	forensic *forensicKeyStore
+	reader          *store.Reader
+	cfg             Config
+	forensic        *forensicKeyStore
+	forensicKeyDirs []string // cleaned, absolute allowed roots for the key path endpoint
 }
 
 // New creates a new Server backed by the given reader. A zero PollInterval
 // in cfg falls back to DefaultPollInterval. When cfg.ForensicKeyPath names an
 // existing file and the server is bound to loopback, the forensic key is
 // loaded automatically so solo operators need no manual UI step.
+//
+// The allowed roots for the forensic key path endpoint are computed once here:
+// the user's home directory (silently omitted if unavailable) plus any
+// absolute paths in cfg.ForensicKeyDirs (non-absolute entries are skipped).
 func New(reader *store.Reader, cfg Config) *Server {
 	if cfg.PollInterval <= 0 {
 		cfg.PollInterval = DefaultPollInterval
 	}
-	s := &Server{reader: reader, cfg: cfg, forensic: &forensicKeyStore{}}
+
+	var dirs []string
+	if home, err := os.UserHomeDir(); err == nil {
+		if cleaned := filepath.Clean(home); filepath.IsAbs(cleaned) {
+			dirs = append(dirs, cleaned)
+		}
+	}
+	for _, d := range cfg.ForensicKeyDirs {
+		cleaned := filepath.Clean(d)
+		if filepath.IsAbs(cleaned) {
+			dirs = append(dirs, cleaned)
+		}
+	}
+
+	s := &Server{reader: reader, cfg: cfg, forensic: &forensicKeyStore{}, forensicKeyDirs: dirs}
 	s.tryLoadDefaultForensicKey()
 	return s
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -580,8 +580,9 @@ var errFileTooLarge = errors.New("file too large")
 // errors.Is to surface a precise message instead of a raw read error.
 var errNotRegularFile = errors.New("not a regular file")
 
-// readFileLimited reads up to limit bytes from path. It returns errFileTooLarge
-// when the file exceeds limit. Non-regular files (symlinks, FIFOs, devices,
+// readFileLimited reads up to limit+1 bytes from path — one past the limit, so
+// an over-size file can be detected without reading it whole — and returns
+// errFileTooLarge when the file exceeds limit. Non-regular files (symlinks, FIFOs, devices,
 // directories) are rejected via Lstat before opening, so a FIFO at the path
 // cannot hang startup and a device cannot be read through the path endpoint.
 // A residual Lstat/Open TOCTOU window remains, which is acceptable here: the

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -570,21 +570,44 @@ func (s *Server) handleIndex(w http.ResponseWriter, r *http.Request) {
 	w.Write(data)
 }
 
-// readFileLimited reads up to limit+1 bytes from path. Returns an error if the
-// file exceeds limit, so callers can reject oversized inputs without reading
-// the whole file into memory first.
+// errFileTooLarge is returned by readFileLimited when a file exceeds the byte
+// limit. Callers can test for it with errors.Is to distinguish an over-size
+// file from other read errors and map it to an appropriate HTTP status (413).
+var errFileTooLarge = errors.New("file too large")
+
+// errNotRegularFile is returned by readFileLimited when the path is not a
+// regular file (symlink, FIFO, device, directory). Callers can test for it with
+// errors.Is to surface a precise message instead of a raw read error.
+var errNotRegularFile = errors.New("not a regular file")
+
+// readFileLimited reads up to limit bytes from path. It returns errFileTooLarge
+// when the file exceeds limit. Non-regular files (symlinks, FIFOs, devices,
+// directories) are rejected via Lstat before opening, so a FIFO at the path
+// cannot hang startup and a device cannot be read through the path endpoint.
+// A residual Lstat/Open TOCTOU window remains, which is acceptable here: the
+// path is operator-supplied on a loopback-only, read-only dashboard.
 func readFileLimited(path string, limit int64) ([]byte, error) {
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, errNotRegularFile
+	}
+
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
 	}
 	defer f.Close()
+
 	data, err := io.ReadAll(io.LimitReader(f, limit+1))
 	if err != nil {
 		return nil, err
 	}
 	if int64(len(data)) > limit {
-		return nil, fmt.Errorf("file exceeds %d byte limit", limit)
+		zero(data)
+		return nil, errFileTooLarge
 	}
 	return data, nil
 }


### PR DESCRIPTION
Closes #78 (follow-up from #77).

Tightens the forensic key file read path (`readFileLimited`) against three edge cases the path-read variant introduced in #77 either lost or never had.

## Changes

1. **Reject non-regular files.** `readFileLimited` now `Lstat`s the path and rejects anything that isn't `mode.IsRegular()` (symlinks, FIFOs, sockets, devices, directories) *before* `os.Open`. This closes:
   - **Startup hang**: a FIFO at `cfg.ForensicKeyPath` previously blocked `os.Open` inside `New()` indefinitely. The auto-load path now logs and skips (never fatal), per its existing contract.
   - **Device read via the path endpoint**: pointing `POST /api/forensic-key/path` at `/dev/zero` no longer triggers a read.
   - Symlinks are rejected at the link level (`Lstat`, not `Stat`). A residual `Lstat`/`Open` TOCTOU window remains and is documented as acceptable: the path is operator-supplied on a loopback-only, read-only dashboard.

2. **Zero the buffer on size-exceeded.** The over-limit branch now `zero()`s the allocated buffer before returning, so key material in a wrong-file read doesn't linger for GC (restoring the property the body-load handler's `defer zero(body)` had).

3. **Return 413 on oversize via the path endpoint.** `readFileLimited` returns an `errFileTooLarge` sentinel; `handleForensicKeyLoadPath` maps it to **413 Request Entity Too Large** (matching `handleForensicKeyLoad`) instead of a generic 400. A companion `errNotRegularFile` sentinel yields a precise `400 "key file must be a regular file"` rather than leaking the raw read error.

## Tests

New coverage in `internal/server/forensic_test.go` (regular/directory/symlink/oversize) and `internal/server/forensic_fifo_test.go` (FIFO cases, behind `//go:build unix` so the suite still compiles on Windows). HTTP-level tests assert 413 on oversize and 400 on directory/symlink/FIFO, plus a startup test that a non-regular `ForensicKeyPath` leaves the key unloaded without hanging.

`go vet ./...` and `go test ./...` pass; `GOOS=windows go vet ./internal/server/` confirms cross-platform compile.