### PR TITLE
Fix modal stacking so receipt previews appear above Session Graph

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **Receipt preview opened from the Session Graph now paints in front of it** — selecting a row (or a chain cell) in the Session Graph modal's receipts table opened the receipt/chain detail modal *behind* the graph, because every modal shared one `z-index` and the graph modal sits later in the document. Modals now track open order and stack the most-recently-opened one on top, and Esc closes the topmost modal only — so dismissing a receipt preview returns to the Session Graph instead of closing both at once.
+- **Receipt preview opened from the Session Graph now paints in front of it** — selecting a row (or a chain cell) in the Session Graph modal's receipts table opened the receipt/chain detail modal *behind* the graph, because every modal shared one `z-index` and the graph modal sits later in the document. Modals now track open order and stack the most-recently-opened one on top, and Esc closes the topmost modal only — so dismissing a receipt preview returns to the Session Graph instead of closing both at once. Closing a stacked modal now moves keyboard focus into the modal still on top (rather than to a background element behind it), and focus only returns to the pre-modal element once the last modal closes.
 
 ## [0.13.0] - 2026-07-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Receipt preview opened from the Session Graph now paints in front of it** — selecting a row (or a chain cell) in the Session Graph modal's receipts table opened the receipt/chain detail modal *behind* the graph, because every modal shared one `z-index` and the graph modal sits later in the document. Modals now track open order and stack the most-recently-opened one on top, and Esc closes the topmost modal only — so dismissing a receipt preview returns to the Session Graph instead of closing both at once.
+
 ## [0.13.0] - 2026-07-17
 
 ### Added

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -3734,10 +3734,31 @@
     // an increasing z-index; Esc closes the topmost first (see closeTopModal).
     const modalStack = [];
     const MODAL_Z_BASE = 50;
+    // modalClosers is the single registry of modal ids and how each one closes;
+    // isModalOpen, closeTopModal, and the backdrop-click wiring all derive from it
+    // (via MODAL_IDS), so a new modal is registered in exactly one place. The
+    // closers are hoisted function declarations, safe to reference before they
+    // appear textually below.
+    const modalClosers = {
+      'receipt-modal': closeModal,
+      'chain-modal': closeChainModal,
+      'shortcuts-modal': closeShortcuts,
+      'forensic-modal': closeForensic,
+      'session-graph-modal': closeSessionGraph,
+    };
+    const MODAL_IDS = Object.keys(modalClosers);
     function restackModals() {
       modalStack.forEach((mid, i) => {
         document.getElementById(mid).style.zIndex = String(MODAL_Z_BASE + i);
       });
+    }
+    // focusFirstIn moves focus to the first focusable element inside a modal, so
+    // keyboard / screen-reader users are never left focused behind the overlay.
+    function focusFirstIn(el) {
+      const focusable = el.querySelector(
+        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
+      );
+      if (focusable) focusable.focus();
     }
     function openModal(id) {
       const el = document.getElementById(id);
@@ -3748,12 +3769,9 @@
       if (existing !== -1) modalStack.splice(existing, 1);
       modalStack.push(id);
       restackModals();
-      // Move focus inside the modal so keyboard / screen-reader users don't
-      // get stuck behind the overlay. Esc and backdrop-click still close.
-      const focusable = el.querySelector(
-        'button, [href], input, select, textarea, [tabindex]:not([tabindex="-1"])'
-      );
-      if (focusable) focusable.focus();
+      // Esc and backdrop-click still close; move focus inside so keyboard /
+      // screen-reader users don't get stuck behind the overlay.
+      focusFirstIn(el);
     }
     function closeModalById(id) {
       const el = document.getElementById(id);
@@ -3761,7 +3779,12 @@
       el.style.zIndex = '';
       const i = modalStack.indexOf(id);
       if (i !== -1) { modalStack.splice(i, 1); restackModals(); }
-      if (lastFocusedBeforeModal && lastFocusedBeforeModal.focus) lastFocusedBeforeModal.focus();
+      // Hand focus to the modal now on top; only once the last modal closes does
+      // focus return to whatever held it before the first modal opened. This stops
+      // focus from landing on a background element behind a still-open overlay.
+      const top = modalStack[modalStack.length - 1];
+      if (top) focusFirstIn(document.getElementById(top));
+      else if (lastFocusedBeforeModal && lastFocusedBeforeModal.focus) lastFocusedBeforeModal.focus();
     }
     function closeModal()      { closeModalById('receipt-modal'); }
     function closeChainModal() { closeModalById('chain-modal'); }
@@ -3790,17 +3813,10 @@
     }
 
     function isModalOpen() {
-      return ['receipt-modal','chain-modal','shortcuts-modal','forensic-modal','session-graph-modal'].some(id => !document.getElementById(id).hidden);
+      return MODAL_IDS.some(id => !document.getElementById(id).hidden);
     }
     // Esc closes the topmost modal only, so dismissing a receipt preview opened
     // from the Session Graph returns to the graph rather than closing both.
-    const modalClosers = {
-      'forensic-modal': closeForensic,
-      'shortcuts-modal': closeShortcuts,
-      'chain-modal': closeChainModal,
-      'receipt-modal': closeModal,
-      'session-graph-modal': closeSessionGraph,
-    };
     function closeTopModal() {
       const top = modalStack[modalStack.length - 1];
       if (top && modalClosers[top]) modalClosers[top]();
@@ -5272,7 +5288,7 @@
     document.getElementById('btn-shortcuts').addEventListener('click', showShortcuts);
 
     // Close modals on backdrop click.
-    ['receipt-modal','chain-modal','shortcuts-modal','forensic-modal','session-graph-modal'].forEach(id => {
+    MODAL_IDS.forEach(id => {
       document.getElementById(id).addEventListener('click', e => {
         if (e.target === e.currentTarget) closeModalById(id);
       });

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -3727,10 +3727,27 @@
 
     // ---------- Modal helpers ----------
     let lastFocusedBeforeModal = null;
+    // Modal stacking. DOM order can't express "opened last paints on top": a
+    // receipt preview opened from the Session Graph sits earlier in the document
+    // than the graph modal, so with equal z-index it would render *behind* it.
+    // modalStack tracks open modals in open order and restackModals assigns each
+    // an increasing z-index; Esc closes the topmost first (see closeTopModal).
+    const modalStack = [];
+    const MODAL_Z_BASE = 50;
+    function restackModals() {
+      modalStack.forEach((mid, i) => {
+        document.getElementById(mid).style.zIndex = String(MODAL_Z_BASE + i);
+      });
+    }
     function openModal(id) {
       const el = document.getElementById(id);
       if (!isModalOpen()) lastFocusedBeforeModal = document.activeElement;
       el.hidden = false;
+      // Re-opening an already-open modal lifts it to the top of the stack.
+      const existing = modalStack.indexOf(id);
+      if (existing !== -1) modalStack.splice(existing, 1);
+      modalStack.push(id);
+      restackModals();
       // Move focus inside the modal so keyboard / screen-reader users don't
       // get stuck behind the overlay. Esc and backdrop-click still close.
       const focusable = el.querySelector(
@@ -3741,6 +3758,9 @@
     function closeModalById(id) {
       const el = document.getElementById(id);
       el.hidden = true;
+      el.style.zIndex = '';
+      const i = modalStack.indexOf(id);
+      if (i !== -1) { modalStack.splice(i, 1); restackModals(); }
       if (lastFocusedBeforeModal && lastFocusedBeforeModal.focus) lastFocusedBeforeModal.focus();
     }
     function closeModal()      { closeModalById('receipt-modal'); }
@@ -3772,12 +3792,18 @@
     function isModalOpen() {
       return ['receipt-modal','chain-modal','shortcuts-modal','forensic-modal','session-graph-modal'].some(id => !document.getElementById(id).hidden);
     }
-    function closeAnyOpenModal() {
-      if (!document.getElementById('forensic-modal').hidden) closeForensic();
-      if (!document.getElementById('shortcuts-modal').hidden) closeShortcuts();
-      if (!document.getElementById('chain-modal').hidden) closeChainModal();
-      if (!document.getElementById('receipt-modal').hidden) closeModal();
-      if (!document.getElementById('session-graph-modal').hidden) closeSessionGraph();
+    // Esc closes the topmost modal only, so dismissing a receipt preview opened
+    // from the Session Graph returns to the graph rather than closing both.
+    const modalClosers = {
+      'forensic-modal': closeForensic,
+      'shortcuts-modal': closeShortcuts,
+      'chain-modal': closeChainModal,
+      'receipt-modal': closeModal,
+      'session-graph-modal': closeSessionGraph,
+    };
+    function closeTopModal() {
+      const top = modalStack[modalStack.length - 1];
+      if (top && modalClosers[top]) modalClosers[top]();
     }
 
     // ---------- Session inline graph ----------
@@ -5130,7 +5156,7 @@
     document.addEventListener('keydown', e => {
       // Esc: highest priority — always closes modals or blurs inputs.
       if (e.key === 'Escape') {
-        if (isModalOpen()) { closeAnyOpenModal(); return; }
+        if (isModalOpen()) { closeTopModal(); return; }
         if (isTypingTarget(document.activeElement)) {
           document.activeElement.blur();
           return;


### PR DESCRIPTION
## What

Implements proper modal stacking to ensure modals opened from within other modals (e.g., a receipt preview opened from the Session Graph modal) render on top of their parent modal, rather than behind it. The fix tracks open modals in a stack, assigns dynamic z-index values based on open order, and changes Esc behavior to close only the topmost modal.

## Why

Previously, all modals shared the same `z-index` value, so rendering order was determined solely by DOM position. When a receipt preview modal was opened from the Session Graph modal, the receipt modal appeared *behind* the graph because the graph modal sits later in the document. This made the receipt preview inaccessible.

The fix ensures:
1. The most recently opened modal always appears on top
2. Pressing Esc closes only the topmost modal, allowing users to dismiss a receipt preview and return to the Session Graph instead of closing both at once
3. Re-opening an already-open modal lifts it to the top of the stack

## Implementation Details

- Added `modalStack` array to track open modals in order
- Added `restackModals()` function to assign increasing z-index values (`MODAL_Z_BASE + position`)
- Modified `openModal()` to add/move modals to the top of the stack and restack
- Modified `closeModalById()` to remove modals from the stack and restack
- Replaced `closeAnyOpenModal()` with `closeTopModal()` that closes only the topmost modal
- Updated Esc keydown handler to call `closeTopModal()` instead of `closeAnyOpenModal()`

## Checklist

- [x] No real keys or secrets in the diff
- [x] Changes are frontend-only (no Go code changes)
- [x] Commit message follows Conventional Commits