### PR TITLE
chore(release): bump to v0.9.0-alpha.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0-alpha.4] - 2026-06-20
+
 ## [0.9.0-alpha.3] - 2026-06-20
 
 ### Added


### PR DESCRIPTION
Stamps the CHANGELOG for `v0.9.0-alpha.4`.

After merge, push the annotated tag:

```
git tag -a v0.9.0-alpha.4 -m "v0.9.0-alpha.4"
git push origin v0.9.0-alpha.4
```

## What's in this release

- Bumps obsigna SDK `v0.20.0-alpha.2` → `v0.21.0-alpha.1` (#147)