### PR TITLE
chore(release): bump to v0.9.0-alpha.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0-alpha.5] - 2026-06-23
+
 ### Changed
 
 - **Rebranded the dashboard UI from "Agent Receipts" to "Obsigna"** — the page title, header brand, action-type reference description, and the empty-database CLI hint now read "Obsigna". GitHub URLs, Go import paths, and on-disk `agent-receipts` paths are unchanged.


### PR DESCRIPTION
Promotes the `[Unreleased]` CHANGELOG entries to `[0.9.0-alpha.5] - 2026-06-23`.

## Changes in this release

- Rebrand dashboard UI from "Agent Receipts" to "Obsigna" (#152)

## Release checklist

- [ ] Merge this PR
- [ ] Tag the merge commit: `git tag -a v0.9.0-alpha.5 -m "v0.9.0-alpha.5" <sha>`
- [ ] Push tag: `git push origin v0.9.0-alpha.5`