### PR TITLE
feat(fleet): --experimental flag + activity-signature data layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`-experimental` flag** — new boolean CLI flag (default `false`) that gates experimental features. When set, the `GET /api/config` response includes `"experimental": true` so the frontend can conditionally enable experimental UI.
-- **`GET /api/fleet/signatures` endpoint** ([#156](https://github.com/agent-receipts/dashboard/issues/156)) — returns per-session activity signatures (receipt count, first/last seen, heuristic activity category breakdown, and agent-type distribution) for the most-recent sessions. Responds **404** unless `--experimental` is passed. Supports an optional `?limit=N` parameter (default 12, max 24, min 1). This is groundwork for the planned fleet activity-signature view.
+- **`GET /api/fleet/signatures` endpoint** ([#156](https://github.com/agent-receipts/dashboard/issues/156)) — returns per-session activity signatures (receipt count, first/last seen, heuristic activity category breakdown, and agent-type distribution) for the most-recent sessions. Responds **404** unless `-experimental` is passed. Supports an optional `?limit=N` parameter (default 12, max 24, min 1). This is groundwork for the planned fleet activity-signature view.
 
 ## [0.9.0] - 2026-06-23
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`-experimental` flag** — new boolean CLI flag (default `false`) that gates experimental features. When set, the `GET /api/config` response includes `"experimental": true` so the frontend can conditionally enable experimental UI.
+- **`GET /api/fleet/signatures` endpoint** ([#156](https://github.com/agent-receipts/dashboard/issues/156)) — returns per-session activity signatures (receipt count, first/last seen, heuristic activity category breakdown, and agent-type distribution) for the most-recent sessions. Responds **404** unless `--experimental` is passed. Supports an optional `?limit=N` parameter (default 12, max 24, min 1). This is groundwork for the planned fleet activity-signature view.
+
 ## [0.9.0] - 2026-06-23
 
 ### Changed

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -127,6 +127,7 @@ func main() {
 	port := flag.Int("port", 8080, "HTTP server port")
 	pollInterval := flag.Duration("poll-interval", server.DefaultPollInterval, "interval between live receipt polls (e.g. 5s)")
 	forensicKeyDirsFlag := flag.String("forensic-key-dirs", "", "comma-separated list of extra absolute directories from which the forensic key path endpoint may load a key (the user's home directory is always allowed)")
+	experimental := flag.Bool("experimental", false, "enable experimental features (e.g. /api/fleet/signatures)")
 	flag.Parse()
 
 	pollFlagSet := false
@@ -185,6 +186,7 @@ func main() {
 		Host:            *host,
 		ForensicKeyPath: defaultForensicKeyPath(),
 		ForensicKeyDirs: forensicKeyDirs,
+		Experimental:    *experimental,
 	})
 	addr := fmt.Sprintf("%s:%d", *host, *port)
 	log.Printf("dashboard listening on http://%s", addr)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -52,6 +52,9 @@ type Config struct {
 	// ForensicKeyDirs lists extra directories, in addition to the user's home
 	// directory, from which the forensic key path endpoint may load a key.
 	ForensicKeyDirs []string
+	// Experimental enables experimental features. When false, experimental
+	// API endpoints respond with 404.
+	Experimental bool
 }
 
 //go:embed static
@@ -146,6 +149,9 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/chains", s.handleChains)
 	mux.HandleFunc("GET /api/chains/{chainID}/verify", s.handleChainVerify)
 
+	// Experimental endpoints — gated by cfg.Experimental; return 404 when disabled.
+	mux.HandleFunc("GET /api/fleet/signatures", s.handleFleetSignatures)
+
 	// Forensic disclosure: load/clear the operator's X25519 private key (held
 	// in memory only) and decrypt a receipt's parameters_disclosure envelope
 	// inline. The decrypt route lives under its own prefix because the receipt
@@ -183,6 +189,7 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"db_path":          s.cfg.DBPath,
 		"db_name":          dbName,
 		"version":          s.cfg.Version,
+		"experimental":     s.cfg.Experimental,
 	})
 }
 
@@ -565,6 +572,53 @@ func (s *Server) handleChainVerify(w http.ResponseWriter, r *http.Request) {
 
 	result := verify.VerifyChainLinks(receipts, publicKeyPEM)
 	writeJSON(w, http.StatusOK, result)
+}
+
+func (s *Server) handleFleetSignatures(w http.ResponseWriter, r *http.Request) {
+	if !s.cfg.Experimental {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	const defaultLimit = 12
+	const maxLimit = 24
+
+	limit := defaultLimit
+	if v := r.URL.Query().Get("limit"); v != "" {
+		n, err := strconv.Atoi(v)
+		if err != nil || n < 1 {
+			writeError(w, http.StatusBadRequest, "limit must be a positive integer")
+			return
+		}
+		if n > maxLimit {
+			n = maxLimit
+		}
+		limit = n
+	}
+
+	sessions, err := s.reader.SessionStats(nil)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "session stats query failed")
+		log.Printf("fleet signatures: session stats error: %v", err)
+		return
+	}
+	if len(sessions) > limit {
+		sessions = sessions[:limit]
+	}
+
+	ids := make([]string, len(sessions))
+	for i, sess := range sessions {
+		ids[i] = sess.SessionID
+	}
+
+	sigs, err := s.reader.FleetSignatures(ids)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "fleet signatures query failed")
+		log.Printf("fleet signatures error: %v", err)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"signatures": sigs})
 }
 
 func validateEd25519PEM(pemStr string) error {

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1404,3 +1404,203 @@ func TestTaxonomyEndpoint(t *testing.T) {
 		}
 	}
 }
+
+// ---------- /api/config experimental field ----------
+
+func TestConfigEndpoint_ExperimentalField(t *testing.T) {
+	dbPath := seedTestDB(t)
+	reader, err := store.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { reader.Close() })
+
+	for _, tc := range []struct {
+		name         string
+		experimental bool
+	}{
+		{"experimental false (default)", false},
+		{"experimental true", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			srv := New(reader, Config{Experimental: tc.experimental})
+			req := httptest.NewRequest("GET", "/api/config", nil)
+			w := httptest.NewRecorder()
+			srv.Handler().ServeHTTP(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("got status %d, want 200", w.Code)
+			}
+			var got struct {
+				Experimental bool `json:"experimental"`
+			}
+			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if got.Experimental != tc.experimental {
+				t.Errorf("experimental = %v, want %v", got.Experimental, tc.experimental)
+			}
+		})
+	}
+}
+
+// ---------- /api/fleet/signatures endpoint ----------
+
+// seedFleetDB builds a DB with two sessions seeded with mixed action types and
+// agent types, suitable for testing the fleet signatures endpoint.
+func seedFleetDB(t *testing.T) *store.Reader {
+	t.Helper()
+	dbPath := t.TempDir() + "/fleet-srv-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	insert := func(ar receipt.AgentReceipt) {
+		h, err := receipt.HashReceipt(ar)
+		if err != nil {
+			t.Fatalf("hash: %v", err)
+		}
+		if err := s.Insert(ar, h); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+
+	makeFleet := func(id, chainID string, seq int, actionType, ts, sessionID, agentType string) receipt.AgentReceipt {
+		ar := makeReceipt(id, chainID, seq, actionType, receipt.RiskLow, receipt.StatusSuccess, ts, nil)
+		ar.Issuer.SessionID = sessionID
+		if agentType != "" {
+			ar.Issuer.Runtime = &receipt.Runtime{AgentType: agentType}
+		}
+		return ar
+	}
+
+	// Session alpha — more recent (last_seen 10:04), comes first in SessionStats.
+	insert(makeFleet("urn:receipt:fl1", "chain-fl1", 1, "claude-code.Bash", "2026-06-01T10:00:00Z", "alpha", ""))
+	insert(makeFleet("urn:receipt:fl2", "chain-fl1", 2, "claude-code.Read", "2026-06-01T10:01:00Z", "alpha", "general-purpose"))
+	insert(makeFleet("urn:receipt:fl3", "chain-fl1", 3, "mcp.github.read", "2026-06-01T10:04:00Z", "alpha", "Explore"))
+
+	// Session beta — older (last_seen 09:01), comes second in SessionStats.
+	insert(makeFleet("urn:receipt:fl4", "chain-fl2", 1, "claude-code.Edit", "2026-06-01T09:00:00Z", "beta", "general-purpose"))
+	insert(makeFleet("urn:receipt:fl5", "chain-fl2", 2, "claude-code.ToolSearch", "2026-06-01T09:01:00Z", "beta", "general-purpose"))
+
+	s.Close()
+
+	reader, err := store.OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	t.Cleanup(func() { reader.Close() })
+	return reader
+}
+
+func TestFleetSignaturesEndpoint_DisabledWithout_Experimental(t *testing.T) {
+	reader := seedFleetDB(t)
+	srv := New(reader, Config{Experimental: false})
+
+	req := httptest.NewRequest("GET", "/api/fleet/signatures", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("got status %d, want 404 when experimental=false", w.Code)
+	}
+	var body map[string]string
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode error body: %v", err)
+	}
+	if body["error"] == "" {
+		t.Error("expected error message in response body")
+	}
+}
+
+func TestFleetSignaturesEndpoint_OK(t *testing.T) {
+	reader := seedFleetDB(t)
+	srv := New(reader, Config{Experimental: true})
+
+	req := httptest.NewRequest("GET", "/api/fleet/signatures", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Signatures []store.SessionSignature `json:"signatures"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if body.Signatures == nil {
+		t.Error("signatures must be [] not null")
+	}
+	if len(body.Signatures) != 2 {
+		t.Fatalf("got %d signatures, want 2", len(body.Signatures))
+	}
+
+	// SessionStats orders by last_seen DESC: alpha (10:04) before beta (09:01).
+	if body.Signatures[0].SessionID != "alpha" {
+		t.Errorf("signatures[0].session_id = %q, want alpha", body.Signatures[0].SessionID)
+	}
+	if body.Signatures[0].ReceiptCount != 3 {
+		t.Errorf("alpha receipt_count = %d, want 3", body.Signatures[0].ReceiptCount)
+	}
+	if body.Signatures[0].Activity["bash"] != 1 {
+		t.Errorf("alpha activity[bash] = %d, want 1", body.Signatures[0].Activity["bash"])
+	}
+	if body.Signatures[0].Activity["mcp"] != 1 {
+		t.Errorf("alpha activity[mcp] = %d, want 1", body.Signatures[0].Activity["mcp"])
+	}
+	if body.Signatures[1].SessionID != "beta" {
+		t.Errorf("signatures[1].session_id = %q, want beta", body.Signatures[1].SessionID)
+	}
+	if body.Signatures[1].ReceiptCount != 2 {
+		t.Errorf("beta receipt_count = %d, want 2", body.Signatures[1].ReceiptCount)
+	}
+}
+
+func TestFleetSignaturesEndpoint_LimitParam(t *testing.T) {
+	reader := seedFleetDB(t)
+	srv := New(reader, Config{Experimental: true})
+
+	// limit=1 should return only the most-recent session (alpha).
+	req := httptest.NewRequest("GET", "/api/fleet/signatures?limit=1", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("limit=1: got status %d, want 200", w.Code)
+	}
+	var body struct {
+		Signatures []store.SessionSignature `json:"signatures"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Signatures) != 1 {
+		t.Fatalf("limit=1: got %d signatures, want 1", len(body.Signatures))
+	}
+	if body.Signatures[0].SessionID != "alpha" {
+		t.Errorf("limit=1: signatures[0].session_id = %q, want alpha", body.Signatures[0].SessionID)
+	}
+
+	// limit=0 and limit=-1 must return 400.
+	for _, bad := range []string{"0", "-1", "abc"} {
+		req = httptest.NewRequest("GET", "/api/fleet/signatures?limit="+bad, nil)
+		w = httptest.NewRecorder()
+		srv.Handler().ServeHTTP(w, req)
+		if w.Code != http.StatusBadRequest {
+			t.Errorf("limit=%s: got status %d, want 400", bad, w.Code)
+		}
+	}
+
+	// limit=99 must be silently capped at 24 (no error).
+	req = httptest.NewRequest("GET", "/api/fleet/signatures?limit=99", nil)
+	w = httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("limit=99: got status %d, want 200 (cap not reject)", w.Code)
+	}
+}

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -1215,6 +1215,154 @@ func (r *Reader) SessionAttribution(sessionID string) (AttributionResult, error)
 	}, nil
 }
 
+// SessionSignature aggregates activity metadata for a single agent session.
+// It is the per-session element returned by FleetSignatures.
+type SessionSignature struct {
+	SessionID    string         `json:"session_id"`
+	ReceiptCount int            `json:"receipt_count"`
+	FirstSeen    string         `json:"first_seen"`
+	LastSeen     string         `json:"last_seen"`
+	// Activity maps a heuristic category name to the number of receipts in that
+	// category for this session. See activityCategory for the mapping rules.
+	Activity map[string]int `json:"activity"`
+	// AgentTypes maps issuer.runtime.agent_type to its receipt count, excluding
+	// receipts with an empty/missing agent_type (the orchestrator/root).
+	AgentTypes map[string]int `json:"agent_types"`
+}
+
+// activityCategory maps an action_type string to a heuristic activity category.
+// The order of checks matters: "mcp" and "bash" take priority over everything
+// else; "edit"/"write"/"file.modify" must be tested before "read" so that
+// "file.modify" is not miscaught by the broader "read" check. This is a
+// starting categorisation to refine as real-world action_type strings are
+// observed.
+func activityCategory(actionType string) string {
+	s := strings.ToLower(actionType)
+	switch {
+	case strings.Contains(s, "mcp"):
+		return "mcp"
+	case strings.Contains(s, "bash"):
+		return "bash"
+	case strings.Contains(s, "edit") || strings.Contains(s, "write") || strings.Contains(s, "file.modify"):
+		return "edit"
+	case strings.Contains(s, "read"):
+		return "read"
+	case strings.Contains(s, "toolsearch") || strings.Contains(s, "grep") || strings.Contains(s, "glob"):
+		return "search"
+	case strings.Contains(s, "webfetch") || strings.Contains(s, "websearch"):
+		return "web"
+	case strings.Contains(s, "agent"):
+		return "agent"
+	case strings.Contains(s, "task"):
+		return "task"
+	default:
+		return "other"
+	}
+}
+
+// FleetSignatures returns one SessionSignature per input session ID, in the
+// same order as sessionIDs. An empty sessionIDs slice returns an empty non-nil
+// slice. Sessions that exist in the input but have no receipts in the store
+// are included with zero counts and empty maps.
+func (r *Reader) FleetSignatures(sessionIDs []string) ([]SessionSignature, error) {
+	if len(sessionIDs) == 0 {
+		return []SessionSignature{}, nil
+	}
+
+	// Build WHERE ... IN (?,?,...) placeholder string.
+	placeholders := strings.Repeat(",?", len(sessionIDs))[1:] // trim leading comma
+	args := make([]any, len(sessionIDs))
+	for i, id := range sessionIDs {
+		args[i] = id
+	}
+
+	// session_id needs no COALESCE: NULL IN (...) is never true, so rows with a
+	// NULL session_id are already excluded by the WHERE before the SELECT runs.
+	// agent_type does need it — root receipts (empty agent_type) reach the SELECT.
+	query := fmt.Sprintf(`
+		SELECT
+			json_extract(receipt_json, '$.issuer.session_id') AS session_id,
+			action_type,
+			COALESCE(json_extract(receipt_json, '$.issuer.runtime.agent_type'), '') AS agent_type,
+			timestamp
+		FROM receipts
+		WHERE json_extract(receipt_json, '$.issuer.session_id') IN (%s)
+	`, placeholders)
+
+	rows, err := r.db.Query(query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	type accum struct {
+		receiptCount int
+		firstSeen    string
+		lastSeen     string
+		activity     map[string]int
+		agentTypes   map[string]int
+	}
+	sessionMap := map[string]*accum{}
+
+	for rows.Next() {
+		var sessionID, actionType, agentType, timestamp string
+		if err := rows.Scan(&sessionID, &actionType, &agentType, &timestamp); err != nil {
+			return nil, err
+		}
+
+		acc := sessionMap[sessionID]
+		if acc == nil {
+			acc = &accum{
+				activity:   map[string]int{},
+				agentTypes: map[string]int{},
+			}
+			sessionMap[sessionID] = acc
+		}
+
+		acc.receiptCount++
+		acc.activity[activityCategory(actionType)]++
+
+		// Exclude empty/missing agent_type (orchestrator/root).
+		if agentType != "" {
+			acc.agentTypes[agentType]++
+		}
+
+		// ISO-8601 timestamps sort lexicographically; plain string comparison works.
+		if acc.firstSeen == "" || timestamp < acc.firstSeen {
+			acc.firstSeen = timestamp
+		}
+		if acc.lastSeen == "" || timestamp > acc.lastSeen {
+			acc.lastSeen = timestamp
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Preserve the caller's ordering.
+	out := make([]SessionSignature, 0, len(sessionIDs))
+	for _, sid := range sessionIDs {
+		acc := sessionMap[sid]
+		if acc == nil {
+			out = append(out, SessionSignature{
+				SessionID:  sid,
+				Activity:   map[string]int{},
+				AgentTypes: map[string]int{},
+			})
+			continue
+		}
+		out = append(out, SessionSignature{
+			SessionID:    sid,
+			ReceiptCount: acc.receiptCount,
+			FirstSeen:    acc.firstSeen,
+			LastSeen:     acc.lastSeen,
+			Activity:     acc.activity,
+			AgentTypes:   acc.agentTypes,
+		})
+	}
+	return out, nil
+}
+
 // Close closes the database connection.
 func (r *Reader) Close() error {
 	return r.db.Close()

--- a/internal/store/reader.go
+++ b/internal/store/reader.go
@@ -1231,11 +1231,11 @@ type SessionSignature struct {
 }
 
 // activityCategory maps an action_type string to a heuristic activity category.
-// The order of checks matters: "mcp" and "bash" take priority over everything
-// else; "edit"/"write"/"file.modify" must be tested before "read" so that
-// "file.modify" is not miscaught by the broader "read" check. This is a
-// starting categorisation to refine as real-world action_type strings are
-// observed.
+// Checks are ordered by precedence so that when an action_type contains more
+// than one category keyword, the intended one wins: "mcp" first (e.g.
+// "mcp.github.pull_request_read" is an MCP call, not a read), then "bash", then
+// edit/write before read. This is a starting categorisation to refine as
+// real-world action_type strings are observed.
 func activityCategory(actionType string) string {
 	s := strings.ToLower(actionType)
 	switch {

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -2852,6 +2852,287 @@ func TestReader_SessionStats_SinceFilter(t *testing.T) {
 	}
 }
 
+// ---------- activityCategory tests ----------
+
+func TestActivityCategory(t *testing.T) {
+	cases := []struct {
+		actionType string
+		want       string
+	}{
+		// MCP must beat all others.
+		{"mcp.github.pull_request_read", "mcp"},
+		{"MCP.tool.call", "mcp"},
+		// Bash.
+		{"claude-code.Bash", "bash"},
+		{"system.bash.execute", "bash"},
+		// Edit checked before read — "file.modify" must not fall through to "read".
+		{"claude-code.Edit", "edit"},
+		{"claude-code.Write", "edit"},
+		{"filesystem.file.modify", "edit"},
+		// Read.
+		{"claude-code.Read", "read"},
+		{"filesystem.file.read", "read"},
+		// Search.
+		{"claude-code.ToolSearch", "search"},
+		{"claude-code.Grep", "search"},
+		{"claude-code.Glob", "search"},
+		// Web.
+		{"claude-code.WebFetch", "web"},
+		{"claude-code.WebSearch", "web"},
+		// Agent.
+		{"claude-code.Agent", "agent"},
+		// Task.
+		{"claude-code.Task", "task"},
+		{"claude-code.TaskCreate", "task"},
+		// Other / fallback.
+		{"filesystem.file.delete", "other"},
+		{"communication.email.send", "other"},
+		{"", "other"},
+	}
+	for _, tc := range cases {
+		got := activityCategory(tc.actionType)
+		if got != tc.want {
+			t.Errorf("activityCategory(%q) = %q, want %q", tc.actionType, got, tc.want)
+		}
+	}
+}
+
+// ---------- FleetSignatures tests ----------
+
+// makeFleetReceipt builds a receipt with session_id and optional agent_type.
+func makeFleetReceipt(id, chainID string, seq int, actionType string,
+	ts, sessionID, agentType string) receipt.AgentReceipt {
+	ar := makeReceipt(id, chainID, seq, actionType, receipt.RiskLow, receipt.StatusSuccess, ts, nil)
+	ar.Issuer.SessionID = sessionID
+	if agentType != "" {
+		ar.Issuer.Runtime = &receipt.Runtime{AgentType: agentType}
+	}
+	return ar
+}
+
+func TestFleetSignatures_Empty(t *testing.T) {
+	dbPath := seedEmptyDB(t)
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer reader.Close()
+
+	sigs, err := reader.FleetSignatures(nil)
+	if err != nil {
+		t.Fatalf("FleetSignatures(nil): %v", err)
+	}
+	if sigs == nil {
+		t.Error("FleetSignatures(nil) returned nil; want non-nil empty slice")
+	}
+	if len(sigs) != 0 {
+		t.Errorf("FleetSignatures(nil): got %d entries, want 0", len(sigs))
+	}
+
+	sigs, err = reader.FleetSignatures([]string{})
+	if err != nil {
+		t.Fatalf("FleetSignatures([]): %v", err)
+	}
+	if sigs == nil {
+		t.Error("FleetSignatures([]) returned nil; want non-nil empty slice")
+	}
+	if len(sigs) != 0 {
+		t.Errorf("FleetSignatures([]): got %d entries, want 0", len(sigs))
+	}
+}
+
+func TestFleetSignatures_ActivityAndAgentTypes(t *testing.T) {
+	dbPath := t.TempDir() + "/fleet-sig-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	// Session A: mix of action types + two distinct agent types.
+	//   claude-code.Bash      → bash  (root: no agent_type)
+	//   claude-code.Read      → read  (general-purpose)
+	//   claude-code.Edit      → edit  (general-purpose)
+	//   mcp.github.read       → mcp   (Explore)
+	//   claude-code.ToolSearch → search (Explore)
+	insertFleet := func(ar receipt.AgentReceipt) {
+		h, err := receipt.HashReceipt(ar)
+		if err != nil {
+			t.Fatalf("hash: %v", err)
+		}
+		if err := s.Insert(ar, h); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	insertFleet(makeFleetReceipt("urn:receipt:fa1", "chain-fa", 1, "claude-code.Bash", "2026-05-01T10:00:00Z", "session-A", ""))
+	insertFleet(makeFleetReceipt("urn:receipt:fa2", "chain-fa", 2, "claude-code.Read", "2026-05-01T10:01:00Z", "session-A", "general-purpose"))
+	insertFleet(makeFleetReceipt("urn:receipt:fa3", "chain-fa", 3, "claude-code.Edit", "2026-05-01T10:02:00Z", "session-A", "general-purpose"))
+	insertFleet(makeFleetReceipt("urn:receipt:fa4", "chain-fa", 4, "mcp.github.read", "2026-05-01T10:03:00Z", "session-A", "Explore"))
+	insertFleet(makeFleetReceipt("urn:receipt:fa5", "chain-fa", 5, "claude-code.ToolSearch", "2026-05-01T10:04:00Z", "session-A", "Explore"))
+
+	// Session B: only a couple of receipts, earlier timestamps.
+	insertFleet(makeFleetReceipt("urn:receipt:fb1", "chain-fb", 1, "filesystem.file.read", "2026-05-01T09:00:00Z", "session-B", "general-purpose"))
+	insertFleet(makeFleetReceipt("urn:receipt:fb2", "chain-fb", 2, "filesystem.file.modify", "2026-05-01T09:01:00Z", "session-B", "general-purpose"))
+
+	s.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	// Call in A-first order to verify result ordering is preserved.
+	sigs, err := reader.FleetSignatures([]string{"session-A", "session-B"})
+	if err != nil {
+		t.Fatalf("FleetSignatures: %v", err)
+	}
+	if len(sigs) != 2 {
+		t.Fatalf("got %d signatures, want 2", len(sigs))
+	}
+
+	// --- session-A ---
+	sigA := sigs[0]
+	if sigA.SessionID != "session-A" {
+		t.Errorf("sigs[0].SessionID = %q, want session-A", sigA.SessionID)
+	}
+	if sigA.ReceiptCount != 5 {
+		t.Errorf("session-A ReceiptCount = %d, want 5", sigA.ReceiptCount)
+	}
+	if sigA.FirstSeen != "2026-05-01T10:00:00Z" {
+		t.Errorf("session-A FirstSeen = %q, want 2026-05-01T10:00:00Z", sigA.FirstSeen)
+	}
+	if sigA.LastSeen != "2026-05-01T10:04:00Z" {
+		t.Errorf("session-A LastSeen = %q, want 2026-05-01T10:04:00Z", sigA.LastSeen)
+	}
+
+	wantActivityA := map[string]int{
+		"bash":   1,
+		"read":   1,
+		"edit":   1,
+		"mcp":    1,
+		"search": 1,
+	}
+	for cat, want := range wantActivityA {
+		if got := sigA.Activity[cat]; got != want {
+			t.Errorf("session-A activity[%q] = %d, want %d", cat, got, want)
+		}
+	}
+	if total := 0; func() int {
+		for _, v := range sigA.Activity { total += v }; return total
+	}() != 5 {
+		t.Errorf("session-A total activity counts != 5: %v", sigA.Activity)
+	}
+
+	wantAgentTypesA := map[string]int{
+		"general-purpose": 2,
+		"Explore":         2,
+	}
+	for at, want := range wantAgentTypesA {
+		if got := sigA.AgentTypes[at]; got != want {
+			t.Errorf("session-A agent_types[%q] = %d, want %d", at, got, want)
+		}
+	}
+	// Root receipt (empty agent_type) must not appear in AgentTypes.
+	if len(sigA.AgentTypes) != 2 {
+		t.Errorf("session-A AgentTypes len = %d, want 2 (root excluded): %v", len(sigA.AgentTypes), sigA.AgentTypes)
+	}
+
+	// --- session-B ---
+	sigB := sigs[1]
+	if sigB.SessionID != "session-B" {
+		t.Errorf("sigs[1].SessionID = %q, want session-B", sigB.SessionID)
+	}
+	if sigB.ReceiptCount != 2 {
+		t.Errorf("session-B ReceiptCount = %d, want 2", sigB.ReceiptCount)
+	}
+	// "filesystem.file.read" → read; "filesystem.file.modify" → edit.
+	if sigB.Activity["read"] != 1 {
+		t.Errorf("session-B activity[read] = %d, want 1", sigB.Activity["read"])
+	}
+	if sigB.Activity["edit"] != 1 {
+		t.Errorf("session-B activity[edit] = %d, want 1 (file.modify must not fall through to read)", sigB.Activity["edit"])
+	}
+	if sigB.AgentTypes["general-purpose"] != 2 {
+		t.Errorf("session-B agent_types[general-purpose] = %d, want 2", sigB.AgentTypes["general-purpose"])
+	}
+}
+
+func TestFleetSignatures_OrderPreserved(t *testing.T) {
+	// Verify that FleetSignatures returns results in the same order as the
+	// input slice, not in the order rows come back from SQLite.
+	dbPath := t.TempDir() + "/fleet-order-test.db"
+	s, err := sdkstore.Open(dbPath)
+	if err != nil {
+		t.Fatalf("open sdk store: %v", err)
+	}
+
+	insertFleet := func(ar receipt.AgentReceipt) {
+		h, err := receipt.HashReceipt(ar)
+		if err != nil {
+			t.Fatalf("hash: %v", err)
+		}
+		if err := s.Insert(ar, h); err != nil {
+			t.Fatalf("insert: %v", err)
+		}
+	}
+	insertFleet(makeFleetReceipt("urn:receipt:fo1", "chain-fo1", 1, "claude-code.Bash", "2026-05-01T09:00:00Z", "session-Z", ""))
+	insertFleet(makeFleetReceipt("urn:receipt:fo2", "chain-fo2", 1, "claude-code.Read", "2026-05-01T10:00:00Z", "session-A", ""))
+	insertFleet(makeFleetReceipt("urn:receipt:fo3", "chain-fo3", 1, "claude-code.Edit", "2026-05-01T11:00:00Z", "session-M", ""))
+	s.Close()
+
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open reader: %v", err)
+	}
+	defer reader.Close()
+
+	// Request in Z, M, A order (reverse of any natural sort).
+	input := []string{"session-Z", "session-M", "session-A"}
+	sigs, err := reader.FleetSignatures(input)
+	if err != nil {
+		t.Fatalf("FleetSignatures: %v", err)
+	}
+	if len(sigs) != 3 {
+		t.Fatalf("got %d signatures, want 3", len(sigs))
+	}
+	for i, want := range input {
+		if sigs[i].SessionID != want {
+			t.Errorf("sigs[%d].SessionID = %q, want %q (order not preserved)", i, sigs[i].SessionID, want)
+		}
+	}
+}
+
+func TestFleetSignatures_UnknownSessionIDReturnsEmptyEntry(t *testing.T) {
+	// A session ID in the input that has no receipts must return an entry with
+	// zero counts and non-nil maps (not omitted from the slice).
+	dbPath := seedEmptyDB(t)
+	reader, err := OpenReadOnly(dbPath)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	defer reader.Close()
+
+	sigs, err := reader.FleetSignatures([]string{"no-such-session"})
+	if err != nil {
+		t.Fatalf("FleetSignatures: %v", err)
+	}
+	if len(sigs) != 1 {
+		t.Fatalf("got %d signatures, want 1", len(sigs))
+	}
+	if sigs[0].SessionID != "no-such-session" {
+		t.Errorf("SessionID = %q, want no-such-session", sigs[0].SessionID)
+	}
+	if sigs[0].ReceiptCount != 0 {
+		t.Errorf("ReceiptCount = %d, want 0", sigs[0].ReceiptCount)
+	}
+	if sigs[0].Activity == nil {
+		t.Error("Activity must be non-nil map for unknown session")
+	}
+	if sigs[0].AgentTypes == nil {
+		t.Error("AgentTypes must be non-nil map for unknown session")
+	}
+}
+
 // seedFileDB creates a temporary SQLite file with test data using the SDK store,
 // then closes the SDK store so the reader can open it read-only.
 func seedFileDB(t *testing.T) string {

--- a/internal/store/reader_test.go
+++ b/internal/store/reader_test.go
@@ -2865,7 +2865,7 @@ func TestActivityCategory(t *testing.T) {
 		// Bash.
 		{"claude-code.Bash", "bash"},
 		{"system.bash.execute", "bash"},
-		// Edit checked before read — "file.modify" must not fall through to "read".
+		// "file.modify" maps to edit via the file.modify check, not read.
 		{"claude-code.Edit", "edit"},
 		{"claude-code.Write", "edit"},
 		{"filesystem.file.modify", "edit"},
@@ -3050,7 +3050,7 @@ func TestFleetSignatures_ActivityAndAgentTypes(t *testing.T) {
 		t.Errorf("session-B activity[read] = %d, want 1", sigB.Activity["read"])
 	}
 	if sigB.Activity["edit"] != 1 {
-		t.Errorf("session-B activity[edit] = %d, want 1 (file.modify must not fall through to read)", sigB.Activity["edit"])
+		t.Errorf("session-B activity[edit] = %d, want 1 (file.modify maps to edit, not read)", sigB.Activity["edit"])
 	}
 	if sigB.AgentTypes["general-purpose"] != 2 {
 		t.Errorf("session-B agent_types[general-purpose] = %d, want 2", sigB.AgentTypes["general-purpose"])


### PR DESCRIPTION
## Summary

PR 1 of the rescoped #156 (fleet activity-signature overview). Adds the data-layer foundation behind a new **`--experimental`** flag — **no UI yet**.

This is the front-door data for the new direction: instead of cross-session collision edges (the old framing, since closed in #158 as a dead end), each session gets an **activity signature** — what kind of work it's doing — which is dense and varies meaningfully across sessions.

## Changes

- **`--experimental` flag** — new boolean CLI flag (default off), threaded into `server.Config` and surfaced in `GET /api/config` as `"experimental"` so the frontend can later gate the entry point.
- **`FleetSignatures(sessionIDs []string)`** (`internal/store/reader.go`) — read-only, one SQL pass over the given sessions, returning per-session: receipt count, first/last seen, an **activity-category histogram**, and an **agent-type histogram** (root excluded). Results preserve caller order; empty input → empty non-nil slice.
- **`activityCategory(actionType)`** — documented heuristic mapping action types to `bash / edit / read / search / mcp / web / agent / task / other`. Order-sensitive (mcp/bash first; edit before read so `file.modify` isn't miscaught). Flagged in-code as a starting categorisation to refine.
- **`GET /api/fleet/signatures?limit=N`** — flag-gated (**404 when `--experimental` is off**); `limit` default 12, cap 24, reject `<1` with 400; picks the N most-recently-active sessions via `SessionStats`.
- Tests: category table-test, `FleetSignatures` (activity/agent aggregation, order preservation, empty/unknown sessions), endpoint (404-when-disabled, OK shape/order, limit handling), `/api/config` experimental field.
- CHANGELOG `[Unreleased]` entry.

## Review notes

- Ran `/code-review`; fixed a dead `COALESCE` on `session_id` (NULL can't pass the `IN` filter). `go vet` + `go test ./...` green.
- `limit>24` is **clamped** (not 400) for consistency with the fleet endpoints; `SessionStats(nil)` fetch-all-then-slice matches the existing `/api/sessions` and fleet-attribution handlers on this local store.
- Categorisation is heuristic and string-based on `action_type`; expected to evolve as real action types are observed.

## Rollout

Behind `--experimental` (default off) — lands on `main` and rides normal releases invisibly; promoted to default once the view (PR 2) proves out on real data. No alpha.

Part of #156.
