### PR TITLE
chore(release): bump to v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-07-15
+
 ### Added
 
 - **Fleet attribution data layer** — new `FleetAttribution([]sessionID)` and `GET /api/fleet/attribution?limit=N` endpoint compute one combined §4 attribution payload across the N most recently-active sessions (default 6, capped at 12). Agent keys are namespaced `<session_id>::<agent_key>` so each session's orchestrator stays distinct, and state-dependency edges spanning two sessions are flagged `cross_session` — the cross-session collision signal where two independent agents touch the same global resource. Each edge also carries `temporal_overlap`: whether the two edge-forming touches of the shared resource happened close in time — within a proximity threshold (generous 1-hour default, configurable via the `-temporal-proximity` flag) — distinguishing a concurrent collision (genuine contention for the resource at nearly the same moment) from the same resource merely touched at different times. This is measured from the two contending action timestamps, not from whether the sessions' lifetimes overlapped, so two long-lived sessions alive simultaneously but touching the resource hours apart are correctly reported as `temporal_overlap: false`. `StatDepEdge` gains `cross_session` and `temporal_overlap`; `NodeAttribution` gains `session_id`; single-session `SessionAttribution` output is unchanged except for the additive `session_id`. Groundwork for the upcoming fleet view (#156); no UI yet.


### PR DESCRIPTION
## What

Bumps the `[Unreleased]` CHANGELOG heading to `[0.11.0] - 2026-07-15`, covering:

- Fleet attribution data layer (`FleetAttribution`, `GET /api/fleet/attribution`) — backend groundwork for the Fleet view (#156); no UI yet
- Path-reuse limitation documented and characterized for cross-session collision detection (#157)
- Session dependency-graph wording made evidential rather than proof-claiming
- Forensic key endpoint security model documented in SECURITY.md

## Why

Minor version bump — new backward-compatible API surface (`/api/fleet/attribution`) since v0.10.0, no breaking changes.

## Checklist

- [x] `go vet ./...` passes
- [x] `go build ./cmd/dashboard` passes
- [x] `go test ./...` passes
- [x] CHANGELOG heading only change — no other content edits