### PR TITLE
fix(enrich): add claude-opus-5 to the local pricing table

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`claude-opus-5` pricing entry** — the local pricing/context table in `internal/enrich/pricing.go` was missing an entry for `claude-opus-5`, so any session that touched it anywhere (even a single subagent turn) had its estimated cost reported as "unavailable" for the whole session rather than just that turn — by design, an unmodelled turn poisons the session total rather than producing a partial guess. Priced at Opus 4.8's rate ($5/$25 per MTok input/output, 1M context), matching Claude Opus 5's launch pricing as a drop-in upgrade at that tier. Bare Claude Code model aliases (e.g. `"sonnet"`, with no version) remain intentionally unpriced, since they don't identify a specific model.
+
 ## [0.14.0] - 2026-07-25
 
 ### Changed

--- a/internal/enrich/pricing.go
+++ b/internal/enrich/pricing.go
@@ -15,6 +15,7 @@ type modelInfo struct {
 // identifiers agents write into their session files.
 var models = map[string]modelInfo{
 	"claude-fable-5":    {inputPerMTok: 10, outputPerMTok: 50, contextWindow: 1_000_000},
+	"claude-opus-5":     {inputPerMTok: 5, outputPerMTok: 25, contextWindow: 1_000_000},
 	"claude-opus-4-8":   {inputPerMTok: 5, outputPerMTok: 25, contextWindow: 1_000_000},
 	"claude-opus-4-7":   {inputPerMTok: 5, outputPerMTok: 25, contextWindow: 1_000_000},
 	"claude-opus-4-6":   {inputPerMTok: 5, outputPerMTok: 25, contextWindow: 1_000_000},

--- a/internal/enrich/pricing_test.go
+++ b/internal/enrich/pricing_test.go
@@ -1,0 +1,49 @@
+package enrich
+
+import "testing"
+
+// TestCostUSDKnownModels locks in the pricing table entries for models
+// expected to be present. A model missing from the table produces a silent
+// "unavailable" cost in the dashboard UI rather than a test failure, so this
+// guards against that regression for the models we explicitly support.
+func TestCostUSDKnownModels(t *testing.T) {
+	tt := usageTotals{input: 1_000_000, output: 1_000_000}
+	for _, model := range []string{
+		"claude-fable-5",
+		"claude-opus-5",
+		"claude-opus-4-8",
+		"claude-opus-4-7",
+		"claude-opus-4-6",
+		"claude-sonnet-5",
+		"claude-sonnet-4-6",
+		"claude-haiku-4-5",
+	} {
+		if _, ok := costUSD(model, tt); !ok {
+			t.Errorf("costUSD(%q, ...) ok = false, want true (model missing from pricing table)", model)
+		}
+	}
+}
+
+// TestCostUSDOpus5Rate checks claude-opus-5 is priced at Opus 4.8's rate:
+// $5/MTok input, $25/MTok output.
+func TestCostUSDOpus5Rate(t *testing.T) {
+	tt := usageTotals{input: 1_000_000, output: 1_000_000}
+	got, ok := costUSD("claude-opus-5", tt)
+	if !ok {
+		t.Fatalf("costUSD(claude-opus-5, ...) ok = false, want true")
+	}
+	want := 5.0 + 25.0
+	if got != want {
+		t.Errorf("costUSD(claude-opus-5, 1M in + 1M out) = %v, want %v", got, want)
+	}
+}
+
+// TestCostUSDUnknownModel checks that an unmodelled model (e.g. a bare
+// Claude Code alias like "sonnet", or a model newer than the local table)
+// reports unknown rather than guessing a price.
+func TestCostUSDUnknownModel(t *testing.T) {
+	tt := usageTotals{input: 100, output: 100}
+	if _, ok := costUSD("sonnet", tt); ok {
+		t.Errorf("costUSD(sonnet, ...) ok = true, want false (bare alias must stay unpriced)")
+	}
+}


### PR DESCRIPTION
## What

Adds `claude-opus-5` to the hand-maintained pricing/context table in `internal/enrich/pricing.go`.

## Why

The estimated-cost feature is designed to poison a whole session's `estimated_cost_usd` to `nil` if *any* turn in that session used a model absent from the local pricing table — deliberately, so the dashboard never shows a partial guess (see the comments in `pricing.go` and `claudecode.go`). `claude-opus-5` wasn't in the table, so any session that touched it anywhere — even a single subagent turn buried in an otherwise-priced multi-day session — showed "Est. cost: unavailable" for the entire session, even though every other turn's model was known.

Confirmed by inspecting an actual local session transcript: it mixed `claude-fable-5` (priced), `claude-opus-5` (unpriced — this PR), and the bare alias `"sonnet"` (unpriced, unchanged).

## Change

- Add `claude-opus-5`: $5/$25 per MTok input/output, 1M context — Claude Opus 5's launch pricing, a drop-in match to `claude-opus-4-8`'s existing rate.
- Add `pricing_test.go` covering the full current model list plus a regression test asserting bare aliases (e.g. `"sonnet"`) stay intentionally unpriced.

## Not changed

The bare `"sonnet"` alias some tooling writes instead of a full model id is left unpriced on purpose — it's ambiguous (could be any Sonnet version) and pricing it would violate the "never guess" design principle.

## Testing

- `go vet ./...` and `go test ./...` pass.
- New `TestCostUSDKnownModels`, `TestCostUSDOpus5Rate`, `TestCostUSDUnknownModel` in `internal/enrich/pricing_test.go`.

CHANGELOG entry added under `[Unreleased]`.