### PR TITLE
feat(fleet): graduate Fleet from experimental to a default feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **Fleet is no longer experimental** ([#156](https://github.com/agent-receipts/dashboard/issues/156)) — the Fleet tab and `GET /api/fleet/signatures` are now always available; the `-experimental` CLI flag, the `Config.Experimental` field, and the `"experimental"` key in `GET /api/config` are removed, since Fleet was their only consumer. Per the issue's rollout plan, Fleet ships behind the flag until proven on real parallel-refactor data; the activity-signature view, cross-session collision detection, and enrichment captions have since landed and been used without issue, so it graduates to a default, stable feature. No change to the Fleet data itself — only to how it's gated.
+- **Fleet is no longer experimental** ([#156](https://github.com/agent-receipts/dashboard/issues/156)) — the Fleet tab and `GET /api/fleet/signatures` are now always available; the `-experimental` CLI flag, the `Config.Experimental` field, and the `"experimental"` key in `GET /api/config` are removed, since Fleet was their only consumer. Per the issue's rollout plan, Fleet shipped behind the flag until proven on real parallel-refactor data; the activity-signature view, cross-session collision detection, and enrichment captions have since landed and been used without issue, so it graduates to a default, stable feature. No change to the Fleet data itself — only to how it's gated.
 
 ## [0.13.1] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Fleet is no longer experimental** ([#156](https://github.com/agent-receipts/dashboard/issues/156)) — the Fleet tab and `GET /api/fleet/signatures` are now always available; the `-experimental` CLI flag, the `Config.Experimental` field, and the `"experimental"` key in `GET /api/config` are removed, since Fleet was their only consumer. Per the issue's rollout plan, Fleet ships behind the flag until proven on real parallel-refactor data; the activity-signature view, cross-session collision detection, and enrichment captions have since landed and been used without issue, so it graduates to a default, stable feature. No change to the Fleet data itself — only to how it's gated.
+
 ## [0.13.1] - 2026-07-20
 
 ### Fixed

--- a/cmd/dashboard/main.go
+++ b/cmd/dashboard/main.go
@@ -128,7 +128,6 @@ func main() {
 	pollInterval := flag.Duration("poll-interval", server.DefaultPollInterval, "interval between live receipt polls (e.g. 5s)")
 	temporalProximity := flag.Duration("temporal-proximity", store.DefaultTemporalProximity, "max gap between two contending touches of a shared resource for a cross-session collision to count as concurrent (temporal_overlap)")
 	forensicKeyDirsFlag := flag.String("forensic-key-dirs", "", "comma-separated list of extra absolute directories from which the forensic key path endpoint may load a key (the user's home directory is always allowed)")
-	experimental := flag.Bool("experimental", false, "enable experimental features (e.g. /api/fleet/signatures)")
 	flag.Parse()
 
 	if *temporalProximity <= 0 {
@@ -191,7 +190,6 @@ func main() {
 		Host:            *host,
 		ForensicKeyPath: defaultForensicKeyPath(),
 		ForensicKeyDirs: forensicKeyDirs,
-		Experimental:    *experimental,
 	})
 	addr := fmt.Sprintf("%s:%d", *host, *port)
 	log.Printf("dashboard listening on http://%s", addr)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -55,9 +55,6 @@ type Config struct {
 	// ForensicKeyDirs lists extra directories, in addition to the user's home
 	// directory, from which the forensic key path endpoint may load a key.
 	ForensicKeyDirs []string
-	// Experimental enables experimental features. When false, experimental
-	// API endpoints respond with 404.
-	Experimental bool
 }
 
 //go:embed static
@@ -159,13 +156,11 @@ func (s *Server) Handler() http.Handler {
 	mux.HandleFunc("GET /api/sessions/{sessionID}/attribution", s.handleSessionAttribution)
 	mux.HandleFunc("GET /api/sessions/{sessionID}/enrichment", s.handleSessionEnrichment)
 	mux.HandleFunc("GET /api/fleet/attribution", s.handleFleetAttribution)
+	mux.HandleFunc("GET /api/fleet/signatures", s.handleFleetSignatures)
 	mux.HandleFunc("GET /api/receipts", s.handleReceipts)
 	mux.HandleFunc("GET /api/receipts/{id...}", s.handleReceiptDetail)
 	mux.HandleFunc("GET /api/chains", s.handleChains)
 	mux.HandleFunc("GET /api/chains/{chainID}/verify", s.handleChainVerify)
-
-	// Experimental endpoints — gated by cfg.Experimental; return 404 when disabled.
-	mux.HandleFunc("GET /api/fleet/signatures", s.handleFleetSignatures)
 
 	// Forensic disclosure: load/clear the operator's X25519 private key (held
 	// in memory only) and decrypt a receipt's parameters_disclosure envelope
@@ -204,7 +199,6 @@ func (s *Server) handleConfig(w http.ResponseWriter, r *http.Request) {
 		"db_path":          s.cfg.DBPath,
 		"db_name":          dbName,
 		"version":          s.cfg.Version,
-		"experimental":     s.cfg.Experimental,
 	})
 }
 
@@ -727,11 +721,6 @@ func (s *Server) handleChainVerify(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleFleetSignatures(w http.ResponseWriter, r *http.Request) {
-	if !s.cfg.Experimental {
-		writeError(w, http.StatusNotFound, "not found")
-		return
-	}
-
 	const defaultLimit = 12
 	const maxLimit = 24
 

--- a/internal/server/server_test.go
+++ b/internal/server/server_test.go
@@ -1866,45 +1866,6 @@ func TestTaxonomyEndpoint(t *testing.T) {
 	}
 }
 
-// ---------- /api/config experimental field ----------
-
-func TestConfigEndpoint_ExperimentalField(t *testing.T) {
-	dbPath := seedTestDB(t)
-	reader, err := store.OpenReadOnly(dbPath)
-	if err != nil {
-		t.Fatalf("open reader: %v", err)
-	}
-	t.Cleanup(func() { reader.Close() })
-
-	for _, tc := range []struct {
-		name         string
-		experimental bool
-	}{
-		{"experimental false (default)", false},
-		{"experimental true", true},
-	} {
-		t.Run(tc.name, func(t *testing.T) {
-			srv := New(reader, Config{Experimental: tc.experimental})
-			req := httptest.NewRequest("GET", "/api/config", nil)
-			w := httptest.NewRecorder()
-			srv.Handler().ServeHTTP(w, req)
-
-			if w.Code != http.StatusOK {
-				t.Fatalf("got status %d, want 200", w.Code)
-			}
-			var got struct {
-				Experimental bool `json:"experimental"`
-			}
-			if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
-				t.Fatalf("decode: %v", err)
-			}
-			if got.Experimental != tc.experimental {
-				t.Errorf("experimental = %v, want %v", got.Experimental, tc.experimental)
-			}
-		})
-	}
-}
-
 // ---------- /api/fleet/signatures endpoint ----------
 
 // seedFleetDB builds a DB with two sessions seeded with mixed action types and
@@ -1955,29 +1916,9 @@ func seedFleetDB(t *testing.T) *store.Reader {
 	return reader
 }
 
-func TestFleetSignaturesEndpoint_DisabledWithout_Experimental(t *testing.T) {
-	reader := seedFleetDB(t)
-	srv := New(reader, Config{Experimental: false})
-
-	req := httptest.NewRequest("GET", "/api/fleet/signatures", nil)
-	w := httptest.NewRecorder()
-	srv.Handler().ServeHTTP(w, req)
-
-	if w.Code != http.StatusNotFound {
-		t.Errorf("got status %d, want 404 when experimental=false", w.Code)
-	}
-	var body map[string]string
-	if err := json.Unmarshal(w.Body.Bytes(), &body); err != nil {
-		t.Fatalf("decode error body: %v", err)
-	}
-	if body["error"] == "" {
-		t.Error("expected error message in response body")
-	}
-}
-
 func TestFleetSignaturesEndpoint_OK(t *testing.T) {
 	reader := seedFleetDB(t)
-	srv := New(reader, Config{Experimental: true})
+	srv := New(reader, Config{})
 
 	req := httptest.NewRequest("GET", "/api/fleet/signatures", nil)
 	w := httptest.NewRecorder()
@@ -2024,7 +1965,7 @@ func TestFleetSignaturesEndpoint_OK(t *testing.T) {
 
 func TestFleetSignaturesEndpoint_LimitParam(t *testing.T) {
 	reader := seedFleetDB(t)
-	srv := New(reader, Config{Experimental: true})
+	srv := New(reader, Config{})
 
 	// limit=1 should return only the most-recent session (alpha).
 	req := httptest.NewRequest("GET", "/api/fleet/signatures?limit=1", nil)
@@ -2073,7 +2014,7 @@ func TestFleetSignaturesEndpoint_LimitParam(t *testing.T) {
 // null — the omitempty tag keeps the common no-local-data case lean.
 func TestFleetSignaturesEndpoint_Enrichment(t *testing.T) {
 	reader := seedFleetDB(t)
-	srv := New(reader, Config{Experimental: true})
+	srv := New(reader, Config{})
 
 	costAlpha := 1.5
 	me := &mapEnricher{data: map[string]*enrich.Enrichment{
@@ -2142,7 +2083,7 @@ func TestFleetSignaturesEndpoint_Enrichment(t *testing.T) {
 // than error or emit an explicit null.
 func TestFleetSignaturesEndpoint_NilEnricher(t *testing.T) {
 	reader := seedFleetDB(t)
-	srv := New(reader, Config{Experimental: true})
+	srv := New(reader, Config{})
 	srv.enricher = nil
 
 	req := httptest.NewRequest("GET", "/api/fleet/signatures", nil)

--- a/internal/server/static/index.html
+++ b/internal/server/static/index.html
@@ -750,7 +750,7 @@
       <button class="tab" onclick="showView('servers')" id="tab-servers">Servers</button>
       <button class="tab" onclick="showView('sessions')" id="tab-sessions">Sessions</button>
       <button class="tab" onclick="showView('chains')" id="tab-chains">Chains</button>
-      <button class="tab" onclick="showView('fleet')" id="tab-fleet" style="display:none;">Fleet</button>
+      <button class="tab" onclick="showView('fleet')" id="tab-fleet">Fleet</button>
     </nav>
   </header>
 
@@ -930,7 +930,7 @@
       <div id="chains-list"></div>
     </div>
 
-    <!-- Fleet view (experimental) -->
+    <!-- Fleet view -->
     <div id="view-fleet" class="hidden">
       <div id="fleet-container"></div>
     </div>
@@ -4780,7 +4780,7 @@
     });
 
 
-    // ---------- Fleet (experimental) ----------
+    // ---------- Fleet ----------
     // Category colors for the discretionary activity ring.
     const FLEET_CAT_COLORS = {
       mcp:    '#bc8cff',
@@ -5047,12 +5047,8 @@
       try {
         data = await fetchJSON('/api/fleet/signatures');
       } catch (err) {
-        if (err.status === 404) {
-          container.innerHTML = '<div class="empty-state"><div class="empty-title">Fleet view unavailable</div><div class="empty-hint">Start the dashboard with <code>-experimental</code> to enable this view.</div></div>';
-        } else {
-          showError('Failed to load fleet signatures: ' + err.message);
-          container.innerHTML = '<div class="empty-state"><div class="empty-title">Failed to load fleet signatures</div><div class="empty-hint">' + escapeHtml(err.message) + '</div></div>';
-        }
+        showError('Failed to load fleet signatures: ' + err.message);
+        container.innerHTML = '<div class="empty-state"><div class="empty-title">Failed to load fleet signatures</div><div class="empty-hint">' + escapeHtml(err.message) + '</div></div>';
         return;
       }
       const sigs = (data && data.signatures) || [];
@@ -5074,9 +5070,6 @@
           poller.serverTime = cfg.server_time;
         }
         renderHeaderContext(cfg, null);
-        if (cfg.experimental) {
-          document.getElementById('tab-fleet').style.display = '';
-        }
       } catch (err) {
         console.warn('config:', err);
       }


### PR DESCRIPTION
## Summary

Closes #156.

Per #156's rollout plan, Fleet shipped behind `-experimental` until proven on real parallel-refactor data. Since then, the activity-signature view (#161/#162), the attribution data layer (#157), cross-session collision detection with the path-reuse fix (#167), and the enrichment captions (#172/#173/#174) have all landed and seen use without issue. This PR removes the gate:

- Removes the `-experimental` CLI flag and `Config.Experimental` (Fleet was their only consumer)
- Removes the `"experimental"` key from `GET /api/config`
- `GET /api/fleet/signatures` no longer 404s when the flag is absent
- The Fleet tab is now always visible in the frontend, not just when `cfg.experimental` is true
- Removed the now-obsolete tests (`TestConfigEndpoint_ExperimentalField`, `TestFleetSignaturesEndpoint_DisabledWithout_Experimental`) that only asserted the gating behavior being removed; remaining Fleet tests updated to drop the now-nonexistent `Experimental` config field

No changes to the Fleet data layer, rendering, or session-signature logic — only to how the feature is gated.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (all packages pass)
- [x] Verified no other references to `Config.Experimental`, `-experimental`, or `cfg.experimental` remain in source
- [x] `node --check` on the edited `<script>` block in `index.html` to confirm valid JS after the edits