### PR TITLE
feat(enrichment): surface session-level local enrichment in Session Graph and Fleet views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Session-level local enrichment in the Session Graph modal and Fleet view** — the display-only, UNVERIFIED local session enrichment introduced in 0.12.0 (token usage, estimated cost) is no longer confined to the single-receipt detail modal. A new `GET /api/sessions/{sessionID}/enrichment` endpoint exposes the same `enrich.Enrichment` payload (or `null`) for a session id on its own; the Session Graph modal header now fetches it alongside the existing attribution call and renders a condensed total-tokens/est.-cost line under the resource-linked coverage stat, with the same "local, unverified" badge and tooltip convention. `GET /api/fleet/signatures` (experimental) now composes each session's enrichment inline via a response-level `fleetSignatureWithEnrichment` wrapper — `internal/store` still has no dependency on `internal/enrich`, only `internal/server` does the composing — and each Fleet universe card gains a compact 4th caption line (e.g. `$0.42 · 128.4k tokens`) when local session data is available; sessions with no local transcript file simply carry no `enrichment` field (omitted, not null) and render no 4th line. No changes to the daemon, emitter, receipt schema, or the read-only store contract.
+
 ## [0.12.0] - 2026-07-15
 
 ### Added

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -727,23 +727,29 @@ func (s *Server) handleFleetSignatures(w http.ResponseWriter, r *http.Request) {
 	// per-session enrichment is composed here, at the one layer that already
 	// imports both. A session with no local transcript file simply gets a nil
 	// Enrichment, which the "omitempty" tag drops from the response entirely.
-	//
+	results := make([]fleetSignatureWithEnrichment, len(sigs))
+	for i, sig := range sigs {
+		results[i] = fleetSignatureWithEnrichment{SessionSignature: sig}
+	}
+
 	// Enrichment lookups run concurrently: each is a filesystem read/parse of a
 	// local session transcript (internal/enrich), so serializing up to maxLimit
 	// of them would make one Fleet page load pay for N sequential file scans.
 	// Each goroutine only ever writes its own results[i], so no locking is
-	// needed beyond the WaitGroup.
-	results := make([]fleetSignatureWithEnrichment, len(sigs))
-	var wg sync.WaitGroup
-	wg.Add(len(sigs))
-	for i, sig := range sigs {
-		results[i] = fleetSignatureWithEnrichment{SessionSignature: sig}
-		go func(i int, sessionID string) {
-			defer wg.Done()
-			results[i].Enrichment = s.enrichSession(sessionID)
-		}(i, sig.SessionID)
+	// needed beyond the WaitGroup. Skipped entirely when no enricher is
+	// configured — the common "no local data" deployment — rather than paying
+	// goroutine setup for N calls that would each just return nil.
+	if s.enricher != nil {
+		var wg sync.WaitGroup
+		wg.Add(len(sigs))
+		for i, sig := range sigs {
+			go func(i int, sessionID string) {
+				defer wg.Done()
+				results[i].Enrichment = s.enrichSession(sessionID)
+			}(i, sig.SessionID)
+		}
+		wg.Wait()
 	}
-	wg.Wait()
 
 	writeJSON(w, http.StatusOK, map[string]any{"signatures": results})
 }

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -156,6 +156,7 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/taxonomy", s.handleTaxonomy)
 	mux.HandleFunc("GET /api/sessions", s.handleSessions)
 	mux.HandleFunc("GET /api/sessions/{sessionID}/attribution", s.handleSessionAttribution)
+	mux.HandleFunc("GET /api/sessions/{sessionID}/enrichment", s.handleSessionEnrichment)
 	mux.HandleFunc("GET /api/fleet/attribution", s.handleFleetAttribution)
 	mux.HandleFunc("GET /api/receipts", s.handleReceipts)
 	mux.HandleFunc("GET /api/receipts/{id...}", s.handleReceiptDetail)
@@ -465,6 +466,24 @@ func (s *Server) handleSessionAttribution(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, result)
 }
 
+// handleSessionEnrichment returns the display-only, unverified local session
+// enrichment for a session id, or null when the enricher is unset or no local
+// session data is available. See ADR-0002 and the analogous nil-safety used by
+// handleReceiptDetail: enrichment never surfaces as an error, only as absence.
+func (s *Server) handleSessionEnrichment(w http.ResponseWriter, r *http.Request) {
+	sessionID := strings.TrimSpace(r.PathValue("sessionID"))
+	if sessionID == "" {
+		writeError(w, http.StatusBadRequest, "sessionID is required")
+		return
+	}
+
+	var enrichment *enrich.Enrichment
+	if s.enricher != nil {
+		enrichment = s.enricher.Enrich(sessionID)
+	}
+	writeJSON(w, http.StatusOK, enrichment)
+}
+
 // defaultFleetSessions is how many recently-active sessions the fleet view
 // renders when no limit is given; maxFleetSessions caps it so the combined
 // graph stays legible and the IN(...) query bounded.
@@ -696,7 +715,28 @@ func (s *Server) handleFleetSignatures(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeJSON(w, http.StatusOK, map[string]any{"signatures": sigs})
+	// internal/store must not depend on internal/enrich (see ADR-0002), so the
+	// per-session enrichment is composed here, at the one layer that already
+	// imports both. A session with no local transcript file simply gets a nil
+	// Enrichment, which the "omitempty" tag drops from the response entirely.
+	results := make([]fleetSignatureWithEnrichment, len(sigs))
+	for i, sig := range sigs {
+		results[i] = fleetSignatureWithEnrichment{SessionSignature: sig}
+		if s.enricher != nil {
+			results[i].Enrichment = s.enricher.Enrich(sig.SessionID)
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"signatures": results})
+}
+
+// fleetSignatureWithEnrichment pairs a store.SessionSignature with its
+// optional display-only, unverified local session enrichment. It exists so
+// the fleet view can render a per-session cost/token caption without
+// internal/store taking a dependency on internal/enrich.
+type fleetSignatureWithEnrichment struct {
+	store.SessionSignature
+	Enrichment *enrich.Enrichment `json:"enrichment,omitempty"`
 }
 
 func validateEd25519PEM(pemStr string) error {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"obsigna.dev/sdk/go/receipt"
@@ -466,6 +467,17 @@ func (s *Server) handleSessionAttribution(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, result)
 }
 
+// enrichSession returns the display-only, unverified local session enrichment
+// for a session id, or nil when no enricher is configured. Every call site
+// that needs enrichment funnels through here so the nil-enricher guard lives
+// in exactly one place. See ADR-0002.
+func (s *Server) enrichSession(sessionID string) *enrich.Enrichment {
+	if s.enricher == nil {
+		return nil
+	}
+	return s.enricher.Enrich(sessionID)
+}
+
 // handleSessionEnrichment returns the display-only, unverified local session
 // enrichment for a session id, or null when the enricher is unset or no local
 // session data is available. See ADR-0002 and the analogous nil-safety used by
@@ -477,11 +489,7 @@ func (s *Server) handleSessionEnrichment(w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	var enrichment *enrich.Enrichment
-	if s.enricher != nil {
-		enrichment = s.enricher.Enrich(sessionID)
-	}
-	writeJSON(w, http.StatusOK, enrichment)
+	writeJSON(w, http.StatusOK, s.enrichSession(sessionID))
 }
 
 // defaultFleetSessions is how many recently-active sessions the fleet view
@@ -619,8 +627,8 @@ func (s *Server) handleReceiptDetail(w http.ResponseWriter, r *http.Request) {
 	// never merged into it. It is nil when the receipt carries no session id or
 	// no local session data is available. See ADR-0002.
 	var enrichment *enrich.Enrichment
-	if s.enricher != nil && ar.Issuer.SessionID != "" {
-		enrichment = s.enricher.Enrich(ar.Issuer.SessionID)
+	if ar.Issuer.SessionID != "" {
+		enrichment = s.enrichSession(ar.Issuer.SessionID)
 	}
 	writeJSON(w, http.StatusOK, receiptDetailResponse{Receipt: ar, Enrichment: enrichment})
 }
@@ -719,13 +727,23 @@ func (s *Server) handleFleetSignatures(w http.ResponseWriter, r *http.Request) {
 	// per-session enrichment is composed here, at the one layer that already
 	// imports both. A session with no local transcript file simply gets a nil
 	// Enrichment, which the "omitempty" tag drops from the response entirely.
+	//
+	// Enrichment lookups run concurrently: each is a filesystem read/parse of a
+	// local session transcript (internal/enrich), so serializing up to maxLimit
+	// of them would make one Fleet page load pay for N sequential file scans.
+	// Each goroutine only ever writes its own results[i], so no locking is
+	// needed beyond the WaitGroup.
 	results := make([]fleetSignatureWithEnrichment, len(sigs))
+	var wg sync.WaitGroup
+	wg.Add(len(sigs))
 	for i, sig := range sigs {
 		results[i] = fleetSignatureWithEnrichment{SessionSignature: sig}
-		if s.enricher != nil {
-			results[i].Enrichment = s.enricher.Enrich(sig.SessionID)
-		}
+		go func(i int, sessionID string) {
+			defer wg.Done()
+			results[i].Enrichment = s.enrichSession(sessionID)
+		}(i, sig.SessionID)
 	}
+	wg.Wait()
 
 	writeJSON(w, http.StatusOK, map[string]any{"signatures": results})
 }

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -320,6 +321,17 @@ type fakeEnricher struct {
 func (f *fakeEnricher) Enrich(sessionID string) *enrich.Enrichment {
 	f.gotSession = sessionID
 	return f.ret
+}
+
+// mapEnricher returns a fixed enrichment per session id, letting tests that
+// exercise more than one session (e.g. fleet signatures) assert per-session
+// enrichment without every session sharing the same fake payload.
+type mapEnricher struct {
+	data map[string]*enrich.Enrichment
+}
+
+func (m *mapEnricher) Enrich(sessionID string) *enrich.Enrichment {
+	return m.data[sessionID]
 }
 
 func TestReceiptDetailEndpoint_EnrichmentSibling(t *testing.T) {
@@ -1438,6 +1450,79 @@ func TestSessionAttributionEndpoint_MissingSession(t *testing.T) {
 	}
 }
 
+// TestSessionEnrichmentEndpoint_OK covers the populated path: an enricher
+// with data for the requested session returns that Enrichment as the raw
+// response body (not wrapped in an envelope).
+func TestSessionEnrichmentEndpoint_OK(t *testing.T) {
+	srv := setupServer(t)
+	cost := 4.2
+	fake := &fakeEnricher{ret: &enrich.Enrichment{
+		Unverified:       true,
+		Source:           "claude-code",
+		Model:            "claude-opus-4-8",
+		TotalTokens:      128000,
+		EstimatedCostUSD: &cost,
+	}}
+	srv.enricher = fake
+
+	req := httptest.NewRequest("GET", "/api/sessions/sess-abc/enrichment", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if fake.gotSession != "sess-abc" {
+		t.Errorf("enricher asked about %q, want sess-abc", fake.gotSession)
+	}
+
+	var got enrich.Enrichment
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !got.Unverified || got.Source != "claude-code" || got.TotalTokens != 128000 {
+		t.Errorf("got %+v, want the fake enrichment", got)
+	}
+}
+
+// TestSessionEnrichmentEndpoint_NilEnricher covers a server with no enricher
+// configured at all: the handler must not panic and must respond with a null
+// body, never an error.
+func TestSessionEnrichmentEndpoint_NilEnricher(t *testing.T) {
+	srv := setupServer(t)
+	srv.enricher = nil
+
+	req := httptest.NewRequest("GET", "/api/sessions/sess-abc/enrichment", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != "null" {
+		t.Errorf("body = %q, want \"null\"", got)
+	}
+}
+
+// TestSessionEnrichmentEndpoint_NoLocalData covers a real enricher with no
+// local transcript file for the requested session — the common case for any
+// dashboard not running on the same host as the agent. Absence must not be an
+// error.
+func TestSessionEnrichmentEndpoint_NoLocalData(t *testing.T) {
+	srv := setupServer(t) // real enrich.New() enricher, no matching local file
+
+	req := httptest.NewRequest("GET", "/api/sessions/no-such-local-session/enrichment", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200: %s", w.Code, w.Body.String())
+	}
+	if got := strings.TrimSpace(w.Body.String()); got != "null" {
+		t.Errorf("body = %q, want \"null\"", got)
+	}
+}
+
 // seedFleetAttributionDB seeds two sessions whose orchestrators collide on one
 // shared global resource, plus one session-local resource that must not collide.
 func seedFleetAttributionDB(t *testing.T) *Server {
@@ -1800,5 +1885,108 @@ func TestFleetSignaturesEndpoint_LimitParam(t *testing.T) {
 	srv.Handler().ServeHTTP(w, req)
 	if w.Code != http.StatusOK {
 		t.Errorf("limit=99: got status %d, want 200 (cap not reject)", w.Code)
+	}
+}
+
+// TestFleetSignaturesEndpoint_Enrichment covers the composed per-session
+// enrichment: each session gets its own distinct Enrichment (never a shared
+// or mixed-up one), and a session with no local transcript file (no entry in
+// the map) gets no "enrichment" key at all in the raw JSON, not an explicit
+// null — the omitempty tag keeps the common no-local-data case lean.
+func TestFleetSignaturesEndpoint_Enrichment(t *testing.T) {
+	reader := seedFleetDB(t)
+	srv := New(reader, Config{Experimental: true})
+
+	costAlpha := 1.5
+	me := &mapEnricher{data: map[string]*enrich.Enrichment{
+		"alpha": {
+			Unverified:       true,
+			Source:           "claude-code",
+			TotalTokens:      128000,
+			EstimatedCostUSD: &costAlpha,
+		},
+		// beta intentionally has no entry, simulating no local transcript file.
+	}}
+	srv.enricher = me
+
+	req := httptest.NewRequest("GET", "/api/fleet/signatures", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	var body struct {
+		Signatures []fleetSignatureWithEnrichment `json:"signatures"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Signatures) != 2 {
+		t.Fatalf("got %d signatures, want 2", len(body.Signatures))
+	}
+
+	// SessionStats orders by last_seen DESC: alpha (10:04) before beta (09:01).
+	if body.Signatures[0].SessionID != "alpha" {
+		t.Fatalf("signatures[0].session_id = %q, want alpha", body.Signatures[0].SessionID)
+	}
+	if body.Signatures[0].Enrichment == nil {
+		t.Fatal("alpha enrichment = nil, want the mapped enrichment")
+	}
+	if body.Signatures[0].Enrichment.TotalTokens != 128000 {
+		t.Errorf("alpha total_tokens = %d, want 128000", body.Signatures[0].Enrichment.TotalTokens)
+	}
+
+	if body.Signatures[1].SessionID != "beta" {
+		t.Fatalf("signatures[1].session_id = %q, want beta", body.Signatures[1].SessionID)
+	}
+	if body.Signatures[1].Enrichment != nil {
+		t.Errorf("beta enrichment = %+v, want nil (no local transcript file)", body.Signatures[1].Enrichment)
+	}
+
+	var raw struct {
+		Signatures []map[string]json.RawMessage `json:"signatures"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	if _, ok := raw.Signatures[0]["enrichment"]; !ok {
+		t.Error("alpha: expected an \"enrichment\" key in the raw JSON")
+	}
+	if _, ok := raw.Signatures[1]["enrichment"]; ok {
+		t.Error("beta: \"enrichment\" key present in raw JSON, want omitted (omitempty)")
+	}
+}
+
+// TestFleetSignaturesEndpoint_NilEnricher covers a server with no enricher
+// configured at all: every signature must omit the "enrichment" key rather
+// than error or emit an explicit null.
+func TestFleetSignaturesEndpoint_NilEnricher(t *testing.T) {
+	reader := seedFleetDB(t)
+	srv := New(reader, Config{Experimental: true})
+	srv.enricher = nil
+
+	req := httptest.NewRequest("GET", "/api/fleet/signatures", nil)
+	w := httptest.NewRecorder()
+	srv.Handler().ServeHTTP(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("got status %d, want 200: %s", w.Code, w.Body.String())
+	}
+
+	var raw struct {
+		Signatures []map[string]json.RawMessage `json:"signatures"`
+	}
+	if err := json.Unmarshal(w.Body.Bytes(), &raw); err != nil {
+		t.Fatalf("decode raw: %v", err)
+	}
+	if len(raw.Signatures) != 2 {
+		t.Fatalf("got %d signatures, want 2", len(raw.Signatures))
+	}
+	for i, sig := range raw.Signatures {
+		if _, ok := sig["enrichment"]; ok {
+			t.Errorf("signatures[%d]: \"enrichment\" key present with nil enricher, want omitted", i)
+		}
 	}
 }

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -3258,12 +3258,13 @@
       </div>`;
     }
 
-    // ENRICHMENT_TIP and enrichmentBadgeHTML are shared by every renderer of
-    // local session enrichment (the receipt detail box, the session graph
-    // header, and — for cost/tokens only — the Fleet caption): this exact
-    // wording/markup is the trust-boundary signal that keeps unverified local
-    // data from being confused with signed receipt data, so it must not drift
-    // between call sites. See docs/adr/0002-local-session-enrichment.md.
+    // ENRICHMENT_TIP is shared by every renderer of local session enrichment —
+    // the receipt detail box and session graph header render it via
+    // enrichmentBadgeHTML's visible HTML badge, while the Fleet caption (SVG
+    // text, which can't host an HTML badge) renders it as a <title> hover —
+    // so the trust-boundary wording can't drift between call sites, per
+    // ADR-0002's requirement that every enrichment rendering carry a "local,
+    // unverified" tooltip. See docs/adr/0002-local-session-enrichment.md.
     const ENRICHMENT_TIP = "Local, unverified — read from this host's agent session files, not from the signed receipt.";
     function enrichmentBadgeHTML(extraStyle) {
       const style = extraStyle ? ` style="${escapeAttr(extraStyle)}"` : '';
@@ -4855,15 +4856,17 @@
         // UNVERIFIED local session enrichment inlined onto this signature by
         // the server (see handleFleetSignatures). Sessions with no local
         // transcript file simply carry no `enrichment` field — render nothing
-        // rather than a placeholder. No badge/tooltip here: this compact,
-        // dense cell context is already clearly not receipt data.
+        // rather than a placeholder. This cell is too dense for the full HTML
+        // badge, but ADR-0002 requires every enrichment rendering to carry a
+        // "local, unverified" tooltip, so an SVG <title> gives the same
+        // hover-to-disclose trust-boundary signal without taking extra space.
         if (sig.enrichment) {
           const en       = sig.enrichment;
           const costStr  = en.estimated_cost_usd != null ? formatCostUSD(en.estimated_cost_usd) : null;
           const tokenStr = en.total_tokens != null ? fleetFormatTokens(en.total_tokens) : null;
           const costLine = [costStr, tokenStr].filter(Boolean).join('  \xb7  ');
           if (costLine) {
-            elems += `<text x="${cx}" y="${capY + 47}" text-anchor="middle" fill="var(--subtle)" font-size="9" font-family="var(--font-sans)">${escapeHtml(costLine)}</text>`;
+            elems += `<text x="${cx}" y="${capY + 47}" text-anchor="middle" fill="var(--subtle)" font-size="9" font-family="var(--font-sans)"><title>${escapeHtml(ENRICHMENT_TIP)}</title>${escapeHtml(costLine)}</text>`;
           }
         }
 

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -3258,6 +3258,26 @@
       </div>`;
     }
 
+    // ENRICHMENT_TIP and enrichmentBadgeHTML are shared by every renderer of
+    // local session enrichment (the receipt detail box, the session graph
+    // header, and — for cost/tokens only — the Fleet caption): this exact
+    // wording/markup is the trust-boundary signal that keeps unverified local
+    // data from being confused with signed receipt data, so it must not drift
+    // between call sites. See docs/adr/0002-local-session-enrichment.md.
+    const ENRICHMENT_TIP = "Local, unverified — read from this host's agent session files, not from the signed receipt.";
+    function enrichmentBadgeHTML(extraStyle) {
+      const style = extraStyle ? ` style="${escapeAttr(extraStyle)}"` : '';
+      return `<span class="enrichment-badge" tabindex="0" title="${escapeAttr(ENRICHMENT_TIP)}"${style}>local, unverified</span>`;
+    }
+
+    // formatCostUSD renders a USD cost estimate as e.g. "$0.42" or "$0.0031" —
+    // 4 decimals below $1 (so sub-cent estimates don't round to "$0.00"),
+    // else 2. Shared by every renderer of estimated enrichment cost.
+    function formatCostUSD(cost) {
+      const c = Number(cost);
+      return '$' + c.toFixed(c < 1 ? 4 : 2);
+    }
+
     // enrichmentSectionHTML renders display-only, UNVERIFIED local session data
     // (token usage, context fill, estimated cost) joined to the receipt by
     // session id. It is styled deliberately apart from the signed receipt
@@ -3266,7 +3286,6 @@
     // data. See docs/adr/0002-local-session-enrichment.md.
     function enrichmentSectionHTML(e) {
       if (!e) return '';
-      const tip = "Local, unverified — read from this host's agent session files, not from the signed receipt.";
       const fmtInt = (n) => (n == null ? '—' : Number(n).toLocaleString());
       const rows = [];
 
@@ -3284,9 +3303,7 @@
       }
 
       if (e.subagent_turns) {
-        const subCost = e.subagent_cost_usd != null
-          ? ` · $${Number(e.subagent_cost_usd).toFixed(Number(e.subagent_cost_usd) < 1 ? 4 : 2)}`
-          : '';
+        const subCost = e.subagent_cost_usd != null ? ` · ${formatCostUSD(e.subagent_cost_usd)}` : '';
         const turns = e.subagent_turns === 1 ? 'turn' : 'turns';
         rows.push(enrichmentRow('Subagents', `${fmtInt(e.subagent_turns)} ${turns} · ${fmtInt(e.subagent_tokens)} tokens${subCost} <span class="enrich-muted">(incl. above)</span>`));
       }
@@ -3298,8 +3315,7 @@
       }
 
       if (e.estimated_cost_usd != null) {
-        const c = Number(e.estimated_cost_usd);
-        rows.push(enrichmentRow('Est. cost', '$' + c.toFixed(c < 1 ? 4 : 2)));
+        rows.push(enrichmentRow('Est. cost', formatCostUSD(e.estimated_cost_usd)));
       } else {
         rows.push(enrichmentRow('Est. cost', `<span class="enrich-muted" title="Model not in the local pricing table">unavailable</span>`));
       }
@@ -3308,7 +3324,7 @@
         <div class="enrichment-box">
           <div class="enrichment-head">
             <span>Local session data</span>
-            <span class="enrichment-badge" tabindex="0" title="${escapeAttr(tip)}">local, unverified</span>
+            ${enrichmentBadgeHTML()}
           </div>
           <div class="enrichment-body">${rows.join('')}</div>
         </div>`;
@@ -4145,16 +4161,12 @@
       if (!el) return;
       if (!e) { el.innerHTML = ''; return; }
 
-      const tip = "Local, unverified — read from this host's agent session files, not from the signed receipt.";
       const parts = [];
       if (e.total_tokens != null) parts.push(Number(e.total_tokens).toLocaleString() + ' tokens');
-      if (e.estimated_cost_usd != null) {
-        const c = Number(e.estimated_cost_usd);
-        parts.push('$' + c.toFixed(c < 1 ? 4 : 2));
-      }
+      if (e.estimated_cost_usd != null) parts.push(formatCostUSD(e.estimated_cost_usd));
       if (!parts.length) { el.innerHTML = ''; return; }
 
-      el.innerHTML = `<span style="font-size:0.72rem;color:var(--muted)">${escapeHtml(parts.join(' · '))}</span> <span class="enrichment-badge" tabindex="0" title="${escapeAttr(tip)}" style="margin-left:6px;">local, unverified</span>`;
+      el.innerHTML = `<span style="font-size:0.72rem;color:var(--muted)">${escapeHtml(parts.join(' · '))}</span> ${enrichmentBadgeHTML('margin-left:6px;')}`;
     }
 
     // renderSessionGraphReceipts renders a compact flat receipt table into the
@@ -4847,9 +4859,7 @@
         // dense cell context is already clearly not receipt data.
         if (sig.enrichment) {
           const en       = sig.enrichment;
-          const costStr  = en.estimated_cost_usd != null
-            ? '$' + Number(en.estimated_cost_usd).toFixed(Number(en.estimated_cost_usd) < 1 ? 4 : 2)
-            : null;
+          const costStr  = en.estimated_cost_usd != null ? formatCostUSD(en.estimated_cost_usd) : null;
           const tokenStr = en.total_tokens != null ? fleetFormatTokens(en.total_tokens) : null;
           const costLine = [costStr, tokenStr].filter(Boolean).join('  \xb7  ');
           if (costLine) {

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -974,7 +974,10 @@
             <h2 class="modal-title" id="session-graph-title">Session Graph</h2>
             <div id="session-graph-session-id" class="font-mono" style="font-size:0.72rem;color:var(--muted);margin-top:2px;"></div>
           </div>
-          <div id="session-graph-coverage" style="flex:1;text-align:right;margin-right:12px;"></div>
+          <div style="flex:1;text-align:right;margin-right:12px;">
+            <div id="session-graph-coverage"></div>
+            <div id="session-graph-enrichment" style="margin-top:3px;"></div>
+          </div>
           <button class="icon-btn" type="button" onclick="closeSessionGraph()" aria-label="Close">×</button>
         </div>
         <div>
@@ -3831,31 +3834,35 @@
     const inlineGraphState = { attribution: null };
 
     async function showSessionGraph(sessionId) {
-      const svgPanel    = document.getElementById('session-graph-svg-panel');
-      const rcptPanel   = document.getElementById('session-graph-receipts-panel');
-      const blastPanel  = document.getElementById('session-graph-blast-panel');
-      const subtitle    = document.getElementById('session-graph-session-id');
-      const coverageEl  = document.getElementById('session-graph-coverage');
+      const svgPanel      = document.getElementById('session-graph-svg-panel');
+      const rcptPanel     = document.getElementById('session-graph-receipts-panel');
+      const blastPanel    = document.getElementById('session-graph-blast-panel');
+      const subtitle      = document.getElementById('session-graph-session-id');
+      const coverageEl    = document.getElementById('session-graph-coverage');
+      const enrichmentEl  = document.getElementById('session-graph-enrichment');
 
       subtitle.textContent = sessionId;
       svgPanel.innerHTML   = '<div class="muted text-sm" style="padding:8px 0;">Loading…</div>';
       rcptPanel.innerHTML  = '';
-      if (blastPanel)  blastPanel.style.display = 'none';
-      if (coverageEl)  coverageEl.innerHTML = '';
+      if (blastPanel)     blastPanel.style.display = 'none';
+      if (coverageEl)     coverageEl.innerHTML = '';
+      if (enrichmentEl)   enrichmentEl.innerHTML = '';
       sessionGraphState.receipts   = [];
       sessionGraphState.attribution = null;
       openModal('session-graph-modal');
 
       try {
-        const [rows, attribution] = await Promise.all([
+        const [rows, attribution, enrichment] = await Promise.all([
           fetchJSON('/api/receipts?session_id=' + encodeURIComponent(sessionId) + '&limit=2000'),
           fetchJSON('/api/sessions/' + encodeURIComponent(sessionId) + '/attribution').catch(() => null),
+          fetchJSON('/api/sessions/' + encodeURIComponent(sessionId) + '/enrichment').catch(() => null),
         ]);
         sessionGraphState.receipts    = rows || [];
         sessionGraphState.attribution = attribution;
         const { nodes, edges } = buildSessionGraph(sessionGraphState.receipts, attribution);
         renderSessionGraphSVG(nodes, edges, svgPanel);
         renderSessionCoverage(attribution, coverageEl);
+        renderSessionGraphEnrichment(enrichment, enrichmentEl);
         renderSessionGraphReceipts(sessionGraphState.receipts, rcptPanel);
       } catch (err) {
         svgPanel.innerHTML = '<div class="muted text-sm">Could not load session: ' + escapeHtml(err.message) + '</div>';
@@ -4124,6 +4131,30 @@
         ? ' <span style="color:var(--risk-medium)" title="Move/rename operations detected — path strings may not reliably identify file versions across renames">⚠ mv ops</span>'
         : '';
       el.innerHTML = `<span style="font-size:0.72rem;color:var(--muted)" title="receipts carrying a target.resource, which can contribute file-dependency edges. Bash/MCP/spawn receipts are signed but carry no resource path.">${escapeHtml(String(cv.identity_receipts))} / ${escapeHtml(String(cv.total_receipts))} receipts resource-linked (${pct}%)${mvWarn}</span>`;
+    }
+
+    // renderSessionGraphEnrichment renders a condensed one-line summary of the
+    // session-wide, display-only, UNVERIFIED local enrichment (total tokens,
+    // estimated cost) into the session graph modal header, below the coverage
+    // line. It carries the same "local, unverified" badge + tooltip convention
+    // as enrichmentSectionHTML so it can never be mistaken for signed receipt
+    // data — just condensed to fit a single header line. Omitted entirely when
+    // no local session data is available (no local transcript file). See
+    // docs/adr/0002-local-session-enrichment.md.
+    function renderSessionGraphEnrichment(e, el) {
+      if (!el) return;
+      if (!e) { el.innerHTML = ''; return; }
+
+      const tip = "Local, unverified — read from this host's agent session files, not from the signed receipt.";
+      const parts = [];
+      if (e.total_tokens != null) parts.push(Number(e.total_tokens).toLocaleString() + ' tokens');
+      if (e.estimated_cost_usd != null) {
+        const c = Number(e.estimated_cost_usd);
+        parts.push('$' + c.toFixed(c < 1 ? 4 : 2));
+      }
+      if (!parts.length) { el.innerHTML = ''; return; }
+
+      el.innerHTML = `<span style="font-size:0.72rem;color:var(--muted)">${escapeHtml(parts.join(' · '))}</span> <span class="enrichment-badge" tabindex="0" title="${escapeAttr(tip)}" style="margin-left:6px;">local, unverified</span>`;
     }
 
     // renderSessionGraphReceipts renders a compact flat receipt table into the
@@ -4691,6 +4722,16 @@
         .join('  ');
     }
 
+    // fleetFormatTokens renders a token count in the compact form used by the
+    // fleet caption line, e.g. 128400 -> "128.4k tokens", 2_100_000 -> "2.1M
+    // tokens". Below 1000 it renders the exact count.
+    function fleetFormatTokens(n) {
+      const v = Number(n);
+      if (v >= 1e6) return (v / 1e6).toFixed(1) + 'M tokens';
+      if (v >= 1e3) return (v / 1e3).toFixed(1) + 'k tokens';
+      return Math.round(v).toLocaleString() + ' tokens';
+    }
+
     // renderFleetSVG renders the full grid of universe cards as an SVG string
     // (plus a legend div below it).
     function renderFleetSVG(signatures) {
@@ -4797,6 +4838,24 @@
         elems += `<text x="${cx}" y="${capY}" text-anchor="middle" fill="var(--text)" font-size="11" font-weight="600" font-family="var(--font-sans)">${escapeHtml(charLabel)}</text>`;
         elems += `<text x="${cx}" y="${capY + 17}" text-anchor="middle" fill="var(--muted)" font-size="9.5" font-family="var(--font-sans)">${escapeHtml(topCatStr + '  \xb7 bash ' + bashPct + '%')}</text>`;
         elems += `<text x="${cx}" y="${capY + 32}" text-anchor="middle" fill="var(--subtle)" font-size="9" font-family="var(--font-mono)">${escapeHtml(shortId)} \xb7 ${escapeHtml(String(sig.receipt_count))} receipts</text>`;
+
+        // 7. Optional 4th caption: cost + total tokens from the display-only,
+        // UNVERIFIED local session enrichment inlined onto this signature by
+        // the server (see handleFleetSignatures). Sessions with no local
+        // transcript file simply carry no `enrichment` field — render nothing
+        // rather than a placeholder. No badge/tooltip here: this compact,
+        // dense cell context is already clearly not receipt data.
+        if (sig.enrichment) {
+          const en       = sig.enrichment;
+          const costStr  = en.estimated_cost_usd != null
+            ? '$' + Number(en.estimated_cost_usd).toFixed(Number(en.estimated_cost_usd) < 1 ? 4 : 2)
+            : null;
+          const tokenStr = en.total_tokens != null ? fleetFormatTokens(en.total_tokens) : null;
+          const costLine = [costStr, tokenStr].filter(Boolean).join('  \xb7  ');
+          if (costLine) {
+            elems += `<text x="${cx}" y="${capY + 47}" text-anchor="middle" fill="var(--subtle)" font-size="9" font-family="var(--font-sans)">${escapeHtml(costLine)}</text>`;
+          }
+        }
 
         // Wrap all universe elements in a clickable group.
         cells += `<g class="fleet-universe" data-session-id="${escapeAttr(sig.session_id || '')}" onclick="showSessionGraph(this.dataset.sessionId)" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();showSessionGraph(this.dataset.sessionId)}" tabindex="0" style="cursor:pointer;" role="button" aria-label="${escapeAttr('View session graph for ' + (sig.session_id || ''))}">`;


### PR DESCRIPTION
## Summary

The display-only, UNVERIFIED local session enrichment introduced in 0.12.0 (token usage, estimated cost) was previously only ever fetched and rendered once per receipt, inside the single-receipt detail modal — even though `enrich.Enrichment` is already a session-wide aggregate, so every receipt in a session shares the same payload today.

This PR surfaces that same data in two more places:

- A new `GET /api/sessions/{sessionID}/enrichment` endpoint, consumed by the Session Graph modal header, which now renders a condensed total-tokens/est.-cost line alongside the existing resource-linked coverage stat (same "local, unverified" badge/tooltip convention).
- `GET /api/fleet/signatures` (experimental) now composes each session's enrichment inline via a `fleetSignatureWithEnrichment` wrapper — `internal/store` still has no dependency on `internal/enrich`, only `internal/server` composes them — and each Fleet universe card gains a compact 4th caption line (e.g. `$0.42 · 128.4k tokens`) when local session data is available.

A follow-up commit addresses `/code-review` findings from the first pass:
- `handleFleetSignatures` now looks up enrichment for all sessions concurrently instead of serially, since each lookup is a filesystem read/parse of a local session transcript and the enricher's cache doesn't help for actively-growing (live) sessions — verified race-free with `go test -race`.
- Extracted `enrichSession()` (Go) as the single nil-enricher guard, replacing three independent copies.
- Extracted `formatCostUSD()` and `enrichmentBadgeHTML()` (JS) as shared helpers, removing duplicated cost-formatting logic and duplicated copies of the trust-boundary "local, unverified" badge/tooltip text.

No changes to the daemon, emitter, receipt schema, or the read-only store contract.

## Test plan

- [x] `go vet ./...`
- [x] `go test -count=1 ./...`
- [x] `go test -count=1 -race ./...` (race detector, given the new goroutine fan-out in `handleFleetSignatures`)
- [x] New backend tests: session-enrichment endpoint (OK / nil-enricher / no-local-data) and fleet-signatures enrichment composition (per-session distinct payloads + `omitempty` behavior, nil-enricher)
- [x] Extracted and syntax-checked the inline `<script>` block (no build step/bundler for the frontend)
- [ ] Manual browser verification of the Session Graph header and Fleet card layout (not done — no visual/browser test harness in this repo; JSON shape and JS syntax were checked instead)