### PR TITLE
chore(deps): bump obsigna SDK to v0.21.0-alpha.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/agent-receipts/dashboard
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.2
+	github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1
 	modernc.org/sqlite v1.52.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.2 h1:u/1czC2DB3S9yAVgR6k+hv9/7pGmsBEHFHbIN1NQlew=
-github.com/agent-receipts/ar/sdk/go v0.20.0-alpha.2/go.mod h1:T1hd+n4TaLjMZ45zCAFK/2U/2BhR+/NVdNSuZkFGl6g=
+github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1 h1:tpH1h9UDjyNF7f/HQ7p1oSVoY/FuizYMI/DtaNPAMM8=
+github.com/agent-receipts/ar/sdk/go v0.21.0-alpha.1/go.mod h1:T1hd+n4TaLjMZ45zCAFK/2U/2BhR+/NVdNSuZkFGl6g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=


### PR DESCRIPTION
## Summary

- Bumps `github.com/agent-receipts/ar/sdk/go` from `v0.20.0-alpha.2` → `v0.21.0-alpha.1`
- All tests pass (`go test ./...`)
- No dashboard API or UI changes

## SDK changes in this release (obsigna #905)

- `refactor(sdk/go)`: risk primitives extracted into a receipt-free leaf package
- `feat(daemon)`: bound inline plaintext error + prompt_preview fields
- `feat(hook)`: classify shell `rm`/`mv`/`cp` so deletes carry a target and real risk