### PR TITLE
chore(deps): migrate Obsigna SDK to obsigna.dev/sdk/go v0.23.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,8 +50,8 @@ internal/verify/        # Hash linkage and chain verification
 This project depends on the Agent Receipts Go SDK for receipt verification and taxonomy:
 
 ```
-github.com/agent-receipts/ar/sdk/go   # Receipt types, hashing, chain verification, taxonomy
-modernc.org/sqlite                     # Pure Go SQLite driver
+obsigna.dev/sdk/go   # Receipt types, hashing, chain verification, taxonomy
+modernc.org/sqlite   # Pure Go SQLite driver
 ```
 
 ## Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Migrated the Obsigna Go SDK to its production module path `obsigna.dev/sdk/go` at `v0.23.0`** — replaces the pre-release `github.com/agent-receipts/ar/sdk/go v0.22.0-alpha.1`. The vanity import path carries the same version history; no API changes.
+
 ## [0.9.0-alpha.5] - 2026-06-23
 
 ### Changed

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/agent-receipts/dashboard
 go 1.26.1
 
 require (
-	github.com/agent-receipts/ar/sdk/go v0.22.0-alpha.1
 	modernc.org/sqlite v1.52.0
+	obsigna.dev/sdk/go v0.23.0
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/agent-receipts/ar/sdk/go v0.22.0-alpha.1 h1:5upEO6dI88n/a7/dnl1p8A5YUTNO1qGWWJiHYSZGzxs=
-github.com/agent-receipts/ar/sdk/go v0.22.0-alpha.1/go.mod h1:T1hd+n4TaLjMZ45zCAFK/2U/2BhR+/NVdNSuZkFGl6g=
 github.com/cloudflare/circl v1.6.3 h1:9GPOhQGF9MCYUeXyMYlqTR6a5gTrgR/fBLXvUgtVcg8=
 github.com/cloudflare/circl v1.6.3/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
@@ -55,3 +53,5 @@ modernc.org/strutil v1.2.1 h1:UneZBkQA+DX2Rp35KcM69cSsNES9ly8mQWD71HKlOA0=
 modernc.org/strutil v1.2.1/go.mod h1:EHkiggD70koQxjVdSBM3JKM7k6L0FbGE5eymy9i3B9A=
 modernc.org/token v1.1.0 h1:Xl7Ap9dKaEs5kLoOQeQmPWevfnk/DM5qcLcYlA8ys6Y=
 modernc.org/token v1.1.0/go.mod h1:UGzOrNV1mAFSEB63lOFHIpNRUVMvYTc6yu1SMY/XTDM=
+obsigna.dev/sdk/go v0.23.0 h1:vNiFOgkWtdAvNqZFa4I4hryp1erdhXVf5PeH6Z0H02w=
+obsigna.dev/sdk/go v0.23.0/go.mod h1:bz3S/FcTDwDwgQytB4CpyXJ1UCiuQ5uqCw+lNTBbiaI=

--- a/internal/server/forensic.go
+++ b/internal/server/forensic.go
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 )
 
 // maxForensicKeyBody bounds the request body accepted by the key-load endpoint.

--- a/internal/server/forensic_test.go
+++ b/internal/server/forensic_test.go
@@ -16,8 +16,8 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	sdkstore "github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/sdk/go/receipt"
+	sdkstore "obsigna.dev/sdk/go/store"
 	"github.com/agent-receipts/dashboard/internal/store"
 )
 

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/taxonomy"
+	"obsigna.dev/sdk/go/taxonomy"
 	"github.com/agent-receipts/dashboard/internal/store"
 	"github.com/agent-receipts/dashboard/internal/verify"
 )

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -8,9 +8,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	sdkstore "github.com/agent-receipts/ar/sdk/go/store"
-	"github.com/agent-receipts/ar/sdk/go/taxonomy"
+	"obsigna.dev/sdk/go/receipt"
+	sdkstore "obsigna.dev/sdk/go/store"
+	"obsigna.dev/sdk/go/taxonomy"
 	"github.com/agent-receipts/dashboard/internal/store"
 )
 

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -11,7 +11,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 
 	_ "modernc.org/sqlite"
 )

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
-	sdkstore "github.com/agent-receipts/ar/sdk/go/store"
+	"obsigna.dev/sdk/go/receipt"
+	sdkstore "obsigna.dev/sdk/go/store"
 )
 
 // testDisclosureEnvelope returns a sentinel HPKE disclosure envelope sized to

--- a/internal/verify/chain.go
+++ b/internal/verify/chain.go
@@ -6,7 +6,7 @@ package verify
 import (
 	"log"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 
 	"github.com/agent-receipts/dashboard/internal/store"
 )

--- a/internal/verify/chain_test.go
+++ b/internal/verify/chain_test.go
@@ -8,7 +8,7 @@ import (
 	"encoding/pem"
 	"testing"
 
-	"github.com/agent-receipts/ar/sdk/go/receipt"
+	"obsigna.dev/sdk/go/receipt"
 
 	"github.com/agent-receipts/dashboard/internal/store"
 )


### PR DESCRIPTION
## Summary

Obsigna has graduated from alpha to a stable production release. This migrates the dashboard to the SDK's production module path and pins the latest stable version.

- **Module path:** `github.com/agent-receipts/ar/sdk/go` → `obsigna.dev/sdk/go` (vanity import; same version history)
- **Version:** `v0.22.0-alpha.1` → `v0.23.0`

The new path is a vanity import carrying the identical version history, so there are no API changes — only the import path and version pin.

## Changes

- Rewrote all SDK imports across `internal/server`, `internal/store`, `internal/verify` (8 Go files) to the new path.
- `go.mod` / `go.sum` updated and tidied.
- `AGENTS.md` Dependencies section now lists `obsigna.dev/sdk/go`.
- `CHANGELOG.md` entry under `[Unreleased]`.

Historical `CHANGELOG.md` entries referencing the old path are left intact (they record what was true at the time).

## Verification

- `go vet ./...` — clean
- `go test ./...` — all packages pass
- `go build ./...` — clean