### PR TITLE
docs: remove overclaiming language from session dependency graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Session dependency-graph wording is now evidential, not proof-claiming** — the README session-attribution section and the graph's coverage indicator no longer describe path-derived state-dependency edges as "provable"/making causal order "provable". These edges are derived from shared `action.target.resource` path strings (path identity ≠ file identity), so they are framed as evidence of a dependency. The coverage label reads `N / M receipts resource-linked` (was `identity-indexed`) and carries a tooltip explaining that Bash/MCP/spawn receipts are signed but carry no resource path. No behaviour change.
+
 ## [0.10.0] - 2026-07-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -126,18 +126,18 @@ The **Overview**, **Actions**, and **Servers** views turn a store into operation
 
 ## Session attribution
 
-When a session involves multiple agents, the dashboard builds a provable dependency graph from `action.target.resource` paths in the receipts (requires obsigna hook v0.19.0+).
+When a session involves multiple agents, the dashboard builds an observed dependency graph from `action.target.resource` paths in the receipts (requires obsigna hook v0.19.0+).
 
 ![Receipts tab with a session filter active — agent graph showing an orchestrator and sub-agents with delegation edges, filtered receipt list below](docs/session-attribution.png)
 
 **What you see:**
 
 - **Delegation edges** (dashed gray) — which agent spawned which
-- **State-dependency edges** (solid blue arrows) — two agents touched the same file; the arrow points from the agent that acted first to the one that acted after, making the causal order provable
+- **State-dependency edges** (solid blue arrows) — two agents touched the same resource path; the arrow points from the agent that acted first to the one that acted after. These edges are derived from shared `action.target.resource` strings, so they are evidence of a dependency, not proof of causal order
 - **Risk rings** — orange (medium) or red (critical) outer rings on nodes with elevated-risk receipts
 - **Blast-radius panel** — click any node to see which files it touched, which other agents share a state dependency on those files, and a heuristic co-turn coupling count when agents operated on the same resource in overlapping time windows
 
-**Coverage fraction** — a `N / M receipts identity-indexed` indicator shows how complete the picture is. Receipts without a `target.resource` (Bash, MCP, spawn) are counted but cannot contribute to file-identity edges. A `⚠ mv ops` warning appears when move or rename operations are detected, because path strings may not reliably identify file versions across renames.
+**Coverage fraction** — a `N / M receipts resource-linked` indicator shows how complete the picture is. Receipts without a `target.resource` (Bash, MCP, spawn) are counted but cannot contribute to file-dependency edges. A `⚠ mv ops` warning appears when move or rename operations are detected, because path strings may not reliably identify file versions across renames.
 
 The attribution data is served by `GET /api/sessions/{sessionID}/attribution`.
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -4042,7 +4042,7 @@
       const mvWarn = attribution.has_move_ops
         ? ' <span style="color:var(--risk-medium)" title="Move/rename operations detected — path strings may not reliably identify file versions across renames">⚠ mv ops</span>'
         : '';
-      el.innerHTML = `<span style="font-size:0.72rem;color:var(--muted)">${escapeHtml(String(cv.identity_receipts))} / ${escapeHtml(String(cv.total_receipts))} receipts identity-indexed (${pct}%)${mvWarn}</span>`;
+      el.innerHTML = `<span style="font-size:0.72rem;color:var(--muted)" title="receipts carrying a target.resource, which can contribute file-dependency edges. Bash/MCP/spawn receipts are signed but carry no resource path.">${escapeHtml(String(cv.identity_receipts))} / ${escapeHtml(String(cv.total_receipts))} receipts resource-linked (${pct}%)${mvWarn}</span>`;
     }
 
     // renderSessionGraphReceipts renders a compact flat receipt table into the


### PR DESCRIPTION
## What

Removes "prov*" overclaiming language from the session / dependency-graph feature. Path-derived state-dependency edges are inferred from shared `action.target.resource` path strings — path identity is not file identity, so these edges are **evidential**, not proof of causal order.

Changes (strings / README prose / tooltip markup only — no behaviour change, no internal identifiers renamed):

- **README** (`Session attribution` section): "provable dependency graph" → "observed dependency graph"; the state-dependency bullet no longer says the edge makes "the causal order provable" and now states the edges are "evidence of a dependency, not proof of causal order"; "touched the same file" → "touched the same resource path".
- **Coverage indicator** (`internal/server/static/index.html`): visible label `receipts identity-indexed` → `receipts resource-linked`, with a new tooltip: _"receipts carrying a target.resource, which can contribute file-dependency edges. Bash/MCP/spawn receipts are signed but carry no resource path."_ The internal fields (`cv.identity_receipts`, `cv.total_receipts`) are unchanged.
- **README** coverage wording aligned: `identity-indexed` → `resource-linked`, `file-identity edges` → `file-dependency edges`.
- **CHANGELOG**: `[Unreleased]` entry.

No tracking issue existed for this audit (the templated `closes #<A-issue>` had no matching issue in the repo), so no `closes` reference is included.

## Why

The graph edges are derived from shared resource-path strings; path identity ≠ file identity, so calling them "provable" overclaims. Wording is now factual and evidential.

## Left-in `prov*` hits (for human review)

Per the audit's ambiguity clause, these were left untouched because they fall outside "strings / README / tooltip markup" scope, or are arguably correct:

- **Code comments** describing state-dep edges as "provable" — `internal/server/static/index.html:3790, 3832, 3857, 3896` and `internal/store/reader.go:903, 908, 1061, 1135` (the latter also document the internal `StatDepEdge` type, which must not be renamed). These are internal docs, not user-facing strings.
- **`CHANGELOG.md:79`** — historical `0.x` entry stating state deps are "provably causal". Rewriting shipped changelog history seemed out of scope; flagging rather than editing.
- **`internal/server/static/index.html:4018`** — the co-turn-coupling warning says "(unproven — not a drawn edge)". This is under-claiming (correctly humble about a heuristic), not overclaiming; left as-is.
- **`internal/verify/chain_test.go:166, 408`** — "proving the test exercises…" refers to test logic / cryptographic divergence, not path edges; correct usage, left as-is.

## Checklist

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] No real keys or secrets in the diff
- [x] No new functionality (docs/strings only — no tests needed)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [ ] AGENTS.md updated if project structure changed (n/a)
