### PR TITLE
chore(release): bump to v0.9.0-alpha.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0-alpha.3] - 2026-06-20
+
 ### Added
 
 - **`-forensic-key-dirs` flag** ([#78](https://github.com/agent-receipts/dashboard/issues/78)) — comma-separated list of extra absolute directories from which the forensic key path endpoint (`POST /api/forensic-key/path`) may load a key. The user's home directory is always allowed; non-absolute entries are silently skipped.


### PR DESCRIPTION
Cuts **v0.9.0-alpha.3**, dating the `[Unreleased]` CHANGELOG section. Same minimal pattern as #142 (insert the version heading; no code changes).

### Included since v0.9.0-alpha.2
- **#78** — forensic key file-read hardening (reject non-regular files, zero over-size buffer, 413), a `validateForensicKeyPath` traversal/NUL barrier, and a path-endpoint directory allowlist with the new `-forensic-key-dirs` flag (#143).
- **#79** — Origin-based CSRF guard on the forensic key write endpoints (#144).

### Release steps after merge
1. Tag the merge commit `v0.9.0-alpha.3` and push — `release.yml` (goreleaser) builds the binaries and creates the GitHub pre-release; `publish.yml` then requests pkg.go.dev indexing.