### PR TITLE
Rebrand dashboard UI from "Agent Receipts" to "Obsigna"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Rebranded the dashboard UI from "Agent Receipts" to "Obsigna"** — the page title, header brand, action-type reference description, and the empty-database CLI hint now read "Obsigna". GitHub URLs, Go import paths, and on-disk `agent-receipts` paths are unchanged.
+
 ## [0.9.0-alpha.4] - 2026-06-20
 
 ### Changed

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -157,7 +157,7 @@ func main() {
 	reader, err := store.OpenReadOnly(*dbPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) && !dbExplicit {
-			log.Fatalf("no receipts database at default path %s\n\nPass -db <path/to/receipts.db>, or run mcp-proxy / an Agent Receipts SDK to create one.", defaultDB)
+			log.Fatalf("no receipts database at default path %s\n\nPass -db <path/to/receipts.db>, or run mcp-proxy / an Obsigna SDK to create one.", defaultDB)
 		}
 		log.Fatalf("open database: %v", err)
 	}

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Agent Receipts Dashboard</title>
+  <title>Obsigna Dashboard</title>
   <script src="https://unpkg.com/htmx.org@2.0.4"></script>
   <script src="https://cdn.tailwindcss.com"></script>
   <script>
@@ -683,7 +683,7 @@
           <path d="M9 12l2 2 4-4"/>
           <path d="M12 22c5.523 0 10-4.477 10-10S17.523 2 12 2 2 6.477 2 12s4.477 10 10 10z"/>
         </svg>
-        <span>Agent Receipts</span>
+        <span>Obsigna</span>
         <span class="brand-label">Dashboard</span>
       </div>
 
@@ -1614,7 +1614,7 @@
         <div class="card-head flex items-center justify-between mb-3">
           <div>
             <h3 class="text-sm font-medium muted">Action type reference</h3>
-            <p class="text-xs subtle" style="margin-top:2px;">Built-in action types from the Agent Receipts taxonomy, with their meaning and default risk level.</p>
+            <p class="text-xs subtle" style="margin-top:2px;">Built-in action types from the Obsigna taxonomy, with their meaning and default risk level.</p>
           </div>
           <button class="card-collapse" type="button" aria-label="Collapse Action type reference" onclick="toggleCardCollapse('taxonomy-reference')">▾</button>
         </div>


### PR DESCRIPTION
## What

Rebrands the dashboard user interface from "Agent Receipts" to "Obsigna" across all user-facing text:
- Page title in HTML `<title>` tag
- Header brand name and logo text
- Action type reference description
- CLI error message hint

Internal paths, GitHub URLs, and Go import paths remain unchanged.

## Why

The project is being rebranded to use "Obsigna" as the primary user-facing name for the dashboard, while maintaining backward compatibility with existing infrastructure and references.

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] No new functionality (rebranding only)
- [x] CHANGELOG.md updated with rebranding note
- [x] Commit messages follow Conventional Commits