### PR TITLE
chore(release): bump to v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-23
+
 ### Changed
 
 - **Migrated the Obsigna Go SDK to its production module path `obsigna.dev/sdk/go` at `v0.23.0`** — replaces the pre-release `github.com/agent-receipts/ar/sdk/go v0.22.0-alpha.1`. The vanity import path carries the same version history; no API changes.


### PR DESCRIPTION
## Summary

First **production** release of the dashboard, graduating out of the `v0.9.0-alpha.N` line to coincide with the Obsigna SDK going prod (`obsigna.dev/sdk/go v0.23.0`, landed in #154).

Per the release process, this PR only flips the CHANGELOG heading: `## [Unreleased]` → `## [0.9.0] - 2026-06-23`. After merge, push the annotated `v0.9.0` tag to trigger goreleaser.

## Release contents

- Migration to the production Obsigna SDK module path `obsigna.dev/sdk/go v0.23.0` (#154).

(All prior `v0.9.0-alpha.1`…`alpha.5` work is already recorded in the changelog under those headings.)

## Post-merge

```
git tag -a v0.9.0 -m "v0.9.0"
git push origin v0.9.0
```